### PR TITLE
Restructure the common trips screen to be more complex

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -55,6 +55,9 @@
     <script src="js/diary/detail.js"></script>
     <script src="js/diary/services.js"></script>
     <script src="js/common.js"></script>
+    <script src="js/common/map.js"></script>
+    <script src="js/common/list.js"></script>
+    <script src="js/common/detail.js"></script>
     <script src="js/common/services.js"></script>
     <script src="js/heatmap.js"></script>
   </head>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -63,7 +63,7 @@ angular.module('emission', ['ionic', 'emission.controllers','emission.services',
     controller: 'RootCtrl'
   });
 
-  alert("about to fall back to otherwise");
+  // alert("about to fall back to otherwise");
   // if none of the above states are matched, use this as the fallback
   $urlRouterProvider.otherwise('/splash');
   console.log("Ending config");

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -63,7 +63,7 @@ angular.module('emission', ['ionic', 'emission.controllers','emission.services',
     controller: 'RootCtrl'
   });
 
-  // alert("about to fall back to otherwise");
+  alert("about to fall back to otherwise");
   // if none of the above states are matched, use this as the fallback
   $urlRouterProvider.otherwise('/splash');
   console.log("Ending config");

--- a/www/js/common.js
+++ b/www/js/common.js
@@ -1,100 +1,45 @@
 angular.module('emission.main.common',['ui-leaflet',
                                       'ionic-datepicker',
+                                      'emission.main.common.map',
+                                      'emission.main.common.list',
+                                      'emission.main.common.detail',
                                       'emission.main.common.services',
                                       'emission.services'])
+.config(function($stateProvider, $ionicConfigProvider, $urlRouterProvider) {
+  $stateProvider
+
+  .state('root.main.common.map', {
+    url: '/map',
+    views: {
+      'menuContent': {
+        templateUrl: 'templates/common/map.html',
+        controller: 'CommonMapCtrl'
+      }
+    }
+  })
+
+  .state('root.main.common.list', {
+    url: '/list',
+    views: {
+      'menuContent': {
+        templateUrl: 'templates/common/list.html',
+        controller: 'CommonListCtrl'
+      }
+    }
+  })
+
+  .state('root.main.common.place-detail', {
+    url: '/place/:placeId',
+    views: {
+        'menuContent': {
+            templateUrl: 'templates/common/detail.html',
+            controller: 'CommonDetailCtrl'
+        }
+     }
+  });
+})
 
 .controller("CommonCtrl", function($scope, $http, $ionicPopup,
                                     leafletData, CommonGraph,Config) {
   console.log("controller CommonCtrl called");
-
-  var db = window.cordova.plugins.BEMUserCache;
-  $scope.mapCtrl = {};
-
-  angular.extend($scope.mapCtrl, {
-    defaults : Config.getMapTiles(),
-    events: {
-      map: {
-        enable: ['zoomstart', 'drag', 'click', 'mousemove', 'contextmenu'],
-        logic: 'emit'
-      }
-    }
-  });
-
-  $scope.$on('leafletDirectiveMap.click', function(event){
-     alert('click '+JSON.stringify(event)+' detected');
-  });
-
-  $scope.$on('leafletDirectiveMap.contextmenu', function(event){
-     alert('conextmenu '+JSON.stringify(event)+' detected');
-  });
-
-  var onEachFeature = function(feature, layer) {
-    console.log("onEachFeature called with "+JSON.stringify(feature));
-    console.log("type is "+feature.geometry.type);
-    var popupContent = "<p>I started out as a GeoJSON " +
-                    feature.geometry.type + ", but now I'm a Leaflet vector!</p>";
-    layer.on('click', function(e) { console.log("layer clicked"); alert(feature.geometry.type) } );
-    // layer.bindPopup(popupContent);
-    /*
-    switch(feature.geometry.type) {
-      case "Point": layer.bindPopup(popupContent); break;
-      case "LineString": layer.bindPopup(popupContent); break;
-    }
-    */
-  }
-
-  $scope.refreshMap = function() {
-      CommonGraph.updateCurrent();
-  };
-
-  $scope.$on(CommonGraph.UPDATE_DONE, function(event, args) {
-    $scope.$apply(function() {
-        $scope.mapCtrl.geojson = {}
-        $scope.mapCtrl.geojson.data = CommonGraph.data.geojson;
-        $scope.mapCtrl.geojson.onEachFeature = onEachFeature;
-    });
-  });
-
-  $scope.refreshMap();
-
-  // TODO: Refactor into common code - maybe a service?
-  // Or maybe pre-populate from the server
-
-  /*
-  $scope.getDisplayName = function(place_feature) {
-    var responseListener = function(data) {
-      var address = data["address"];
-      var name = "";
-      if (address["road"]) {
-        name = address["road"];
-      } else if (address["neighbourhood"]) {
-        name = address["neighbourhood"];
-      }
-        if (address["city"]) {
-          name = name + ", " + address["city"];
-        } else if (address["town"]) {
-          name = name + ", " + address["town"];
-        } else if (address["county"]) {
-            name = name + ", " + address["county"];
-        }
-  
-       console.log("got response, setting display name to "+name);
-       place_feature.properties.displayName = name;
-    };
-  
-  
-    var url = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + place_feature.geometry.coordinates[1]
-        + "&lon=" + place_feature.geometry.coordinates[0];
-      console.log("About to make call "+url);
-      $http.get(url).then(function(response) {
-             console.log("while reading data from nominatim, status = "+response.status
-                 +" data = "+JSON.stringify(response.data));
-             responseListener(response.data);
-          }, function(response) {
-             console.log("while reading data from nominatim, status = "+response.status);
-             notFoundFn(day, response);
-          });
-  };
-  */
-
 });

