### PR TITLE
Switch the startup storage to localStorage + support re-consent

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -20,11 +20,12 @@
   <preference name="android-minSdkVersion" value="18"/>
   <preference name="BackupWebStorage" value="none"/>
   <preference name="SplashScreen" value="screen"/>
-  <preference name="SplashScreenDelay" value="3000"/>
+  <preference name="SplashScreenDelay" value="100"/>
   <preference name="xwalkVersion" value="19+" />
   <preference name="xwalkCommandLine" value="--disable-pull-to-refresh-effect" />
   <preference name="xwalkMode" value="embedded" />
   <preference name="xwalkMultipleApk" value="true" />
+  <preference name="emSensorDataCollectionProtocolApprovalDate" value="2016-07-14" />
   <feature name="StatusBar">
     <param name="ios-package" onload="true" value="CDVStatusBar"/>
   </feature>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "cordova-plugin-device",
     "cordova-plugin-console",
     "cordova-plugin-whitelist",
-    "cordova-plugin-splashscreen",
     "cordova-plugin-statusbar",
     "ionic-plugin-keyboard",
     {

--- a/www/index.html
+++ b/www/index.html
@@ -81,6 +81,7 @@
     <script src="js/goals.js"></script>
     <!--script src="js/goals/party.js"></script-->
     <script src="js/goals/signup.js"></script>
+    <script src="js/plugin/logger.js"></script>
 
 
     <script src="lib/d3/d3.js"></script>  

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -25,6 +25,38 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
       $rootScope.checkedForUpdates = true;
     } */
   });
+  $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error){
+    console.log("Error "+error+" while changing state from "+JSON.stringify(fromState)
+      +" to "+JSON.stringify(toState));
+  });
+  $rootScope.$on('$stateNotFound',
+    function(event, unfoundState, fromState, fromParams){
+        console.log("unfoundState.to = "+unfoundState.to); // "lazy.state"
+        console.log("unfoundState.toParams = " + unfoundState.toParams); // {a:1, b:2}
+        console.log("unfoundState.options = " + unfoundState.options); // {inherit:false} + default options
+  });
+
+  var isInList = function(element, list) {
+    return list.indexOf(element) != -1
+  }
+
+  $rootScope.$on('$stateChangeStart',
+    function(event, toState, toParams, fromState, fromParams, options){
+      var personalTabs = ['root.main.common.map',
+                          'root.main.control',
+                          'root.main.goals',
+                          'root.main.diary']
+      if (isInList(toState.name, personalTabs)) {
+        // toState is in the personalTabs list
+        StartPrefs.getPendingOnboardingState().then(function(result) {
+          if (result != null) {
+            event.preventDefault();
+            $state.go(result);
+          };
+          // else, will do default behavior, which is to go to the tab
+        });
+      }
+  })
   console.log('SplashCtrl invoke finished');
 })
 

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -10,7 +10,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope,
     UpdateCheck, StartPrefs) {
   console.log('SplashCtrl invoked');
-  // alert("attach debugger!");
+  alert("attach debugger!");
   UpdateCheck.checkForUpdates();
   StartPrefs.startWithPrefs();
 

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -10,7 +10,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope,
     UpdateCheck, StartPrefs) {
   console.log('SplashCtrl invoked');
-  alert("attach debugger!");
+  // alert("attach debugger!");
   UpdateCheck.checkForUpdates();
   StartPrefs.startWithPrefs();
 

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -1,6 +1,7 @@
 'use strict';
 
-angular.module('emission.intro', ['ionic-toast'])
+angular.module('emission.intro', ['emission.splash.startprefs',
+                                  'ionic-toast'])
 
 .config(function($stateProvider) {
   $stateProvider
@@ -10,10 +11,15 @@ angular.module('emission.intro', ['ionic-toast'])
     templateUrl: 'templates/intro/intro.html',
     controller: 'IntroCtrl'
   })
+  .state('root.reconsent', {
+    url: '/reconsent',
+    templateUrl: 'templates/intro/reconsent.html',
+    controller: 'IntroCtrl'
+  });
 })
 
