### PR TITLE
File tile loading on android

### DIFF
--- a/www/js/diary/detail.js
+++ b/www/js/diary/detail.js
@@ -8,9 +8,14 @@ angular.module('emission.main.diary.detail',['ui-leaflet',
   console.log("controller DiaryDetailCtrl called with params = "+
     JSON.stringify($stateParams));
 
-  $scope.mapCtrl = {};  
+  $scope.mapCtrl = {};
   angular.extend($scope.mapCtrl, {
     defaults : Config.getMapTiles()
+  });
+
+  $scope.$on('leafletDirectiveMap.detail.resize', function(event, data) {
+      console.log("diary/detail received resize event, invalidating map size");
+      data.leafletObject.invalidateSize();
   });
   $scope.getFormattedDate = DiaryHelper.getFormattedDate;
   $scope.arrowColor = DiaryHelper.arrowColor;
@@ -30,7 +35,7 @@ angular.module('emission.main.diary.detail',['ui-leaflet',
   $scope.getFormattedDuration = DiaryHelper.getFormattedDuration;
   $scope.getTripDetails = DiaryHelper.getTripDetails
   $scope.tripgj = DiaryHelper.directiveForTrip($scope.trip);
-  
+
   console.log("trip.start_place = " + JSON.stringify($scope.trip.start_place));
 
   var data  = [];
@@ -59,9 +64,9 @@ angular.module('emission.main.diary.detail',['ui-leaflet',
 
   chart.yAxis     //Chart y-axis settings
       .axisLabel('Speed (m/s)')
-      .tickFormat(d3.format('.1f'));  
+      .tickFormat(d3.format('.1f'));
 
-  d3.select('#chart svg')    //Select the <svg> element you want to render the chart in.   
+  d3.select('#chart svg')    //Select the <svg> element you want to render the chart in.
       .datum([dataset,])         //Populate the <svg> element with chart data...
       .call(chart);          //Finally, render the chart!
 

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -13,6 +13,12 @@ angular.module('emission.main.diary.list',['ui-leaflet',
   // Add option
   // StatusBar.styleBlackOpaque()
   $scope.dark_theme = $rootScope.dark_theme;
+
+  $scope.$on('leafletDirectiveMap.resize', function(event, data) {
+      console.log("diary/list received resize event, invalidating map size");
+      data.leafletObject.invalidateSize();
+  });
+
   StatusBar.styleDefault();
   var readAndUpdateForDay = function(day) {
     // This just launches the update. The update can complete in the background
@@ -63,39 +69,39 @@ angular.module('emission.main.diary.list',['ui-leaflet',
      * +date and -date operations.
      */
      $scope.listExpandClass = function () {
-      return ($scope.dark_theme)? "earlier-later-expand-dark" : "earlier-later-expand"; 
+      return ($scope.dark_theme)? "earlier-later-expand-dark" : "earlier-later-expand";
      }
      $scope.listLocationClass = function() {
-        return ($scope.dark_theme)? "item item-icon-left list-location-dark" : "item item-icon-left list-location"; 
-      
+        return ($scope.dark_theme)? "item item-icon-left list-location-dark" : "item item-icon-left list-location";
+
      }
      $scope.listTextClass = function() {
-        return ($scope.dark_theme)? "list-text-dark" : "list-text"; 
+        return ($scope.dark_theme)? "list-text-dark" : "list-text";
      }
     $scope.ionViewBackgroundClass = function() {
-      return ($scope.dark_theme)? "ion-view-background-dark" : "ion-view-background"; 
+      return ($scope.dark_theme)? "ion-view-background-dark" : "ion-view-background";
     }
     $scope.datePickerClass = function() {
     }
     $scope.listCardClass = function() {
       if ($window.screen.width <= 320) {
-        return ($scope.dark_theme)? "list card list-card-dark list-card-sm" : "list card list-card list-card-sm"; 
+        return ($scope.dark_theme)? "list card list-card-dark list-card-sm" : "list card list-card list-card-sm";
       } else if ($window.screen.width <= 375) {
-        return ($scope.dark_theme)? "list card list-card-dark list-card-md" : "list card list-card list-card-md"; 
+        return ($scope.dark_theme)? "list card list-card-dark list-card-md" : "list card list-card list-card-md";
       } else {
-        return ($scope.dark_theme)? "list card list-card-dark list-card-lg" : "list card list-card list-card-lg"; 
+        return ($scope.dark_theme)? "list card list-card-dark list-card-lg" : "list card list-card list-card-lg";
       }
-      
+
     }
     $scope.listColLeftClass = function(margin) {
       if (margin == 0) {
-        return ($scope.dark_theme)? "col-50 list-col-left-dark" : "col-50 list-col-left";   
+        return ($scope.dark_theme)? "col-50 list-col-left-dark" : "col-50 list-col-left";
       } else {
-        return ($scope.dark_theme)? "col-50 list-col-left-margin-dark" : "col-50 list-col-left-margin"; 
+        return ($scope.dark_theme)? "col-50 list-col-left-margin-dark" : "col-50 list-col-left-margin";
       }
     }
     $scope.listColRightClass = function() {
-      return ($scope.dark_theme)? "col-50 list-col-right-dark" : "col-50 list-col-right"; 
+      return ($scope.dark_theme)? "col-50 list-col-right-dark" : "col-50 list-col-right";
     }
     $scope.differentCommon = function(tripgj) {
         return ($scope.isCommon(tripgj.id))? ((DiaryHelper.getEarlierOrLater(tripgj.data.properties.start_ts, tripgj.data.id) == '')? false : true) : false;
@@ -244,7 +250,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     $scope.isCommon = DiaryHelper.isCommon;
     // $scope.expandEarlierOrLater = DiaryHelper.expandEarlierOrLater;
     // $scope.increaseRestElementsTranslate3d = DiaryHelper.increaseRestElementsTranslate3d;
-    
+
 
     $scope.userModes = [
         "walk", "bicycle", "car", "bus", "train", "unicorn"

--- a/www/js/heatmap.js
+++ b/www/js/heatmap.js
@@ -17,6 +17,11 @@ angular.module('emission.main.heatmap',['ui-leaflet', 'emission.services'])
 
   angular.extend($scope.mapCtrl.defaults, Config.getMapTiles())
 
+  $scope.$on('leafletDirectiveMap.heatmap.resize', function(event, data) {
+      console.log("heatmap received resize event, invalidating map size");
+      data.leafletObject.invalidateSize();
+  });
+
   $scope.getPopRoute = function() {
     $ionicLoading.show({
         template: 'Loading...'

--- a/www/js/recent.js
+++ b/www/js/recent.js
@@ -13,7 +13,7 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
         });
     }
 })
-     
+
 .controller('logCtrl', function(ControlHelper, $scope, $cordovaFile, $cordovaEmailComposer, $ionicPopup) {
     console.log("Launching logCtr");
     var RETRIEVE_COUNT = 100;
@@ -79,7 +79,7 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
     $scope.refreshEntries();
 })
-   
+
 .controller('sensedDataCtrl', function($scope, $cordovaEmailComposer, $ionicActionSheet) {
     var currentStart = 0;
 
@@ -114,12 +114,12 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
         if (ionic.Platform.isAndroid()) {
             parentDir = "app://databases";
-        } 
+        }
         if (ionic.Platform.isIOS()) {
             alert("You must have the mail app on your phone configured with an email address. Otherwise, this won't work");
             parentDir = cordova.file.dataDirectory+"../LocalDatabase";
         }
-        
+
         /*
         window.Logger.log(window.Logger.LEVEL_INFO,
             "Going to export logs to "+parentDir);
@@ -172,7 +172,7 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
     $scope.setSelected = function(newVal) {
       $scope.selected.key = newVal;
       $scope.updateEntries();
-    } 
+    }
 
   $scope.updateEntries = function() {
     if (angular.isUndefined($scope.selected.key)) {
@@ -204,7 +204,7 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
   $scope.updateEntries();
 })
-   
+
 .controller('mapCtrl', function($scope, Config) {
     /* Let's keep a reference to the database for convenience */
     var db = window.cordova.plugins.BEMUserCache;
@@ -213,6 +213,11 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
     angular.extend($scope.mapCtrl, {
         defaults : Config.getMapTiles()
+    });
+
+    $scope.$on('leafletDirectiveMap.resize', function(event, data) {
+          console.log("recent/map received resize event, invalidating map size");
+          data.leafletObject.invalidateSize();
     });
 
     $scope.refreshMap = function() {
@@ -233,6 +238,6 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
     $scope.refreshMap();
 });
- 
+
 
 


### PR DESCRIPTION
Apparently because of loading differences between android and iOS, the leaflet
maps on android frequently ended up with tiles only partially loaded.
This is tracked in issue:
https://github.com/e-mission/e-mission-phone/issues/75

In e3d6f7181c25a4ec0742f949854c7b9c77e5794a, I added a button to manually
apply the workaround for the issue and @yw374cornell confirmed that it worked.

In this change, I apply the workaround automatically and for all maps.

There are also minor whitespace differences that were automatically added by
the editor configuration. Anything that is not related to the leafletDirective.*resize code is whitespace.

Also added code to listen to all events in the common map so that we can get a
better sense of what events are actually generated on the phone versus in the
emulator. Since we do not have access to an android phone or emulator, it can
also help us debug in case android does not generate resize events and the
workaround still does not work.