--- a/www/js/common.js
+++ b/www/js/common.js
@@ -19,7 +19,7 @@ angular.module('emission.main.common',['ui-leaflet',
   })
 
   .state('root.main.common.list', {
-    url: '/list',
+    url: '/places',
     views: {
       'menuContent': {
         templateUrl: 'templates/common/list.html',
@@ -29,7 +29,7 @@ angular.module('emission.main.common',['ui-leaflet',
   })
 
   .state('root.main.common.place-detail', {
-    url: '/place/:placeId',
+    url: '/places/:placeId',
     views: {
         'menuContent': {
             templateUrl: 'templates/common/detail.html',

--- a/www/js/common/detail.js
+++ b/www/js/common/detail.js
@@ -14,7 +14,6 @@ angular.module('emission.main.common.detail',['ui-leaflet',
       console.log("Found common trip "+cTrip);
       var retDict = {
         trip: cTrip,
-        trip_count: cTrip.trips.length,
         place: sp
       };
       return retDict;

--- a/www/js/common/detail.js
+++ b/www/js/common/detail.js
@@ -1,0 +1,9 @@
+'use strict';
+angular.module('emission.main.common.detail',['ui-leaflet',
+                                      'ionic-datepicker',
+                                      'emission.services'])
+
+.controller("CommonDetailCtrl", function($scope, $stateParams,
+                                        Timeline, DiaryHelper,Config) {
+    $scope.placeId = $stateParams.placeId;
+});

--- a/www/js/common/detail.js
+++ b/www/js/common/detail.js
@@ -4,6 +4,7 @@ angular.module('emission.main.common.detail',['ui-leaflet',
                                       'emission.services'])
 
 .controller("CommonDetailCtrl", function($scope, $stateParams,
-                                        Timeline, DiaryHelper,Config) {
+                                        CommonGraph) {
     $scope.placeId = $stateParams.placeId;
+    $scope.place = CommonGraph.data.cPlaceId2ObjMap[$scope.placeId];
 });

--- a/www/js/common/detail.js
+++ b/www/js/common/detail.js
@@ -7,4 +7,16 @@ angular.module('emission.main.common.detail',['ui-leaflet',
                                         CommonGraph) {
     $scope.placeId = $stateParams.placeId;
     $scope.place = CommonGraph.data.cPlaceId2ObjMap[$scope.placeId];
+
+    $scope.succ_trips_places = $scope.place.succ_places.map(function(sp, index, array) {
+      console.log("Considering succ_place "+sp);
+      var cTrip = CommonGraph.getCommonTripForStartEnd($scope.placeId, sp._id.$oid);
+      console.log("Found common trip "+cTrip);
+      var retDict = {
+        trip: cTrip,
+        trip_count: cTrip.trips.length,
+        place: sp
+      };
+      return retDict;
+    });
 });

--- a/www/js/common/list.js
+++ b/www/js/common/list.js
@@ -1,0 +1,9 @@
+angular.module('emission.main.common.list',['ui-leaflet',
+                                      'ionic-datepicker',
+                                      'emission.main.common.services',
+                                      'emission.services'])
+
+.controller("CommonListCtrl", function($window, $scope, $rootScope, $ionicPlatform, $state,
+                                    CommonGraph) {
+  console.log("controller CommonListCtrl called");
+});

--- a/www/js/common/list.js
+++ b/www/js/common/list.js
@@ -6,4 +6,5 @@ angular.module('emission.main.common.list',['ui-leaflet',
 .controller("CommonListCtrl", function($window, $scope, $rootScope, $ionicPlatform, $state,
                                     CommonGraph) {
   console.log("controller CommonListCtrl called");
+  $scope.places = CommonGraph.data.graph.common_places;
 });

--- a/www/js/common/map.js
+++ b/www/js/common/map.js
@@ -1,0 +1,99 @@
+angular.module('emission.main.common.map',['ionic-datepicker',
+                                      'emission.main.common.services',
+                                      'emission.services'])
+
+.controller("CommonMapCtrl", function($window, $scope, $rootScope, $ionicPlatform, $state,
+                                    CommonGraph, Config) {
+  console.log("controller CommonMapCtrl called");
+
+  var db = window.cordova.plugins.BEMUserCache;
+  $scope.mapCtrl = {};
+
+  angular.extend($scope.mapCtrl, {
+    defaults : Config.getMapTiles(),
+    events: {
+      map: {
+        enable: ['zoomstart', 'drag', 'click', 'mousemove', 'contextmenu'],
+        logic: 'emit'
+      }
+    }
+  });
+
+  $scope.$on('leafletDirectiveMap.click', function(event){
+     alert('click '+JSON.stringify(event)+' detected');
+  });
+
+  $scope.$on('leafletDirectiveMap.contextmenu', function(event){
+     alert('conextmenu '+JSON.stringify(event)+' detected');
+  });
+
+  var onEachFeature = function(feature, layer) {
+    console.log("onEachFeature called with "+JSON.stringify(feature));
+    console.log("type is "+feature.geometry.type);
+    var popupContent = "<p>I started out as a GeoJSON " +
+                    feature.geometry.type + ", but now I'm a Leaflet vector!</p>";
+    layer.on('click', function(e) { console.log("layer clicked"); alert(feature.geometry.type) } );
+    // layer.bindPopup(popupContent);
+    /*
+    switch(feature.geometry.type) {
+      case "Point": layer.bindPopup(popupContent); break;
+      case "LineString": layer.bindPopup(popupContent); break;
+    }
+    */
+  }
+
+  $scope.refreshMap = function() {
+      CommonGraph.updateCurrent();
+  };
+
+  $scope.$on(CommonGraph.UPDATE_DONE, function(event, args) {
+    $scope.$apply(function() {
+        $scope.mapCtrl.geojson = {}
+        $scope.mapCtrl.geojson.data = CommonGraph.data.geojson;
+        $scope.mapCtrl.geojson.onEachFeature = onEachFeature;
+    });
+  });
+
+  $scope.refreshMap();
+
+  // TODO: Refactor into common code - maybe a service?
+  // Or maybe pre-populate from the server
+
+  /*
+  $scope.getDisplayName = function(place_feature) {
+    var responseListener = function(data) {
+      var address = data["address"];
+      var name = "";
+      if (address["road"]) {
+        name = address["road"];
+      } else if (address["neighbourhood"]) {
+        name = address["neighbourhood"];
+      }
+        if (address["city"]) {
+          name = name + ", " + address["city"];
+        } else if (address["town"]) {
+          name = name + ", " + address["town"];
+        } else if (address["county"]) {
+            name = name + ", " + address["county"];
+        }
+
+       console.log("got response, setting display name to "+name);
+       place_feature.properties.displayName = name;
+    };
+
+
+    var url = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + place_feature.geometry.coordinates[1]
+        + "&lon=" + place_feature.geometry.coordinates[0];
+      console.log("About to make call "+url);
+      $http.get(url).then(function(response) {
+             console.log("while reading data from nominatim, status = "+response.status
+                 +" data = "+JSON.stringify(response.data));
+             responseListener(response.data);
+          }, function(response) {
+             console.log("while reading data from nominatim, status = "+response.status);
+             notFoundFn(day, response);
+          });
+  };
+  */
+
+});

--- a/www/js/common/map.js
+++ b/www/js/common/map.js
@@ -10,37 +10,36 @@ angular.module('emission.main.common.map',['ionic-datepicker',
   $scope.mapCtrl = {};
 
   angular.extend($scope.mapCtrl, {
-    defaults : Config.getMapTiles(),
-    events: {
-      map: {
-        enable: ['zoomstart', 'drag', 'click', 'mousemove', 'contextmenu'],
-        logic: 'emit'
-      }
-    }
+    defaults : Config.getMapTiles()
   });
 
-  $scope.$on('leafletDirectiveMap.click', function(event){
-     alert('click '+JSON.stringify(event)+' detected');
-  });
-
-  $scope.$on('leafletDirectiveMap.contextmenu', function(event){
-     alert('conextmenu '+JSON.stringify(event)+' detected');
-  });
+  var styleFeature = function(feature) {
+    switch(feature.geometry.type) {
+      case "Point":
+        var place = CommonGraph.data.cPlaceId2ObjMap[feature.id];
+        var popularity = place.places.length;
+        var toReturn = {opacity: 0.3};
+        return toReturn;
+    };
+  };
 
   var onEachFeature = function(feature, layer) {
     console.log("onEachFeature called with "+JSON.stringify(feature));
     console.log("type is "+feature.geometry.type);
     var popupContent = "<p>I started out as a GeoJSON " +
                     feature.geometry.type + ", but now I'm a Leaflet vector!</p>";
-    layer.on('click', function(e) { console.log("layer clicked"); alert(feature.geometry.type) } );
-    // layer.bindPopup(popupContent);
-    /*
+    console.log(popupContent);
+    layer.on('click', layer.bindPopup("layer clicked"));
+    console.log("Finished registering for onClick for feature "+feature.id)
+  };
+
+  var pointFormat = function(feature, latlng) {
     switch(feature.geometry.type) {
-      case "Point": layer.bindPopup(popupContent); break;
-      case "LineString": layer.bindPopup(popupContent); break;
+      case "Point": return L.marker(latlng, {opacity: 0.3});
+      default: alert("Found unknown type in feature"  + feature); return L.marker(latlng)
     }
-    */
-  }
+  };
+
 
   $scope.refreshMap = function() {
       CommonGraph.updateCurrent();
@@ -50,7 +49,9 @@ angular.module('emission.main.common.map',['ionic-datepicker',
     $scope.$apply(function() {
         $scope.mapCtrl.geojson = {}
         $scope.mapCtrl.geojson.data = CommonGraph.data.geojson;
+        $scope.mapCtrl.geojson.style = styleFeature;
         $scope.mapCtrl.geojson.onEachFeature = onEachFeature;
+        // $scope.mapCtrl.geojson.pointToLayer = pointFormat;
     });
   });
 

--- a/www/js/common/services.js
+++ b/www/js/common/services.js
@@ -40,7 +40,7 @@ angular.module('emission.main.common.services', [])
      * Returns the common trip corresponding to the specified tripId
      */
     commonGraph.findCommon = function(tripId) {
-        return commonGraph.data.tripMap[tripId];
+        return commonGraph.data.trip2CommonMap[tripId];
     };
 
     /*
@@ -49,6 +49,28 @@ angular.module('emission.main.common.services', [])
     commonGraph.getCount = function(cTripId) {
         return commonGraph.data.cTripCountMap[cTripId];
     };
+
+    /*
+     * Returns the common trip for a (start, end) pair
+     */
+     commonGraph.getCommonTripForStartEnd = function(commonStartPlaceId, commonEndPlaceId) {
+        var retArray = [];
+        commonGraph.data.graph.common_trips.forEach(function(cTrip, index, array) {
+          if (cTrip.start_place.$oid == commonStartPlaceId &&
+              cTrip.end_place.$oid == commonEndPlaceId) {
+              retArray.push(cTrip);
+          }
+        });
+        var retVal = null;
+        var maxCount = 0;
+        retArray.forEach(function(cTrip, index, array) {
+          if (cTrip.trips.length > maxCount) {
+            maxCount = cTrip.trips.length;
+            retVal = cTrip;
+          }
+        });
+        return retVal;
+     };
 
     var postProcessData = function() {
         // Count the number of trips in each common trip. Also, create a map
@@ -91,10 +113,10 @@ angular.module('emission.main.common.services', [])
         var places = commonGraph.data.graph.common_places.map(function(place) {
             return {
                 "type": "Feature",
-                "id": place._id,
+                "id": place._id.$oid,
                 "geometry": place.location,
                 "properties": {
-                    "successors": place.successors
+                    "displayName": place.displayName
                 }
             };
         });
@@ -102,13 +124,10 @@ angular.module('emission.main.common.services', [])
         var trips = commonGraph.data.graph.common_trips.map(function(trip) {
             return {
                 "type": "Feature",
-                "id": trip._id,
+                "id": trip._id.$oid,
                 "geometry": {
                     "type": "LineString",
                     "coordinates": [trip.start_loc.coordinates, trip.end_loc.coordinates]
-                },
-                "properties": {
-                    "probabilities": trip.probabilites
                 }
             };
         });

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -94,14 +94,14 @@ angular.module('emission.main.diary.services', ['emission.services'])
         'top': '310px',
         'line-height': '16px'
       }
-    }   
+    }
   }
   dh.getIcon = function(section) {
     var icons = {"BICYCLING":"ion-android-bicycle",
     "WALKING":" ion-android-walk",
     "RUNNING":" ion-android-walk",
     "IN_VEHICLE":"ion-disc",}
-    return icons[dh.getHumanReadable(section.properties.sensed_mode)]; 
+    return icons[dh.getHumanReadable(section.properties.sensed_mode)];
   }
   dh.getHumanReadable = function(sensed_mode) {
     var ret_string = sensed_mode.split('.')[1];
@@ -122,7 +122,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
   dh.getPercentages = function(trip) {
     var rtn0 = []; // icons
     var rtn1 = []; //percentages
-    
+
     var icons = {"BICYCLING":"ion-android-bicycle",
     "WALKING":"ion-android-walk",
     // "RUNNING":" ion-android-walk",
@@ -197,7 +197,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
     } else {
       return "---";
     }
-  };  
+  };
   dh.getFormattedTimeRange = function(end_ts_in_secs, start_ts_in_secs) {
     var startMoment = moment(start_ts_in_secs * 1000);
     var endMoment = moment(end_ts_in_secs * 1000);
@@ -208,12 +208,15 @@ angular.module('emission.main.diary.services', ['emission.services'])
   };
   dh.getTripDetails = function(trip) {
     return (trip.sections.length) + " sections";
-  }; 
+  };
   dh.getEarlierOrLater = function(ts, id) {
+    if (!angular.isDefined(id)) {
+      return '';
+    }
     var ctrip = CommonGraph.findCommon(id);
     if (!angular.isUndefined(ctrip)) {
       // assume probabilities array is Monday-indexed + 1-indexed
-      var mostFrequestHour = ctrip.start_times[0].hour;    
+      var mostFrequestHour = ctrip.start_times[0].hour;
       var thisHour = parseInt(dh.getFormattedTime(ts).split(':')[0]);
       if (thisHour == mostFrequestHour) {
         return '';
@@ -248,11 +251,11 @@ angular.module('emission.main.diary.services', ['emission.services'])
         return noChangeReturn;
       } else {
         if (diff > 0) {
-          return [1, dh.getFormattedDuration(diff)]; 
+          return [1, dh.getFormattedDuration(diff)];
         } else {
-          return [-1, dh.getFormattedDuration(diff)]; 
+          return [-1, dh.getFormattedDuration(diff)];
         }
-        
+
       }
     } else {
       return noChangeReturn;
@@ -293,17 +296,17 @@ angular.module('emission.main.diary.services', ['emission.services'])
           return 'Started ' + val + ' hour later than usual'
         } else {
           return 'Started ' + val + ' hours later than usual'
-        }        
+        }
       }
     }
-  
+
   dh.fillCommonTripCount = function(tripWrapper) {
       var cTrip = CommonGraph.findCommon(tripWrapper.data.id);
       if (!angular.isUndefined(cTrip)) {
           tripWrapper.common_count = cTrip.trips.length;
       }
   };
-  dh.directiveForTrip = function(trip) { 
+  dh.directiveForTrip = function(trip) {
     var retVal = {};
     retVal.data = trip;
     retVal.style = style_feature;
@@ -565,7 +568,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
 
         console.log("currIndex = "+timeline.data.currDay+" currDayTrips = "+ timeline.data.currDayTrips.length);
 
-            // Return to the top of the page. If we don't do this, then we will be stuck at the 
+            // Return to the top of the page. If we don't do this, then we will be stuck at the
             $rootScope.$emit(timeline.UPDATE_DONE, {'from': 'emit', 'status': 'success'});
             $rootScope.$broadcast(timeline.UPDATE_DONE, {'from': 'broadcast', 'status': 'success'});
             console.log("About to hide 'Processing trips'");

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -24,11 +24,11 @@ angular.module('emission.main.diary.services', ['emission.services'])
   //   .setAttribute('style', 'width: '+oldVal2);
   // }
   dh.isCommon = function(id) {
-    var ctrip = CommonGraph.findCommon(id);
+    var ctrip = CommonGraph.trip2Common(id);
     return !angular.isUndefined(ctrip);
   }
   dh.getStartTimeTagStyle = function(id) {
-    var ctrip = CommonGraph.findCommon(id);
+    var ctrip = CommonGraph.trip2Common(id);
     if (angular.isUndefined(ctrip)) {
       return {
         'box-shadow': '0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23)',
@@ -63,7 +63,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
     }
   }
   dh.getStopTimeTagStyle = function(id) {
-     var ctrip = CommonGraph.findCommon(id);
+     var ctrip = CommonGraph.trip2Common(id);
     if (angular.isUndefined(ctrip)) {
       return {
         'box-shadow': '0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23)',
@@ -213,7 +213,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
     if (!angular.isDefined(id)) {
       return '';
     }
-    var ctrip = CommonGraph.findCommon(id);
+    var ctrip = CommonGraph.trip2Common(id);
     if (!angular.isUndefined(ctrip)) {
       // assume probabilities array is Monday-indexed + 1-indexed
       var mostFrequestHour = ctrip.start_times[0].hour;
@@ -239,7 +239,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
   }
   dh.getLongerOrShorter = function(trip, id) {
     var noChangeReturn = [0, ''];
-    var ctrip = CommonGraph.findCommon(id);
+    var ctrip = CommonGraph.trip2Common(id);
     if (!angular.isUndefined(ctrip)) {
       var cDuration = dh.average(ctrip.durations);
       if (cDuration == null) {
@@ -301,7 +301,7 @@ angular.module('emission.main.diary.services', ['emission.services'])
     }
 
   dh.fillCommonTripCount = function(tripWrapper) {
-      var cTrip = CommonGraph.findCommon(tripWrapper.data.id);
+      var cTrip = CommonGraph.trip2Common(tripWrapper.data.id);
       if (!angular.isUndefined(cTrip)) {
           tripWrapper.common_count = cTrip.trips.length;
       }

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -1,6 +1,11 @@
 'use strict';
 
-angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 'emission.main.common', 'emission.main.heatmap', 'ngCordova', 'emission.services'])
+angular.module('emission.main', ['emission.main.recent',
+                                 'emission.main.diary',
+                                 'emission.main.common',
+                                 'emission.main.heatmap',
+                                 'ngCordova',
+                                 'emission.services'])
 
 .config(function($stateProvider, $ionicConfigProvider, $urlRouterProvider) {
   $stateProvider
@@ -14,12 +19,13 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
 
   .state('root.main.common', {
     url: '/common',
-    views: {
-      'main-common': {
+    abstract: true,
+    views: { 
+      'main-common': { 
         templateUrl: 'templates/main-common.html',
         controller: 'CommonCtrl'
-      }
-    }
+      } 
+    } 
   })
 
   .state('root.main.heatmap', {
@@ -57,7 +63,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
           templateUrl: "templates/recent/map.html",
           controller: 'mapCtrl'
         }
-      }    
+      }
   })
   .state('root.main.log', {
     url: '/log',
@@ -73,6 +79,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
   $ionicConfigProvider.tabs.style('standard')
   $ionicConfigProvider.tabs.position('bottom');
 })
+
 .controller('appCtrl', function($scope, $ionicModal, $timeout) {
     $scope.openNativeSettings = function() {
         window.Logger.log(window.Logger.LEVEL_DEBUG, "about to open native settings");
@@ -111,15 +118,15 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
             if (window.plugins && window.plugins.appPreferences) {
                 var prefs = plugins.appPreferences;
                 prefs.store('dark_theme', false);
-            } 
+            }
             // StatusBar.styleDefault();
-            
+
         } else {
             $rootScope.dark_theme = true;
             $scope.dark_theme = true;
             if (window.plugins && window.plugins.appPreferences) {
                 var prefs = plugins.appPreferences;
-                prefs.store('dark_theme', true);                
+                prefs.store('dark_theme', true);
             }
             // StatusBar.style(2);
         }
@@ -162,21 +169,21 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
         });
     };
 
-    $scope.getSyncSettings = function() {               
-        var promiseList = []                
-        promiseList.push(window.cordova.plugins.BEMServerSync.getConfig());             
-        Promise.all(promiseList).then(function(resultList) {                
-            var config = resultList[0];             
-            var accuracyOptions = resultList[1];                
-            $scope.settings.sync.config = config;               
-            var retVal = [];                
-            for (var prop in config) {              
-                retVal.push({'key': prop, 'val': config[prop]});                
-            }               
-            $scope.$apply(function() {              
-                $scope.settings.sync.show_config = retVal;              
-            });             
-        });             
+    $scope.getSyncSettings = function() {
+        var promiseList = []
+        promiseList.push(window.cordova.plugins.BEMServerSync.getConfig());
+        Promise.all(promiseList).then(function(resultList) {
+            var config = resultList[0];
+            var accuracyOptions = resultList[1];
+            $scope.settings.sync.config = config;
+            var retVal = [];
+            for (var prop in config) {
+                retVal.push({'key': prop, 'val': config[prop]});
+            }
+            $scope.$apply(function() {
+                $scope.settings.sync.show_config = retVal;
+            });
+        });
     };
     $scope.getEmail = function() {
         /*
@@ -238,7 +245,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
 
         $scope.getConnectURL();
         $scope.getCollectionSettings();
-        $scope.getSyncSettings();  
+        $scope.getSyncSettings();
         $scope.getEmail();
         $scope.getState();
     };
@@ -274,7 +281,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
     $scope.forceState = function() {
         var forceStateActions = [{text: "Initialize",
                                   transition: "INITIALIZE"},
-                                 {text: 'Start trip', 
+                                 {text: 'Start trip',
                                   transition: "EXITED_GEOFENCE"},
                                  {text: 'End trip',
                                   transition: "STOPPED_MOVING"},
@@ -282,7 +289,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
                                   transition: "VISIT_ENDED"},
                                  {text: 'Visit started',
                                   transition: "VISIT_STARTED"},
-                                 {text: 'Remote push', 
+                                 {text: 'Remote push',
                                   transition: "RECEIVED_SILENT_PUSH"}];
         $ionicActionSheet.show({
             buttons: forceStateActions,
@@ -313,7 +320,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
         console.log("settings popup = "+$scope.syncSettingsPopup);
         $scope.syncSettingsPopup.show($event);
     }
-    
+
     $scope.saveAndReloadSettingsPopup = function(result) {
         console.log("new config = "+$scope.settings.collect.new_config);
         if (result == true) {
@@ -338,7 +345,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
     // Execute action on hide popover
     $scope.$on('$destroy', function() {
       $scope.collectSettingsPopup.remove();
-      $scope.syncSettingsPopup.remove();  
+      $scope.syncSettingsPopup.remove();
     });
 
     $scope.setAccuracy= function() {
@@ -356,21 +363,21 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
             }
         });
     };
-    $scope.setSyncInterval = function() {               
-        var syncIntervalActions = [];               
-        syncIntervalActions.push({text: "1 min", value: 60});               
-        syncIntervalActions.push({text: "10 min", value: 10 * 60});             
-        syncIntervalActions.push({text: "30 min", value: 30 * 60});             
-        syncIntervalActions.push({text: "1 hr", value: 60 * 60});               
-        $ionicActionSheet.show({                
-            buttons: syncIntervalActions,               
-            titleText: "Select sync interval",              
-            cancelText: "Cancel",               
-            buttonClicked: function(index, button) {                
-                $scope.settings.sync.new_config.sync_interval = button.value;               
-                return true;                
-            }               
-        });             
+    $scope.setSyncInterval = function() {
+        var syncIntervalActions = [];
+        syncIntervalActions.push({text: "1 min", value: 60});
+        syncIntervalActions.push({text: "10 min", value: 10 * 60});
+        syncIntervalActions.push({text: "30 min", value: 30 * 60});
+        syncIntervalActions.push({text: "1 hr", value: 60 * 60});
+        $ionicActionSheet.show({
+            buttons: syncIntervalActions,
+            titleText: "Select sync interval",
+            cancelText: "Cancel",
+            buttonClicked: function(index, button) {
+                $scope.settings.sync.new_config.sync_interval = button.value;
+                return true;
+            }
+        });
     };
 
     $scope.isAndroid = function() {
@@ -387,10 +394,10 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
     }).then(function(popover) {
         $scope.collectSettingsPopup = popover;
     });
-    $ionicPopover.fromTemplateUrl('templates/control/main-sync-settings.html', {        
-        scope: $scope       
-    }).then(function(popover) {     
-        $scope.syncSettingsPopup = popover;     
+    $ionicPopover.fromTemplateUrl('templates/control/main-sync-settings.html', {
+        scope: $scope
+    }).then(function(popover) {
+        $scope.syncSettingsPopup = popover;
     });
     $scope.trackingOn = function() {
         return $scope.settings.collect.state != "STATE_TRACKING_STOPPED";
@@ -404,10 +411,10 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
             $scope.startStopBtnToggle = true;
         }
     }
-    $scope.startStopBtnToggle = $scope.trackingOn(); 
+    $scope.startStopBtnToggle = $scope.trackingOn();
     $scope.getAvatarStyle = function() {
         return {
-            'width': ($window.screen.width * 0.30).toString() + 'px', 
+            'width': ($window.screen.width * 0.30).toString() + 'px',
             'height': ($window.screen.width * 0.30).toString() + 'px',
             'border-radius': ($window.screen.width * 0.15).toString() + 'px',
             'margin-top': ($window.screen.width * 0.1).toString() + 'px',
@@ -421,7 +428,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
         return {
             'text-align': 'center',
             'float': 'right',
-            'height': '100%', 
+            'height': '100%',
             'background-color': '#' + color,
             'color': '#fff',
             'padding': '15px 15px',
@@ -432,7 +439,7 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
         return {
             'text-align': 'center',
             'float': 'right',
-            'height': '100%', 
+            'height': '100%',
             'background-color': '#' + color,
             'color': '#fff',
             'padding': '15px 15px',
@@ -457,13 +464,13 @@ angular.module('emission.main', ['emission.main.recent', 'emission.main.diary', 
             $scope.expanded = false;
             $ionicScrollDelegate.resize();
             $ionicScrollDelegate.scrollTo(0, 0, true);
-            
+
         } else {
             $scope.expanded = true;
             $ionicScrollDelegate.resize();
             $ionicScrollDelegate.scrollTo(0, 1000, true);
-            
-            
+
+
         }
     }
     $scope.collectionExpanded = function() {

--- a/www/templates/common/detail.html
+++ b/www/templates/common/detail.html
@@ -1,5 +1,22 @@
 <ion-view style="" title="Common Patterns">
     <ion-content>
-        This is the detail view for {{placeId}}
+      <div class="row">
+        <div class="col" style="background-color: #C0C0C0">
+          <div class="row">{{place.displayName}}</div>
+          <div class="row">{{place.location.coordinates}}</div>
+          <div class="row">visited: {{place.places.length}}</div>
+          <div class="row">successors: {{place.successors.length}}</div>
+        </div>
+      </div>
+      <ion-list>
+        <div collection-repeat="succ_place in place.succ_places">
+          <ion-item href="#/root/main/common/places/{{succ_place._id.$oid}}">
+            <div class="row">{{succ_place.displayName}}</div>
+            <div class="row">{{succ_place.location.coordinates}}</div>
+            <div class="row">visited: {{succ_place.places.length}}</div>
+            <div class="row">successors: {{succ_place.successors.length}}</div>
+          </ion-item>
+        </div>
+        </ion-list>
     </ion-content>
 </ion-view>

--- a/www/templates/common/detail.html
+++ b/www/templates/common/detail.html
@@ -12,7 +12,9 @@
         <div collection-repeat="succ_tp in succ_trips_places">
           <ion-item href="#/root/main/common/places/{{succ_tp.place._id.$oid}}">
             <div class="col item-text-wrap">
-              {{succ_tp.trip_count}} trips to
+              <div class="row"> {{succ_tp.trip.trips.length}} trips </div>
+              <div class="row"> starting at {{succ_tp.trip.common_hour}}:00 </div>
+              <div class="row"> taking {{succ_tp.trip.common_duration}} seconds </div>
             </div>
             <div class="col">
               <div class="row">{{succ_tp.place.displayName}}</div>

--- a/www/templates/common/detail.html
+++ b/www/templates/common/detail.html
@@ -9,12 +9,17 @@
         </div>
       </div>
       <ion-list>
-        <div collection-repeat="succ_place in place.succ_places">
-          <ion-item href="#/root/main/common/places/{{succ_place._id.$oid}}">
-            <div class="row">{{succ_place.displayName}}</div>
-            <div class="row">{{succ_place.location.coordinates}}</div>
-            <div class="row">visited: {{succ_place.places.length}}</div>
-            <div class="row">successors: {{succ_place.successors.length}}</div>
+        <div collection-repeat="succ_tp in succ_trips_places">
+          <ion-item href="#/root/main/common/places/{{succ_tp.place._id.$oid}}">
+            <div class="col item-text-wrap">
+              {{succ_tp.trip_count}} trips to
+            </div>
+            <div class="col">
+              <div class="row">{{succ_tp.place.displayName}}</div>
+              <div class="row">{{succ_tp.place.location.coordinates}}</div>
+              <div class="row">visited: {{succ_tp.place.places.length}}</div>
+              <div class="row">successors: {{succ_tp.place.successors.length}}</div>
+            </div>
           </ion-item>
         </div>
         </ion-list>

--- a/www/templates/common/detail.html
+++ b/www/templates/common/detail.html
@@ -1,0 +1,5 @@
+<ion-view style="" title="Common Patterns">
+    <ion-content>
+        This is the detail view for {{placeId}}
+    </ion-content>
+</ion-view>

--- a/www/templates/common/list.html
+++ b/www/templates/common/list.html
@@ -1,0 +1,5 @@
+<ion-view style="" title="Common Patterns">
+    <ion-content>
+        This is the list view
+    </ion-content>
+</ion-view>

--- a/www/templates/common/list.html
+++ b/www/templates/common/list.html
@@ -1,5 +1,27 @@
-<ion-view style="" title="Common Patterns">
-    <ion-content>
-        This is the list view
-    </ion-content>
+<ion-view nav-title="Places list">
+  <ion-nav-title class="dark-color">
+    <!--
+    <div class="buttons" style="text-align:center; background-color: transparent !important;" id="toget">
+      <button class="button button-icon icon ion-arrow-left-b date-picker-arrow" ng-click="prevDay()">
+      </button>
+      <ionic-datepicker input-obj="datepickerObject" style="color: white;">
+        <button class="button date-picker-button"> {{datepickerObject.inputDate | date:datepickerObject.dateFormat}} <i class="ion-ios-calendar-outline" style="font-size: 16px !important;"></i></button>
+      </ionic-datepicker>
+      <button class="button button-icon icon ion-arrow-right-b ion-arrow-left-b date-picker-arrow" ng-click="nextDay()">
+      </button>
+    </div>
+    -->
+  </ion-nav-title>
+  <ion-content>
+    <ion-list>
+      <div collection-repeat="place in places">
+        <ion-item class="list-item" href="#/root/main/common/places/{{place._id.$oid}}">
+          <div class="row">{{place.displayName}}</div>
+          <div class="row">{{place.location.coordinates}}</div>
+          <div class="row">visited: {{place.places.length}}</div>
+          <div class="row">successors: {{place.successors.length}}</div>
+        </ion-item>
+      </div>
+    </ion-list>
+  </ion-content>
 </ion-view>

--- a/www/templates/common/map.html
+++ b/www/templates/common/map.html
@@ -14,7 +14,6 @@
       <leaflet geojson="mapCtrl.geojson"
                id="common"
                defaults="mapCtrl.defaults"
-               event-broadcast="mapCtrl.events"
                height="100%" width="100%">
       </leaflet>
     </ion-content>

--- a/www/templates/common/map.html
+++ b/www/templates/common/map.html
@@ -1,0 +1,21 @@
+<ion-view style="" title="Common Patterns">
+      <ion-content class="has-header" overflow-scroll="true" padding="true">
+      <!--
+      <ion-refresher
+        pulling-text="Pull to refresh..."
+        on-refresh="refreshMap()">
+      </ion-refresher>
+      -->
+      <div style="" class="button-bar">
+        <button class="button button-stable button-block icon ion-refresh"
+          ng-click="refreshMap()">Refresh</button>
+      </div>
+
+      <leaflet geojson="mapCtrl.geojson"
+               id="common"
+               defaults="mapCtrl.defaults"
+               event-broadcast="mapCtrl.events"
+               height="100%" width="100%">
+      </leaflet>
+    </ion-content>
+</ion-view>

--- a/www/templates/main-common.html
+++ b/www/templates/main-common.html
@@ -21,7 +21,7 @@
         <ion-content padding="false" class="side-menu-left has-header" <="" ion-content="">
             <ion-list style="">
                 <ion-item style="" menu-close="" href="#/root/main/common/map">Map</ion-item>
-                <ion-item style="" menu-close="" href="#/root/main/common/list">Places</ion-item>
+                <ion-item style="" menu-close="" href="#/root/main/common/places">Places</ion-item>
             </ion-list>
         </ion-content>
     </ion-side-menu>

--- a/www/templates/main-common.html
+++ b/www/templates/main-common.html
@@ -1,13 +1,29 @@
-<ion-view style="" title="Common Patterns">
-    <ion-content class="has-header" overflow-scroll="true" padding="true">
-        <div style="" class="button-bar">
-            <button class="button button-stable button-block icon ion-refresh"
-                ng-click="refreshMap()">Refresh</button>
+<ion-view title="Common Travel Patterns">
+<ion-side-menus style="" enable-menu-with-back-views="false">
+    <ion-side-menu-content>
+        <ion-nav-bar class="bar-stable">
+            <ion-nav-back-button></ion-nav-back-button>
+            <ion-nav-buttons side="left">
+                <button class="button button-icon button-clear ion-navicon" menu-toggle=""></button>
+            </ion-nav-buttons>
             <!--
-            <button style="" class="button button-stable button-block  icon ion-checkmark">Valid</button>
+            <ion-nav-buttons side="right">
+                <button class="button button-icon button-clear ion-settings" ng-click="openNativeSettings()"></button>
+            </ion-nav-buttons>
             -->
-        </div>
-        <leaflet geojson="mapCtrl.geojson" id="common" defaults="mapCtrl.defaults" event-broadcast="mapCtrl.events" height="80%" width="100%">
-        </leaflet>
-    </ion-content>
+        </ion-nav-bar>
+        <ion-nav-view name="menuContent"></ion-nav-view>
+    </ion-side-menu-content>
+    <ion-side-menu side="left">
+        <ion-header-bar class="bar-stable">
+            <div class="title">Menu</div>
+        </ion-header-bar>
+        <ion-content padding="false" class="side-menu-left has-header" <="" ion-content="">
+            <ion-list style="">
+                <ion-item style="" menu-close="" href="#/root/main/common/map">Map</ion-item>
+                <ion-item style="" menu-close="" href="#/root/main/common/list">Places</ion-item>
+            </ion-list>
+        </ion-content>
+    </ion-side-menu>
+</ion-side-menus>
 </ion-view>

--- a/www/templates/main.html
+++ b/www/templates/main.html
@@ -12,7 +12,7 @@ navigation history that also transitions its views in and out.
   </ion-tab>
 
   <!-- Common Patterns Tab -->
-  <ion-tab title="Common" icon="ion-star" href="#/root/main/common">
+  <ion-tab title="Common" icon="ion-star" href="#/root/main/common/map">
     <ion-nav-view name="main-common"></ion-nav-view>
   </ion-tab>
 


### PR DESCRIPTION
The default view is still a map, but we also have the option of seeing a list
or details of the places.

Similar to the recent view, the selection between screens is using a sidebar
menu. I would have liked to use tabs, but ionic tabs cannot be used inside a
content, or at least, I could not get it to work.

http://ionicframework.com/docs/api/directive/ionTabs/

> Note: do not place ion-tabs inside of an ion-content element; it has been known to cause a certain CSS bug.

The actual functionality in list and detail have not yet been implemented, but
I wanted to get the structure in place first for easy reviewing.