### PR TITLE
Minor fixes to match data collection changes

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -44,6 +44,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
     function(event, toState, toParams, fromState, fromParams, options){
       var personalTabs = ['root.main.common.map',
                           'root.main.control',
+                          'root.main.metrics',
                           'root.main.goals',
                           'root.main.diary']
       if (isInList(toState.name, personalTabs)) {

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -37,17 +37,12 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
     };
 
     var writeConsentToNative = function() {
-      return $window.cordova.plugins.BEMUserCache.putRWDocument(
-        CONSENTED_KEY,
-        JSON.stringify({category: "emSensorDataCollectionProtocol",
-         protocol_id: $rootScope.req_consent.protocol_id,
-         approval_date: $rootScope.req_consent.approval_date})
-      );
+      return $window.cordova.plugins.BEMDataCollection.markConsented($rootScope.req_consent);
     };
 
     startprefs.markConsented = function() {
       logger.log("changing consent from "+
-        $rootScope.curr_consented+" -> "+$rootScope.req_consent);
+        JSON.stringify($rootScope.curr_consented)+" -> "+JSON.stringify($rootScope.req_consent));
       // mark in native storage
       return readConsentState().then(writeConsentToNative).then(function(response) {
           // mark in local storage
@@ -99,6 +94,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
           return $http.get("json/startupConfig.json")
               .then(function(startupConfigResult) {
                   $rootScope.req_consent = startupConfigResult.data.emSensorDataCollectionProtocol;
+                  $rootScope.req_consent.category = "emSensorDataCollectionProtocol";
                   logger.log("required consent version = " + JSON.stringify($rootScope.req_consent));
                   $rootScope.curr_consented = storage.get(
                     startprefs.DATA_COLLECTION_CONSENTED_PROTOCOL);


### PR DESCRIPTION
- add the metrics to the list of tabs that are disabled when not logged in
  because we don't yet have code that disables user retrieval when not logged
  in
- use the new method in the data collection plugin to `markConsented`
- ensure that the category is filled in for the `req_consent` object so that
  it can be saved correctly to the database
- stringify printout values so that we don't see [object Object]