### PR TITLE
Bump up version number + fix two week query

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <widget id="edu.berkeley.eecs.emission" 
-        version="1.0.0" 
-        android-versionCode="13"
-        ios-CFBundleVersion="13"
+        version="1.1.0" 
+        android-versionCode="14"
+        ios-CFBundleVersion="14.1"
         xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>emission</name>
   <description>

--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -310,8 +310,8 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
         };
       } else if (mode === 'timestamp') { // timestamp range
         if(lastTwoWeeksQuery) {
-          var tempFrom = moment2Timestamp(moment().utc().day(-14)); 
-          var tempTo = moment2Timestamp(moment().utc().day(-1));
+          var tempFrom = moment2Timestamp(moment().utc().subtract(14, 'days'));
+          var tempTo = moment2Timestamp(moment().utc().subtract(1, 'days'))
           lastTwoWeeksQuery = false; // Only get last week's data once          
         } else {
           var tempFrom = moment2Timestamp($scope.selectCtrl.fromDateTimestamp);


### PR DESCRIPTION
Two weeks is 14 days before today, not two calendar weeks.
Unlike the building dashboard, we don't want to be slower than we already are.