### PR TITLE
Minor changes to the javascript to handle the new usercache interface

### DIFF
--- a/www/js/common/map.js
+++ b/www/js/common/map.js
@@ -8,7 +8,6 @@ angular.module('emission.main.common.map',['ionic-datepicker',
                                     CommonGraph, Config, DiaryHelper) {
   console.log("controller CommonMapCtrl called");
 
-  var db = window.cordova.plugins.BEMUserCache;
   $scope.mapCtrl = {};
 
   angular.extend($scope.mapCtrl, {

--- a/www/js/common/services.js
+++ b/www/js/common/services.js
@@ -9,22 +9,28 @@ angular.module('emission.main.common.services', [])
 
     var db = window.cordova.plugins.BEMUserCache;
     var selKey = "common-trips";
+    
+    commonGraph.createEmpty = function() {
+        return { 'user_id': 'unknown',
+                 'common_trips': [],
+                 'common_places': []
+               }
+    };
 
     commonGraph.updateCurrent = function() {
       db.getDocument(selKey).then(function(entryList) {
         try{
-            var cmGraph = JSON.parse(entryList);
+            var cmGraph = entryList;
+            if (db.isEmptyDoc(cmGraph)) {
+                cmGraph = createEmpty();
+            }
         } catch(err) {
             window.Logger.log("Error "+err+" while parsing common trip data");
             // If there was an error in parsing the current common trips, and
             // there is no existing cached common trips, we create a blank
             // version so that other things don't crash
             if (angular.isUndefined(cmGraph)) {
-                cmGraph = {
-                    'user_id': 'unknown',
-                    'common_trips': [],
-                    'common_places': []
-                }
+                cmGraph = createEmpty();
             }
         }
         commonGraph.data.graph = cmGraph;

--- a/www/js/control.js
+++ b/www/js/control.js
@@ -413,8 +413,12 @@ angular.module('emission.main.control',['emission.services',
       UpdateCheck.checkForUpdates();
     }
     $scope.checkConsent = function() {
-        ControlHelper.getDocument().then(function(resultList){
-            $ionicPopup.alert({template: resultList});
+        ControlHelper.getConsentDocument().then(function(resultDoc){
+            if (window.cordova.plugins.BEMUserCache.isEmptyDoc(resultDoc)) {
+                $ionicPopup.alert({template: "No consent for data collection, please log out and log in again"});
+            } else {
+                $ionicPopup.alert({template: JSON.stringify(resultDoc)});
+            }
         }, function(error) {
             $ionicPopup.alert({template: error});
         });

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -367,10 +367,9 @@ angular.module('emission.main.diary.services', ['emission.services', 'emission.m
         template: 'Reading from cache...'
       });
       window.cordova.plugins.BEMUserCache.getDocument(getKeyForDate(day))
-      .then(function (tripListArray) {
-         if (tripListArray.length > 0) {
-           var tripListStr = tripListArray[0];
-           var tripList = JSON.parse(tripListStr);
+      .then(function (timelineDoc) {
+         if (!window.cordova.plugins.BEMUserCache.isEmptyDoc(timelineDoc)) {
+           var tripList = timelineDoc;
            console.log("About to hide 'Reading from cache'");
            $ionicLoading.hide();
            foundFn(day, tripList);

--- a/www/js/recent.js
+++ b/www/js/recent.js
@@ -89,15 +89,15 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
     $scope.config = {}
     $scope.config.key_data_mapping = {
         "Transitions": {
-            fn: db.getMessages,
+            fn: db.getAllMessages,
             key: "statemachine/transition"
         },
         "Locations": {
-            fn: db.getSensorData,
+            fn: db.getAllSensorData,
             key: "background/location"
         },
         "Motion Type": {
-            fn: db.getSensorData,
+            fn: db.getAllSensorData,
             key: "background/motion_activity"
         },
     }
@@ -176,7 +176,7 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
 
   $scope.updateEntries = function() {
     if (angular.isUndefined($scope.selected.key)) {
-        usercacheFn = db.getMessages;
+        usercacheFn = db.getAllMessages;
         usercacheKey = "statemachine/transition";
     } else {
         usercacheFn = $scope.config.key_data_mapping[$scope.selected.key]["fn"]
@@ -221,7 +221,7 @@ angular.module('emission.main.recent', ['ngCordova', 'emission.services'])
     });
 
     $scope.refreshMap = function() {
-        db.getSensorData($scope.mapCtrl.selKey, function(entryList) {
+        db.getAllSensorData($scope.mapCtrl.selKey, function(entryList) {
             var coordinates = entryList.map(function(locWrapper, index, locList) {
                 var parsedData = JSON.parse(locWrapper.data);
                 return [parsedData.longitude, parsedData.latitude];

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -71,6 +71,7 @@ angular.module('emission.services', [])
       })
     };
 })
+
 .service('ReferHelper', function($http) {
 
     this.habiticaRegister = function(groupid, successCallback, errorCallback) {
@@ -173,7 +174,7 @@ angular.module('emission.services', [])
       return window.cordova.plugins.BEMServerSync.forceSync();
     };
 
-    this.getDocument = function() {
+    this.getConsentDocument = function() {
       return window.cordova.plugins.BEMUserCache.getDocument("config/consent");
     };
 })


### PR DESCRIPTION
- Deal with empty documents and their checks since we cannot return null
- Switch method names to new ones in the recent tab
- Minor rename (getDocument -> getConsentDocument)

This is now consistent with
https://github.com/e-mission/cordova-usercache/pull/20