### PR TITLE
Minor changes to kickstart the release cycle again

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,34 @@ Installation is now complete. You can view the current state of the application 
 
     $ ionic emulate ios --target="iPhone-6"
 
+
+#### Temporary workaround *for android only* ####
+Unfortunately, `ionic state` does not store plugin version numbers, and
+versions of crosswalk > 16 are so large that the generated APK is too big
+and needs `multi-dex` support.
+https://developer.android.com/studio/build/multidex.html#mdex-gradle
+
+It looks like multi-dex is a pain, and is complicated to use with cordova since
+it requires a modification to the AndroidManifest.xml to use a different
+activity.
+
+```
+In your manifest add the MultiDexApplication class from the multidex support library to the application element.
+```
+
+It seems like it would be a Good Thing to trim down the app anyway instead of
+using multi-dex, since that will also help with memory usage and with load
+times. But for now, the workaround is to force the use of the older and smaller
+crosswalk version.
+
+So before we build the android version, we need to do
+```
+$ cordova plugin remove cordova-plugin-crosswalk-webview
+$ cordova plugin add cordova-plugin-crosswalk-webview@1.5.0
+```
+
+This does NOT affect iOS.
+
 Troubleshooting
 ---
 
@@ -52,6 +80,22 @@ the project:
 ``
 
 and then run the project with IOS emulator.
+
+Debugging
+---
+If users run into problems, they have the ability to email logs to the
+maintainer. These logs are in the form of an sqlite3 database, so they have to
+be opened using `sqlite3`. Alternatively, you can export it to a csv with
+dates using the `bin/csv_export_add_date.py` script.
+
+```
+<download the log file>
+$ mv ~/Downloads/loggerDB /tmp/logger.<issue>
+$ pwd
+.../e-mission-phone
+$ python bin/csv_export_add_date.py /tmp/loggerDB.<issue>
+$ less /tmp/loggerDB.<issue>.withdate.log
+```
 
 End to end testing
 ---

--- a/config.xml
+++ b/config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <widget id="edu.berkeley.eecs.emission" 
-        version="0.0.8" 
-        android-versionCode="8"
-        ios-CFBundleVersion="8"
+        version="0.0.9" 
+        android-versionCode="9"
+        ios-CFBundleVersion="9"
         xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>emission</name>
   <description>

