### PR TITLE
Allow users to override the channel that ionic deploy is pulled from

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "angular-nvd3": "^1.0.7",
-    "string.startsWith": "*"
+    "string.startsWith": "*",
+    "angularLocalStorage": "^0.3.2"
   }
 }

--- a/www/index.html
+++ b/www/index.html
@@ -44,6 +44,8 @@
     <script src="lib/nvd3/build/nv.d3.min.js"></script>
     <script src="lib/angular-nvd3/dist/angular-nvd3.min.js"></script>
     <script src="lib/string.startsWith/src/string.startsWith.js"></script>
+    <script src="lib/angular-cookies/angular-cookies.min.js"></script>
+    <script src="lib/angularLocalStorage/dist/angularLocalStorage.min.js"></script>
 
 
     <!-- Manually installed javascript for libraries that are not published through bower -->

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -326,6 +326,9 @@ angular.module('emission.main', ['emission.main.recent',
         $scope.settings.sync = {};
         $scope.settings.auth = {};
         $scope.settings.connect = {};
+        $scope.settings.channel = function(newName) {
+          return arguments.length ? (UpdateCheck.setChannel(newName)) : UpdateCheck.getChannel();
+        };
 
         $scope.getConnectURL();
         $scope.getCollectionSettings();

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -72,6 +72,12 @@
         <div ng-click="refreshScreen()" ng-style="getIconButtonStyle('D6C780')"><i class="ion-refresh" ng-style="getIconStyle()"></i></div>
       </div>
       <div class="control-list-item">
+        <div class="control-list-text">Set UI channel</div>
+        <input type="text" name="userName"
+          ng-model="settings.channel"
+          ng-model-options="{ getterSetter: true }" />
+      </div>
+      <div class="control-list-item">
         <div class="control-list-text">{{parseState(settings.collect.state)}}</div>
         <div ng-click="forceState()" ng-style="getIconButtonStyle('CCCCCC')"><i class="ion-edit" ng-style="getIconStyle()"></i></div>
       </div>


### PR DESCRIPTION
By default, we pull ionic deploy updates from the dev channel. This change adds
an input within the Developer Zone that allows the channel to be overriden. We
plan to use this to beta test the game without publishing it to the play store.

Highlights of change:
- Add support for local storage so that we can read and write small local
  preferences without using native code through a plugin. This is particularly
  important for startup because the splash screen may be loaded before the
  plugins are initialized. The design goal is to use the appPreferences for
  settings that should be shared between the native code and the javascript,
  and to use local storage for javascript-only preferences.
- Add support for loading and storing the channel to the `UpdateCheck` service.
  This allows us to change the implementation later in a principled way.
- Convert `UpdateCheck` from a service to a factory so that we can reuse `getChannel()` in another function in the factory.
- Add a new function that uses the overriden channel if it exists, and "dev" otherwise.
  Set the channel while checking for updates, to ensure that users can set the
  channel and then immediately pull the update.
- Finally, add a new input with an `ng-model` that is linked to the channel in
  the `UpdateCheck` service.

Testing done:
Set the value of the overridden channel to many possible values and ensured
that they were used while checking for the status.

```
[Log] Ionic Deploy: Checking for updates (console-via-logger.js, line 173)
[Log] Returning channel Habitica (console-via-logger.js, line 173)
[Log] Ionic Deploy: – "no updates available" (console-via-logger.js, line 173)
[Log] Ionic Deploy: Checking for updates (console-via-logger.js, line 173)
[Log] No saved channel found, using dev (console-via-logger.js, line 173)
[Log] Returning channel dev (console-via-logger.js, line 173)
[Log] Ionic Deploy: – "no updates available" (console-via-logger.js, line 173)
[Log] Ionic Deploy: Checking for updates (console-via-logger.js, line 173)
[Log] Returning channel MimiMoMo (console-via-logger.js, line 173)
[Log] Ionic Deploy: – "no updates available" (console-via-logger.js, line 173)
```