### PR TITLE
Slim down the android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,34 +41,6 @@ Installation is now complete. You can view the current state of the application 
 
     $ ionic emulate ios --target="iPhone-6"
 
-
-#### Temporary workaround *for android only* ####
-Unfortunately, `ionic state` does not store plugin version numbers, and
-versions of crosswalk > 16 are so large that the generated APK is too big
-and needs `multi-dex` support.
-https://developer.android.com/studio/build/multidex.html#mdex-gradle
-
-It looks like multi-dex is a pain, and is complicated to use with cordova since
-it requires a modification to the AndroidManifest.xml to use a different
-activity.
-
-```
-In your manifest add the MultiDexApplication class from the multidex support library to the application element.
-```
-
-It seems like it would be a Good Thing to trim down the app anyway instead of
-using multi-dex, since that will also help with memory usage and with load
-times. But for now, the workaround is to force the use of the older and smaller
-crosswalk version.
-
-So before we build the android version, we need to do
-```
-$ cordova plugin remove cordova-plugin-crosswalk-webview
-$ cordova plugin add cordova-plugin-crosswalk-webview@1.5.0
-```
-
-This does NOT affect iOS.
-
 Troubleshooting
 ---
 

--- a/bin/sign_and_align_keys.sh
+++ b/bin/sign_and_align_keys.sh
@@ -5,10 +5,22 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
+# Sign and release arm7
 cp platforms/android/build/outputs/apk/android-armv7-release-unsigned.apk platforms/android/build/outputs/apk/android-armv7-release-signed-unaligned.apk
 jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-armv7-release-signed-unaligned.apk androidproductionkey
 ~/Library/Android/sdk/build-tools/22.0.1/zipalign -v 4 platforms/android/build/outputs/apk/android-armv7-release-signed-unaligned.apk emission-armv7-build-$1.apk
 
+# Sign and release x86
 cp platforms/android/build/outputs/apk/android-x86-release-unsigned.apk platforms/android/build/outputs/apk/android-x86-release-signed-unaligned.apk
 jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-x86-release-signed-unaligned.apk androidproductionkey
 ~/Library/Android/sdk/build-tools/22.0.1/zipalign -v 4 platforms/android/build/outputs/apk/android-x86-release-signed-unaligned.apk emission-x86-build-$1.apk
+
+# Remove the plugin, sign and release general
+ionic plugin remove cordova-plugin-crosswalk-webview
+ionic build android --release -- --minSdkVersion=21
+cp platforms/android/build/outputs/apk/android-release-unsigned.apk platforms/android/build/outputs/apk/android-L+-release-signed-unaligned.apk
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-L+-release-signed-unaligned.apk androidproductionkey
+~/Library/Android/sdk/build-tools/22.0.1/zipalign -v 4 platforms/android/build/outputs/apk/android-L+-release-signed-unaligned.apk emission-L+-build-$1.apk
+
+# Re-add the plugin
+ionic plugin add cordova-plugin-crosswalk-webview  --variable XWALK_MODE="lite"

--- a/config.xml
+++ b/config.xml
@@ -21,10 +21,10 @@
   <preference name="BackupWebStorage" value="none"/>
   <preference name="SplashScreen" value="screen"/>
   <preference name="SplashScreenDelay" value="3000"/>
-  <preference name="xwalkVersion" value="16+"/>
-  <preference name="xwalkCommandLine" value="--disable-pull-to-refresh-effect"/>
-  <preference name="xwalkMode" value="embedded"/>
-  <preference name="xwalkMultipleApk" value="true"/>
+  <preference name="xwalkVersion" value="xwalk_core_library_canary:17+" />
+  <preference name="xwalkCommandLine" value="--disable-pull-to-refresh-effect" />
+  <preference name="xwalkMode" value="lite" />
+  <preference name="xwalkMultipleApk" value="true" />
   <feature name="StatusBar">
     <param name="ios-package" onload="true" value="CDVStatusBar"/>
   </feature>


### PR DESCRIPTION
So that it launches more quickly.
In particular, versions 5.0 (Lollipop+) which have the system updated webview will no longer use crosswalk