### PR TITLE
Several minor fit and finish fixes

### DIFF
--- a/www/js/goals.js
+++ b/www/js/goals.js
@@ -207,8 +207,8 @@ angular.module('emission.main.goals',['emission.services', 'ngSanitize', 'ngAnim
             getMembers();
             console.log($scope.profile);
             prepopulateMessage = {
-                message: 'Join my party in Emission',
-                subject: 'Emission - Party Invite',
+                message: 'Fight the global warming monster with me (link joins group, reshare responsibly)',
+                subject: 'Help Berkeley become more bikeable and walkable',
                 url: 'https://e-mission.eecs.berkeley.edu/redirect/join?groupid=' + partyId + '&userid=' + userId
             };
             $ionicLoading.hide();

--- a/www/js/heatmap.js
+++ b/www/js/heatmap.js
@@ -182,4 +182,5 @@ angular.module('emission.main.heatmap',['ui-leaflet', 'emission.services'])
   $scope.mapHeight = $window.screen.height - 250;
   $scope.selectCtrl = {}
   initSelect();
+  $scope.getPopRoute();
 })

--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -14,6 +14,23 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
     var lastWeekCarbonInt = [];
     var twoWeeksAgoCarbonInt = [];
     var twoWeeksAgoCalories = 0;
+
+    // If we want to share this function (see the pun?) between the control screen and the dashboard, we need to put it into a service/factory.
+    // But it is not clear to me why it needs to be in the profile screen...
+    var prepopulateMessage = {
+      message: 'Have fun, support research and get active. Your privacy is protected. \nDownload the emission app:', // not supported on some apps (Facebook, Instagram)
+      subject: 'Help Berkeley become more bikeable and walkable', // fi. for email
+      url: 'https://bic2cal.eecs.berkeley.edu/#download'
+    }
+
+    $scope.share = function() {
+        window.plugins.socialsharing.shareWithOptions(prepopulateMessage, function(result) {
+            console.log("Share completed? " + result.completed); // On Android apps mostly return false even while it's true
+            console.log("Shared to app: " + result.app); // On Android result.app is currently empty. On iOS it's empty when sharing is cancelled (result.completed=false)
+        }, function(msg) {
+            console.log("Sharing failed with message: " + msg);
+        });
+    }
     
     $scope.setCookie = function(){
       $scope.foodCompare = 'cookie';

--- a/www/templates/main-goals.html
+++ b/www/templates/main-goals.html
@@ -112,7 +112,10 @@
       </div>
       <div class="row" id="costume-tab">
         <div class="col">
+         <!--
           <button id="challenge" class="button" ng-class="{'active': isActive}" ng-click="activeButton()" type="button">Challenges</button>
+         -->
+          <button class="button" ng-class="{'active': hasParty}" ng-click="inviteToParty()" type="Button">Invite friends</button>
           <button id="party" class="button" ng-class="{'active': isActiveP}" ng-click="partyButton()" type="button">Party</button> 
         </div>
       </div>

--- a/www/templates/main-metrics.html
+++ b/www/templates/main-metrics.html
@@ -2,6 +2,11 @@
   <ion-nav-bar class="bar-stable">
     <ion-nav-back-button></ion-nav-back-button>
   </ion-nav-bar>
+  <ion-nav-buttons side="left">
+      <button class="button button-icon" ng-click="share()">
+        <i class="ion-share"></i>
+      </button>
+  </ion-nav-buttons>
   <ion-content class="has-header">
     <div style="height: 40px; width: 100%; padding: 10px;" ng-if="uictrl.showVis"> <!-- visualization control -->
       <div class="metric-half">

--- a/www/templates/main.html
+++ b/www/templates/main.html
@@ -16,12 +16,12 @@ navigation history that also transitions its views in and out.
     <ion-nav-view name="main-goals"></ion-nav-view>
   </ion-tab>
 
-  <!-- Common Patterns Tab -->
+  <!-- Common Patterns Tab
   <ion-tab title="Common" icon="ion-star" href="#/root/main/common/map">
     <ion-nav-view name="main-common"></ion-nav-view>
-  </ion-tab>
+  </ion-tab> -->
 
-  <!-- Metrics Tab -->
+  <!-- Dashboard Tab -->
   <ion-tab title="Dashboard" icon="ion-ios-analytics" href="#/root/main/metrics">
     <ion-nav-view name="main-metrics"></ion-nav-view>
   </ion-tab>


### PR DESCRIPTION
- Tweak the messages for share + invite to emphasise helping berkeley, and the text to emphasise all the good stuff that we do.
- Add share button to the top of the dashboard, and to the main goals screen
- Comment out the challenges tab since we are de-emphasising the hardcoded challenges anyway
- Comment out common patterns since that step is currently disabled on the server, and the screen could use some TLC