-.controller('IntroCtrl', function($scope, $state, $ionicSlideBoxDelegate, 
-        $ionicPopup, ionicToast, $timeout, CommHelper) {
+.controller('IntroCtrl', function($scope, $state, $ionicSlideBoxDelegate,
+    $ionicPopup, ionicToast, $timeout, CommHelper, StartPrefs) {
   $scope.getIntroBox = function() {
     return $ionicSlideBoxDelegate.$getByHandle('intro-box');
   };
@@ -29,7 +35,7 @@ angular.module('emission.intro', ['ionic-toast'])
         title: 'settings',
         template: errorMsg
       });
-   
+
       alertPopup.then(function(res) {
         $scope.next();
       });
@@ -38,18 +44,17 @@ angular.module('emission.intro', ['ionic-toast'])
     });
   };
 
-  $scope.popupUninstall = function() {
-    var alertPopup = $ionicPopup.show({
-      template: 'Please close and uninstall this application. You must accept the terms to use E-Mission',
-      cssClass: 'refuse-popup',
-      buttons: [
-          { text: 'Cancel',
-            type: 'button button-block button-outline button-positive' }
-       ]
-    });
- 
-    alertPopup.then(function(res) {
-      window.Logger.log(window.Logger.LEVEL_INFO, 'User confirmed that they understood that consent is required'+res);
+  $scope.disagree = function() {
+    $state.go('root.main.heatmap');
+  };
+
+  $scope.agree = function() {
+    StartPrefs.markConsented().then(function(response) {
+      if ($state.is('root.intro')) {
+        $scope.next();
+      } else {
+        StartPrefs.loadPreferredScreen();
+      }
     });
   };
 
@@ -60,14 +65,14 @@ angular.module('emission.intro', ['ionic-toast'])
   $scope.previous = function() {
     $scope.getIntroBox().previous();
   };
-  
+
   $scope.alertError = function(title, errorResult) {
       var errorMsg = JSON.stringify(errorResult);
       var alertPopup = $ionicPopup.alert({
         title: title,
         template: errorMsg
       });
-   
+
       alertPopup.then(function(res) {
         window.Logger.log(window.Logger.LEVEL_INFO, errorMsg + ' ' + res);
       });
@@ -108,13 +113,10 @@ angular.module('emission.intro', ['ionic-toast'])
   };
 
   $scope.finish = function() {
-    var prefs = window.plugins.appPreferences;
-    prefs.store('setup_complete', true).then(function(value) {
-        // $scope.alertError("setup_complete", "success -> "+value);
-        $state.go('root.main.diary');
-    }, function(error) {
-        $scope.alertError("setup_complete", "error -> "+error);
-    });
+    // this is not a promise, so we don't need to use .then
+    StartPrefs.markIntroDone();
+    $scope.getIntroBox().slide(0);
+    StartPrefs.loadPreferredScreen();
   }
 });
 

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -8,7 +8,8 @@ angular.module('emission.main', ['emission.main.recent',
                                  'emission.main.metrics',
                                  'ngCordova',
                                  'emission.services',
-                                 'emission.splash.updatecheck'])
+                                 'emission.splash.updatecheck',
+                                 'emission.splash.startprefs'])
 
 .config(function($stateProvider, $ionicConfigProvider, $urlRouterProvider) {
   $stateProvider
@@ -145,7 +146,8 @@ angular.module('emission.main', ['emission.main.recent',
 })
 
 .controller('ControlCtrl', function($scope, $window, $ionicScrollDelegate,
-               $state, $ionicPopup, $ionicActionSheet, $ionicPopover, $rootScope,
+               $state, $ionicPopup, $ionicActionSheet, $ionicPopover,
+               $rootScope, StartPrefs,
                ControlHelper, UpdateCheck) {
     $scope.emailLog = ControlHelper.emailLog;
     $scope.dark_theme = $rootScope.dark_theme;
@@ -199,20 +201,11 @@ angular.module('emission.main', ['emission.main.recent',
         if ($scope.dark_theme) {
             $rootScope.dark_theme = false;
             $scope.dark_theme = false;
-            if (window.plugins && window.plugins.appPreferences) {
-                var prefs = plugins.appPreferences;
-                prefs.store('dark_theme', false);
-            }
-            // StatusBar.styleDefault();
-
+            StartPrefs.setDefaultTheme(null);
         } else {
             $rootScope.dark_theme = true;
             $scope.dark_theme = true;
-            if (window.plugins && window.plugins.appPreferences) {
-                var prefs = plugins.appPreferences;
-                prefs.store('dark_theme', true);
-            }
-            // StatusBar.style(2);
+            StartPrefs.setDefaultTheme('dark_theme');
         }
         $ionicPopup.alert({template: 'Restart the app to see all changes!'})
     }

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -29,7 +29,7 @@ angular.module('emission.main', ['emission.main.recent',
         templateUrl: 'templates/main-common.html',
         controller: 'CommonCtrl'
       }
-    }
+    },
   })
 
   .state('root.main.heatmap', {
@@ -331,7 +331,13 @@ angular.module('emission.main', ['emission.main.recent',
     };
 
     $scope.returnToIntro = function() {
+      var testReconsent = false
+      if (testReconsent) {
+        $rootScope.req_consent.approval_date = Math.random();
+        StartPrefs.loadPreferredScreen();
+      } else {
         $state.go("root.intro");
+      }
     };
 
     $scope.forceTransition = function(transition) {
@@ -558,5 +564,13 @@ angular.module('emission.main', ['emission.main.recent',
     }
     $scope.checkUpdates = function() {
       UpdateCheck.checkForUpdates();
+    }
+    $scope.checkConsent = function() {
+      window.cordova.plugins.BEMUserCache.getDocument(
+            "config/consent", function(resultList) {
+              $ionicPopup.alert({template: resultList});
+            }, function(error) {
+              $ionicPopup.alert({template: error});
+            });
     }
 });

--- a/www/js/plugin/logger.js
+++ b/www/js/plugin/logger.js
@@ -1,0 +1,9 @@
+angular.module('emission.plugin.logger', [])
+
+.factory('Logger', function($window, $state, $interval, $rootScope) {
+    var loggerJs = {}
+    loggerJs.log = function(message) {
+        $window.Logger.log($window.Logger.LEVEL_DEBUG, message);
+    }
+    return loggerJs;
+});

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -1,20 +1,29 @@
-angular.module('emission.splash.startprefs', [])
+angular.module('emission.splash.startprefs', ['angularLocalStorage'])
 
-.factory('StartPrefs', function($window, $state, $interval) {
+.factory('StartPrefs', function($window, $state, $interval, $rootScope, storage) {
     var logger = $window.Logger;
     var startprefs = {};
+    var DEFAULT_THEME_KEY = 'curr_theme'
 
-    startprefs.loadDefaultTheme = function(prefs) {
+    startprefs.setDefaultTheme = function(new_theme) {
+      storage.set(DEFAULT_THEME_KEY, new_theme);
+    }
+
+    startprefs.getDefaultTheme = function() {
+      return storage.get(DEFAULT_THEME_KEY);
+    }
+
+    startprefs.loadDefaultTheme = function() {
         logger.log(logger.LEVEL_INFO, "About to set theme from preference")
-        prefs.fetch('dark_theme').then(function(value) {
-          logger.log(logger.LEVEL_INFO, "preferred dark_theme = "+value)
-          if (value == true) {
+        var curr_theme = startprefs.getDefaultTheme();
+        logger.log(logger.LEVEL_INFO, "preferred theme = "+curr_theme)
+
+        if (curr_theme == 'dark_theme') {
             $rootScope.dark_theme = true;
-          } else {
+        } else {
             $rootScope.dark_theme = false;
-          }
-          logger.log(logger.LEVEL_INFO, "set dark_theme = "+$rootScope.dark_theme)
-        });
+        }
+        logger.log(logger.LEVEL_INFO, "set dark_theme = "+$rootScope.dark_theme);
     };
 
     var changeState = function(destState) {
@@ -49,7 +58,7 @@ angular.module('emission.splash.startprefs', [])
         if ($window.plugins && $window.plugins.appPreferences && $window.Logger) {
           logger = $window.Logger;
           var prefs = plugins.appPreferences;
-          startprefs.loadDefaultTheme(prefs);
+          startprefs.loadDefaultTheme();
           startprefs.loadPreferredScreen(prefs);
         } else {
           console.log("appPreferences plugin not installed, waiting...");

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -1,9 +1,19 @@
-angular.module('emission.splash.startprefs', ['angularLocalStorage'])
+angular.module('emission.splash.startprefs', ['emission.plugin.logger',
+                                              'angularLocalStorage'])
 
-.factory('StartPrefs', function($window, $state, $interval, $rootScope, storage) {
-    var logger = $window.Logger;
+.factory('StartPrefs', function($window, $state, $interval, $rootScope,
+      $ionicPopup, storage, $http, Logger) {
+    var logger = Logger;
     var startprefs = {};
-    var DEFAULT_THEME_KEY = 'curr_theme'
+    var DEFAULT_THEME_KEY = 'curr_theme';
+     // Boolean: represents that the "intro" - the one page summary
+     // and the login are done
+    var INTRO_DONE_KEY = 'intro_done';
+    // data collection consented protocol: string, represents the date on
+    // which the consented protocol was approved by the IRB
+    var DATA_COLLECTION_CONSENTED_PROTOCOL = 'data_collection_consented_protocol';
+
+    var CONSENTED_KEY = "config/consent";
 
     startprefs.setDefaultTheme = function(new_theme) {
       storage.set(DEFAULT_THEME_KEY, new_theme);
@@ -14,19 +24,129 @@ angular.module('emission.splash.startprefs', ['angularLocalStorage'])
     }
 
     startprefs.loadDefaultTheme = function() {
-        logger.log(logger.LEVEL_INFO, "About to set theme from preference")
+        logger.log("About to set theme from preference");
         var curr_theme = startprefs.getDefaultTheme();
-        logger.log(logger.LEVEL_INFO, "preferred theme = "+curr_theme)
+        logger.log("preferred theme = "+curr_theme);
 
         if (curr_theme == 'dark_theme') {
             $rootScope.dark_theme = true;
         } else {
             $rootScope.dark_theme = false;
         }
-        logger.log(logger.LEVEL_INFO, "set dark_theme = "+$rootScope.dark_theme);
+        logger.log("set dark_theme = "+$rootScope.dark_theme);
+    };
+
+    var writeConsentToNative = function() {
+      return $window.cordova.plugins.BEMUserCache.putRWDocument(
+        CONSENTED_KEY,
+        JSON.stringify({category: "emSensorDataCollectionProtocol",
+         protocol_id: $rootScope.req_consent.protocol_id,
+         approval_date: $rootScope.req_consent.approval_date})
+      );
+    };
+
+    startprefs.markConsented = function() {
+      logger.log("changing consent from "+
+        $rootScope.curr_consented+" -> "+$rootScope.req_consent);
+      // mark in native storage
+      return readConsentState().then(writeConsentToNative).then(function(response) {
+          // mark in local storage
+          storage.set(startprefs.DATA_COLLECTION_CONSENTED_PROTOCOL,
+            $rootScope.req_consent);
+          // mark in local variable as well
+          $rootScope.curr_consented = angular.copy($rootScope.req_consent);
+      });
+    };
+
+    startprefs.markIntroDone = function() {
+      storage.set(INTRO_DONE_KEY, true);
+    }
+
+    // returns boolean
+    startprefs.isIntroDone = function() {
+      var read_val = storage.get(INTRO_DONE_KEY);
+      if (read_val == null || read_val == "") {
+        return false;
+      } else {
+        return read_val;
+      }
+    }
+
+    $rootScope.isConsented = function() {
+      if ($rootScope.curr_consented == null || $rootScope.curr_consented == "") {
+        logger.log("curr_consented = "+$rootScope.curr_consented+
+            "INTRO_DONE_KEY" + storage.get(INTRO_DONE_KEY));
+        alert("why is curr_consented null when intro is done?");
+      }
+      if ($rootScope.curr_consented.approval_date != $rootScope.req_consent.approval_date) {
+        console.log("Not consented, need to show consent");
+        return false;
+      } else {
+        console.log("Consented, no need to show consent");
+        return true;
+      }
+    }
+
+    var readConsentState = function() {
+      if (angular.isDefined($rootScope.req_consent) &&
+          angular.isDefined($rootScope.curr_consented)) {
+          // consent state is all populated
+          return new Promise(function(resolve, reject) {
+            resolve();
+          });
+      } else {
+          // read consent state from the file and populate it
+          return $http.get("json/startupConfig.json")
+              .then(function(startupConfigResult) {
+                  $rootScope.req_consent = startupConfigResult.data.emSensorDataCollectionProtocol;
+                  logger.log("required consent version = " + JSON.stringify($rootScope.req_consent));
+                  $rootScope.curr_consented = storage.get(
+                    startprefs.DATA_COLLECTION_CONSENTED_PROTOCOL);
+              });
+      }
+    }
+
+    /*
+     * getNextState() returns a promise, since reading the startupConfig is
+     * async. The promise returns an onboarding state to navigate to, or
+     * null for the default state
+     */
+
+    startprefs.getPendingOnboardingState = function() {
+      if (!startprefs.isIntroDone()) {
+        // Since we must return a promise when the intro is done,
+        // we create and return one here even though we don't need it
+        return new Promise(function(resolve, reject) {
+          resolve('root.intro');
+        });
+      } else {
+        // intro is done. Now, let's read and check the current version
+        // of the startup config
+        return $http.get("json/startupConfig.json")
+          .then(readConsentState)
+          .then($rootScope.isConsented)
+          .then(function(result) {
+            if (result) {
+              return null;
+            } else {
+              return 'root.reconsent';
+            }
+          });
+      }
+    };
+
+    startprefs.getNextState = function() {
+      return startprefs.getPendingOnboardingState().then(function(result){
+        if (result == null) {
+          return 'root.main.diary';
+        } else {
+          return result;
+        }
+      });
     };
 
     var changeState = function(destState) {
+        logger.log('changing state to '+destState);
         console.log("loading "+destState);
         $state.go(destState);
         $interval.cancel(currPromise);
@@ -36,30 +156,21 @@ angular.module('emission.splash.startprefs', ['angularLocalStorage'])
     // But easily extensible to storing the last screen that the user was on,
     // or the users' preferred screen
 
-    startprefs.loadPreferredScreen = function(prefs) {
-        logger.log(logger.LEVEL_INFO, "About to navigate to preferred tab")
-        prefs.fetch('setup_complete').then(function(value) {
-          logger.log(logger.LEVEL_DEBUG, 'setup_complete result '+value);
-          if (value == true) {
-              logger.log(logger.LEVEL_INFO, 'changing state to root.main.diary');
-              changeState('root.main.diary');
-          } else {
-              logger.log(logger.LEVEL_INFO, 'changing state to root.intro');
-              changeState('root.intro');
-          }
-        }, function(error) {
-          logger.log(logger.LEVEL_ERROR, "error "+error+" loading root.intro");
-          changeState('root.intro');
-        });
+    startprefs.loadPreferredScreen = function() {
+      logger.log("About to navigate to preferred tab");
+      startprefs.getNextState().then(changeState).catch(function(error) {
+        logger.log("error "+error+" loading finding tab, loading root.intro");
+        changeState('root.intro');
+      });
     };
 
     startprefs.loadWithPrefs = function() {
+        // alert("attach debugger!");
         console.log("Checking to see whether we are ready to load the screen");
-        if ($window.plugins && $window.plugins.appPreferences && $window.Logger) {
-          logger = $window.Logger;
-          var prefs = plugins.appPreferences;
+        if (angular.isDefined($window.Logger)) {
+          logger = Logger;
           startprefs.loadDefaultTheme();
-          startprefs.loadPreferredScreen(prefs);
+          startprefs.loadPreferredScreen();
         } else {
           console.log("appPreferences plugin not installed, waiting...");
         }

--- a/www/json/startupConfig.json
+++ b/www/json/startupConfig.json
@@ -1,0 +1,6 @@
+{
+    "emSensorDataCollectionProtocol": {
+        "protocol_id": "2014-04-6267",
+        "approval_date": "2016-07-14"
+    }
+}

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -72,6 +72,10 @@
         <div ng-click="refreshScreen()" ng-style="getIconButtonStyle('D6C780')"><i class="ion-refresh" ng-style="getIconStyle()"></i></div>
       </div>
       <div class="control-list-item">
+        <div class="control-list-text">Check consent</div>
+        <div ng-click="checkConsent()" ng-style="getIconButtonStyle('D6C780')"><i class="ion-checkmark-circled" ng-style="getIconStyle()"></i></div>
+      </div>
+      <div class="control-list-item">
         <div class="control-list-text">Set UI channel</div>
         <input type="text" name="userName"
           ng-model="settings.channel"

--- a/www/templates/intro/changes.html
+++ b/www/templates/intro/changes.html
@@ -1,0 +1,21 @@
+<ion-content>
+	<!-- <div class="intro-space"></div> -->
+	<div class="intro-title">
+	<center><h4>E-Mission: Data driven carbon emission reduction</h4></center>
+	</div>
+	<!-- <div class="intro-space"></div> -->
+	<div class="intro-text">
+	Changes between the previously approved protocol and the current one are:
+	<div class="intro-space"></div>
+    <ol>
+        <li>Switch from moves to our own data collection</li>
+        <li>Define policies when used as a platform for an external study</li>
+        <li>Specify policies for time-delayed access of datasets</li>
+    </ol>
+	</div>
+	<div class="bar bar-footer no-bgColor" id="intro-footer">
+	  <button class="button button-block button-outline button-positive" ng-click="next()">
+	  	FULL TEXT
+	  </button>
+	</div>
+</ion-content>

--- a/www/templates/intro/consent.html
+++ b/www/templates/intro/consent.html
@@ -3,86 +3,87 @@
 <center><h4>E-Mission: Data driven carbon emission reduction</h4></center>
 </div>
 <div class="consent-text">
-
-<h5><b>Introduction and Purpose</b></h5>
-This app is designed to collect information for a research study at the
-University of California, Berkeley. The study is being led by <a
+<h3>Introduction and Purpose</h3>
+This app is part of a travel behavior research platform developed at the
+University of California, Berkeley. The platform development is being led by <a
 href="http://www.cs.berkeley.edu/~shankari">K. Shankari</a> under the
-supervision of <a href="http://www.cs.berkeley.edu/~culler/">Prof. David Culler</a>.
-The goal of the study is to understand people's travel behavior and mode usage
-as people commute to trip generators. We will use this information to make
-recommendations for changes that can reduce emissions.
-<div class="consent-space"></div>
-<h5>Benefits</h5>
-There are no direct benefits to you for enrolling in the study. However, we
-will use this information to provide you with a personalized carbon footprint
-for travel that can be compared with the average carbon footprint of our users,
-and with statewide goals for emission reduction. In addition, we will use the
-aggregate data to recommend structural changes and incentives for more energy
-efficient transportation.
-<div class="consent-space"></div>
-<h5>Procedures</h5>
-We will automatically track your location and use it to generate a list of
-trips that you made, and the route for the trip. We will attempt to
-automatically determine the mode (walk/bike/car/train/bus/air) for the trip,
-and prompt you for confirmation. You confirm trips directly from your phone -
-confirming a trip should take no more than a couple of seconds. Since this is a
-long-term, longitudinal study, we will continue to collect data as long as the
-apps are installed. In order to withdraw from the study temporarily, you can
-turn off data collection in Moves. In order to withdraw permanently, you can
-uninstall both the Moves and E-Mission apps.
-<div class="consent-space"></div>
-<h5>Risks/Discomforts</h5>
-As with all research, there is a chance that confidentiality could be
-compromised; however, we are taking precautions to minimize this risk as
-described below. The biggest complaint that we have had from our beta testers
-is the battery drain on the phone. This seems to be a particular concern for
-iOS users. The "Battery Saving" mode in Moves (M -&gt; Settings -&gt; Tracking
-Priority) seems to help significantly.
-<div class="consent-space"></div>
-<h5>Confidentiality</h5>
-We understand that location data can be sensitive, and we have taken several
-precautions related to the security of your data. In particular:
-<ol>
-  <li>All communication with our server is encrypted.</li>
-  <li>We divide our endpoints into ones that expose personally identifiable
-  information (PII) (such as your personal carbon footprint) and ones which
-  expose aggregate information (such as the carbon footprint of UC Berkeley). All
-  endpoints which expose PII have a "user" field in the request that is used for
-  authentication.</li>
-  <li>We use your gmail ID for authentication in order to avoid the risks
-  associated with storing passwords. If you wish to remain completely anonymous,
-  you can create a separate gmail address only for this app.</li>
-  <li>The trip data is associated with unique user IDs, not with the gmail addresses. The mapping from the userIDs to the gmail addresses is done through a separate table. The lead researcher (Shankari) is the only person who has access to the database, for both the trip and user access tables. Other researchers will only have access to data from the trip database, exported by the lead researcher, but without the linked gmail addresses.</li>
-  <li>The server on which the web app is running is protected by a firewall which only exposes the Secure Shell (SSH) and HTTPS ports - the database cannot be accessed directly from outside the host. The SSH server on the host is configured to only support public key authentication, and the only user with access to the private key for the server is the lead researcher (Shankari).</li>
-</ol>
+supervision of <a href="http://www.cs.berkeley.edu/~culler/">Prof. David
+Culler</a>. Our goal is to collect information from users about travel behavior
+across all modes, and use the aggregate information for better transportation
+infrastructure planning.
 
-Note, however, that we integrate with a third party app - <a
-href="http://www.moves-app.com/">Moves</a> - to collect the data. Moves has its
-<a href="http://www.moves-app.com/privacy.html">own policies on data
-collection, privacy and storage</a>. At the end of the study, we plan to
-destroy the table linking email addresses with the uuids. The trip table
-containing user UUIDs along with the list of trips will be retained as a travel
-pattern dataset for ongoing research. The travel pattern dataset will be available by
-request only, and researchers will be asked to agree that they will publish
+<h3>What we collect</h3>
+We automatically track your location, accelerometer, device-generated activity
+recognition, and battery usage. We also allow you to optionally enter your
+experiences and feedback during travel through the app. Since our code is
+open source, you can inspect the data that we collect in the background at
+<a
+href="https://github.com/e-mission/e-mission-data-collection.git">https://github.com/e-mission/e-mission-data-collection.git</a>,
+explore the prompts for optional sentiment reporting at <a
+href="https://github.com/e-mission/e-mission-phone.git">https://github.com/e-mission/e-mission-phone.git</a>,
+and see the analysis that we perform at <a
+href="https://github.com/e-mission/e-mission-server.git">https://github.com/e-mission/e-mission-server.git</a>
+
+<h3>How we associate it with you</h3>
+You log in to the app using a valid gmail address. We map the gmail address to
+a unique UUID and associate all collected data with the UUID. In general, the
+mapping between the email address and the UUID will only be made available to
+the lead researcher for the platform (Shankari). If you are not comfortable
+sharing your real gmail adress, you can create a fake one to use for this
+platform. The only reason we use an email address is so that we can ensure that
+your data is only available to somebody logged in as you, and remains available
+even if you switch phones.
+
+<h3>Who gets to see it</h3>
+Individually identified, real-time data is only available to the lead
+researcher for the study (Shankari). The data may be shared for aggregate
+analysis under two scenarios as described below. It will not be used for
+marketing or advertising purposes.
+<ul>
+<li> Aggregate views of the collected data (both automatic and optional) that
+do not show individual trajectories (e.g. heatmaps) will be made publicly
+available through the platform website and on the phone app. You can explore
+this data on the "aggregate" tab of this app before consenting to data
+collection.
+<li> Time-delayed subsets of individual trajectory data, associated with their
+UUIDs but not email addresses, may by shared with collaborators, or released as
+research datasets to the community from time to time. If this is done, the time
+delay for sharing with collaborators will be at least one month, and the time
+delay for releasing to the community will be at least one year. Both
+collaborators and researchers will be asked to agree that they will publish
 only aggregate, non personally identifiable results, and will not re-share the
-data with others. It will not be used for marketing or advertising purposes.
+data with others.
+</ul>
 
-Please note that Moves was recently acquired by Facebook, so data collected by
-Moves is searchable by Facebook. You do not have to provide your Facebook ID to
-use either Moves or E-Mission, so there is no explicit link between the data
-collected and your Facebook identity.  We communicate with Moves over SSL,
-using an access token for authentication.
-<div class="consent-space"></div>
-<h5>Compensation</h5>
-You will not be paid for taking part in this study.
-<div class="consent-space"></div>
-<h5>Rights</h5>
+<h3>Benefits and Compensation</h3>
+You will not be directly compensated for contributing your data to this
+platform.
+<p>
+However, we will use this information to provide you with a personalized travel
+profile that can be compared with the travel profiles of our other users, and
+with state and federal goals for daily exercise and GHG emission reduction. In
+addition, we will display aggregate travel patterns and aggregate crowdsourced
+safe/unsafe zones that you can use while making travel choices. You will have a
+chance to see the aggregate data generated before choosing to provide your own.
+
+<h3>Studies lead by other researchers</h3>
+If this platform is being used to collect data for a study conducted by another
+researcher, for example, from a Transportation Engineering Department, then you
+will be asked to assent to a separate document outlining the data association,
+retention and sharing policies for that study, <b>in addition to the policies
+above</b>. We will make all data, including the mapping between the email
+address and the UUID, directly available to the lead researcher for the main
+study. This will allow them to associate the automatically gathered information
+with demographic data, and any pre and post surveys that they conduct as part
+of their study. The other researcher may also choose to compensate you for your
+time, as described in the protocol document for that study.
+
+<h3>Your rights</h3>
 <b><i>Participation in research is completely voluntary</i></b>.  You have the
 right to decline to participate or to withdraw at any point in this study
 without penalty or loss of benefits to which you are otherwise entitled.
-<div class="consent-space"></div>
-<h5>Questions</h5>
+
+<h3>Questions</h3>
 If you have any questions about this research, please feel free to contact us.
 For the quickest response, you can send email to the entire team at <a
 href="mailto:e-mission@lists.eecs.berkeley.edu">e-mission@lists.eecs.berkeley.edu</a>.
@@ -90,21 +91,23 @@ If you want to contact only the lead researcher or the PI, you can use their
 profiles above.
 
 If you have any questions about your rights or treatment as a research
-participant in this study, please contact the University of California at
+participant using this platform, please contact the University of California at
 Berkeley's Committee for Protection of Human Subjects at 510-642-7461, or
 e-mail <a href="mailto:subjects@berkeley.edu">subjects@berkeley.edu</a>.
 
-If you agree to take part in the research, please click "I agree" below to
-proceed. If you do not wish to take part in the research, please click "I
-disagree" below to exit the app. This notice is also available <a
-href="consent">online</a> in case you need to read it again in the future.
+If you agree to contribute your data to the platform, please click "I agree"
+below to proceed. If you do not wish to contribute your data to the platform,
+please click "I disagree" below to return to the aggregate views. This notice
+is also available <a
+href="https://e-mission.eecs.berkeley.edu/consent">online</a> in case you need
+to read it again in the future.
 
 <div class="row" style="margin-top: 20px;">
   <div class="col" style="margin-right: 5px">
-    <button class="button button-block button-assertive button-outline" ng-click="popupUninstall()" id="consent-button">I Refuse</button>
+    <button class="button button-block button-assertive button-outline" ng-click="disagree()" id="consent-button">I Refuse</button>
   </div>
   <div class="col" style="margin-left: 5px">
-    <button class="button button-block button-balanced button-outline" ng-click="next()" id="consent-button">I Agree</button>
+    <button class="button button-block button-balanced button-outline" ng-click="agree()" id="consent-button">I Agree</button>
   </div>
 </div>
 </div>

--- a/www/templates/intro/reconsent.html
+++ b/www/templates/intro/reconsent.html
@@ -1,0 +1,10 @@
+<ion-view hide-nav-bar="true" class="intro-view">
+    <ion-slide-box delegate-handle="intro-box" on-slide-changed="slideChanged(index)" show-pager="false">
+      <ion-slide>
+        <ng-include src="'templates/intro/changes.html'"></ng-include>
+      </ion-slide>
+      <ion-slide>
+        <ng-include src="'templates/intro/consent.html'"></ng-include>
+      </ion-slide>
+    </ion-slide-box>
+</ion-view>


### PR DESCRIPTION
The goal is to remove all native code from the splash screen in order to allow
startup to proceed more quickly.

This should help us with issues like https://github.com/e-mission/e-mission-phone/issues/56 in which preferences don't appear to be read correctly on startup.