### PR TITLE
Couple of fixes to make it easier to develop

### DIFF
--- a/android/app/src/main/java/edu/berkeley/eecs/e_mission/OnboardingActivity.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/e_mission/OnboardingActivity.java
@@ -24,6 +24,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.net.http.AndroidHttpClient;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
@@ -166,9 +167,16 @@ public class OnboardingActivity extends Activity implements OnActionListener {
 	}
 	
 	public void getLinkToMovesComplete() {
-		final String key = "linkToMoves";
-    	final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-    	linkToMovesComplete = prefs.getBoolean(key, false);
+        if (Build.FINGERPRINT.startsWith("generic")) {
+            // We are running in an emulator
+            // TODO: Populate the database with some dummy data here to allow easier testing
+            linkToMovesComplete = true;
+        } else {
+            // We are running in a real device, so we want to link to moves to collect data
+            final String key = "linkToMoves";
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+            linkToMovesComplete = prefs.getBoolean(key, false);
+        }
 	}
 	
 	public void getOnboardingComplete() {

--- a/android/app/src/main/java/edu/berkeley/eecs/e_mission/UnclassifiedSection.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/e_mission/UnclassifiedSection.java
@@ -34,7 +34,10 @@ public class UnclassifiedSection {
 		this.sectionBlob = sectionBlob;
 		try {
 			this.obj = new JSONObject(sectionBlob);
-			JSONObject predMap = obj.getJSONObject("predicted_mode");
+            JSONObject predMap = new JSONObject();
+            if (obj.has("predicted_mode"))  {
+                predMap = obj.getJSONObject("predicted_mode");
+            }
 			String maxString = "UNKNOWN";
 			double maxConf = 0.0;
 			Iterator<String> it = predMap.keys();


### PR DESCRIPTION
- If we are running in an emulator, then skip the link to moves, since moves is
  not available for install on the emulator.
- If we hack our system to load in fake data, we may not always have predicted
  data, specially if we haven't run the pipeline code yet. This handles that
  case gracefully by checking for the predicted mode before using it. If the
  predicted mode does not exist, we should end up displaying "UNKNOWN".