### PR TITLE
Add a new method to the CommHelper to invoke the habitica proxy API on our server

### DIFF
--- a/www/js/services.js
+++ b/www/js/services.js
@@ -27,6 +27,27 @@ angular.module('emission.services', [])
         var dateString = date.startOf('day').format('YYYY-MM-DD');
         window.cordova.plugins.BEMServerComm.postUserPersonalData("/habiticaRegister", "regConfig", regConfig, successCallback, errorCallback);
     };
+
+    /*
+     * Example usage:
+     * Get profile:
+     * callOpts = {'method': 'GET', 'method_url': "/api/v3/user",
+                    'method_args': null}
+     * Go to sleep:
+     * callOpts = {'method': 'POST', 'method_url': "/api/v3/user/sleep",
+                   'method_args': {'data': True}}
+     * Stop sleeping:
+     * callOpts = {'method': 'POST', 'method_url': "/api/v3/user/sleep",
+                   'method_args': {'data': False}}
+     * Get challenges for a user:
+     * callOpts = {'method': 'GET', 'method_url': "/api/v3/challenges/user",
+                    'method_args': null}
+     * ....
+     */
+    this.habiticaProxy = function(callOpts, successCallback, errorCallback) {
+        var dateString = date.startOf('day').format('YYYY-MM-DD');
+        window.cordova.plugins.BEMServerComm.postUserPersonalData("/habiticaProxy", "callOpts", callOpts, successCallback, errorCallback);
+    };
 })
 
 .service('ControlHelper', function($cordovaEmailComposer) {


### PR DESCRIPTION
Again, we use the `CommHelper` so that we can add the auth headers
automatically and make an authenticated user call.
The server implementation is at
https://github.com/e-mission/e-mission-server/pull/307

sample `callObj` objects are in the comments before the function.
Note that this is completely untested.

In particular, I am not sure whether the JSON generated using `null` objects
for the args can be serialized correctly. If this does not work, we should skip
the args for `GET` messages, and change the server-side to check whether the
`method_args` key exists before reading it and pass in None if it doesn't.

However, I assume that @sunil07t and @juemura can make such minor fixes if the
basic structure is in place.