--- a/www/js/common.js
+++ b/www/js/common.js
@@ -1,23 +1,17 @@
 angular.module('emission.main.common',['ui-leaflet', 'nvd3ChartDirectives',
                                       'ionic-datepicker',
-                                      'emission.main.common.services'])
+                                      'emission.main.common.services',
+                                      'emission.services'])
 
 .controller("CommonCtrl", function($scope, $http, $ionicPopup,
-                                    leafletData, CommonGraph) {
+                                    leafletData, CommonGraph,Config) {
   console.log("controller CommonCtrl called");
 
   var db = window.cordova.plugins.BEMUserCache;
   $scope.mapCtrl = {};
 
   angular.extend($scope.mapCtrl, {
-    defaults : {
-      tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      tileLayerOptions: {
-          opacity: 0.9,
-          detectRetina: true,
-          reuseTiles: true,
-      }
-    }, 
+    defaults : Config.getMapTiles(),
     events: {
       map: {
         enable: ['zoomstart', 'drag', 'click', 'mousemove', 'contextmenu'],

--- a/www/js/diary/detail.js
+++ b/www/js/diary/detail.js
@@ -1,22 +1,17 @@
 'use strict';
 angular.module('emission.main.diary.detail',['ui-leaflet', 'nvd3ChartDirectives',
-                                      'ionic-datepicker'])
+                                      'ionic-datepicker',
+                                      'emission.services'])
 
-.controller("DiaryDetailCtrl", function($scope, $stateParams, Timeline, DiaryHelper) {
+.controller("DiaryDetailCtrl", function($scope, $stateParams,
+                                        Timeline, DiaryHelper,Config) {
   console.log("controller DiaryDetailCtrl called with params = "+
     JSON.stringify($stateParams));
 
   $scope.mapCtrl = {};
 
   angular.extend($scope.mapCtrl, {
-    defaults : {
-      tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      tileLayerOptions: {
-          opacity: 0.9,
-          detectRetina: true,
-          reuseTiles: true,
-      }
-    } 
+    defaults : Config.getMapTiles()
   });
   $scope.arrowColor = DiaryHelper.arrowColor;
   $scope.parseEarlierOrLater = DiaryHelper.parseEarlierOrLater;

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -1,12 +1,14 @@
 angular.module('emission.main.diary.list',['ui-leaflet', 'nvd3ChartDirectives',
                                       'ionic-datepicker',
-                                      'emission.main.common.services'])
+                                      'emission.main.common.services',
+                                      'emission.services'])
 
 .controller("DiaryListCtrl", function($window, $scope, $ionicPlatform, $state,
                                     $ionicScrollDelegate, $ionicPopup,
                                     $ionicLoading,
                                     $ionicActionSheet,
-                                    leafletData, Timeline, CommonGraph, DiaryHelper) {
+                                    leafletData, Timeline, CommonGraph, DiaryHelper,
+                                    Config) {
   console.log("controller DiaryListCtrl called");
 
   var readAndUpdateForDay = function(day) {
@@ -29,14 +31,10 @@ angular.module('emission.main.diary.list',['ui-leaflet', 'nvd3ChartDirectives',
           scrollWheelZoom: false,
           doubleClickZoom: false,
           boxZoom: false,
-          tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-          tileLayerOptions: {
-              opacity: 0.9,
-              detectRetina: true,
-              reuseTiles: true,
-          }
       }
   });
+
+  angular.extend($scope.defaults, Config.getMapTiles())
 
   moment.locale('en', {
     relativeTime : {

--- a/www/js/heatmap.js
+++ b/www/js/heatmap.js
@@ -1,19 +1,12 @@
 'use strict';
 
-angular.module('emission.main.heatmap',['ui-leaflet'])
+angular.module('emission.main.heatmap',['ui-leaflet', 'emission.services'])
 
-.controller('HeatmapCtrl', function($scope, $ionicActionSheet, $http, leafletData) {
+.controller('HeatmapCtrl', function($scope, $ionicActionSheet, $http, leafletData, Config) {
   $scope.mapCtrl = {};
 
   angular.extend($scope.mapCtrl, {
     defaults : {
-      tileLayer: 'http://tile.stamen.com/toner/{z}/{x}/{y}.png',
-      tileLayerOptions: {
-        attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-        opacity: 0.9,
-        detectRetina: true,
-        reuseTiles: true,
-      },
       center: {
         lat: 37.87269,
         lng: -122.25921,
@@ -21,6 +14,8 @@ angular.module('emission.main.heatmap',['ui-leaflet'])
       }
     }
   });
+
+  angular.extend($scope.mapCtrl.defaults, Config.getMapTiles())
 
   $scope.getPopRoute = function() {
     var data = {

--- a/www/js/recent.js
+++ b/www/js/recent.js
@@ -1,4 +1,4 @@
-angular.module('emission.main.recent', ['ngCordova'])
+angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
 .config(function($stateProvider, $urlRouterProvider) {
   $stateProvider
@@ -280,21 +280,14 @@ angular.module('emission.main.recent', ['ngCordova'])
   $scope.updateEntries();
 })
    
-.controller('mapCtrl', function($scope) {
+.controller('mapCtrl', function($scope, Config) {
     /* Let's keep a reference to the database for convenience */
     var db = window.cordova.plugins.BEMUserCache;
     $scope.mapCtrl = {};
     $scope.mapCtrl.selKey = "background/location";
 
     angular.extend($scope.mapCtrl, {
-        defaults : {
-          tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-          tileLayerOptions: {
-              opacity: 0.9,
-              detectRetina: true,
-              reuseTiles: true,
-          }
-        }
+        defaults : Config.getMapTiles()
     });
 
     $scope.refreshMap = function() {

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -20,6 +20,27 @@ angular.module('emission.services', [])
     };
 })
 
+// common configuration methods across all screens
+// e.g. maps
+// for consistent L&F
+
+.factory('Config', function() {
+    var config = {};
+
+    config.getMapTiles = function() {
+      return {
+          tileLayer: 'http://tile.stamen.com/toner/{z}/{x}/{y}.png',
+          tileLayerOptions: {
+              attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+              opacity: 0.9,
+              detectRetina: true,
+              reuseTiles: true,
+          }
+      };
+    };
+    return config;
+})
+
 .factory('Chats', function() {
   // Might use a resource here that returns a JSON array
 


### PR DESCRIPTION
* From updated plugins, turn off debug UI notifications by default. They can be enabled again by turning on simulateUserInteraction from the config screen (android: https://github.com/e-mission/e-mission-data-collection/commit/2cc112c753c409abcdaba4e3056125a52572d9d2, ios: https://github.com/shankari/cordova-unified-logger/commit/f55fc2dd15f157b1d4a77c496d55a56f717621e2)

* Change the tilemap for the app maps from OSM to stamen toner + make it easier to change them in the future
* Update README with information on reading phone logs + avoiding multi-dex on android