### PR TITLE
Refactor metrics code to separate user and aggregate processing

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -12,7 +12,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope,
     CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler) {
   console.log('SplashCtrl invoked');
-  alert("attach debugger!");
+  // alert("attach debugger!");
   CustomURLScheme.onLaunch(function(event, url){
     console.log("GOT URL:"+url);
     var kvList = ReferralHandler.parseURL(url);

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -12,7 +12,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope,
     CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler) {
   console.log('SplashCtrl invoked');
-  // alert("attach debugger!");
+  alert("attach debugger!");
   CustomURLScheme.onLaunch(function(event, url){
     console.log("GOT URL:"+url);
     var kvList = ReferralHandler.parseURL(url);

--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -31,7 +31,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
             console.log("Sharing failed with message: " + msg);
         });
     }
-    
+
     $scope.setCookie = function(){
       $scope.foodCompare = 'cookie';
       storage.set('foodCompare', 'cookie');
@@ -198,7 +198,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
       $scope.userData.gender = gender;
     }
 
-    $scope.storeUserData = function() {     
+    $scope.storeUserData = function() {
       var info = {'gender': $scope.userData.gender,
                   'heightUnit': $scope.userData.heightUnit,
                   'weightUnit': $scope.userData.weightUnit,
@@ -329,7 +329,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
         if(lastTwoWeeksQuery) {
           var tempFrom = moment2Timestamp(moment().utc().startOf('day').subtract(14, 'days'));
           var tempTo = moment2Timestamp(moment().utc().startOf('day').subtract(1, 'days'))
-          lastTwoWeeksQuery = false; // Only get last week's data once          
+          lastTwoWeeksQuery = false; // Only get last week's data once
         } else {
           var tempFrom = moment2Timestamp($scope.selectCtrl.fromDateTimestamp);
           var tempTo = moment2Timestamp($scope.selectCtrl.toDateTimestamp);
@@ -413,12 +413,13 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
         'banana' : 105, //medium banana 118g
       };
 
-      Promise.all([getDuration(), getSpeed(), getCount(), getDistance()]).then(function(results) {
+      return Promise.all([getDuration(), getSpeed(), getCount(), getDistance()]).then(function(results) {
         // cacheResults(response);
         $ionicLoading.hide();
         if(results[0].user_metrics.length == 0){
-          first = false; 
-          // If there is no data from last week (ex. new user) 
+          console.log("first = "+first);
+          first = false;
+          // If there is no data from last week (ex. new user)
           // Don't store the any other data as last we data
          }
          var seventhDayAgo = moment().utc().startOf('day').subtract(7, 'days');
@@ -435,7 +436,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
               userDuration.push(results[0].user_metrics[i]);
               usedMedianSpeed.push(results[1].user_metrics[i]);
               userCount.push(results[2].user_metrics[i]);
-              userDistance.push(results[3].user_metrics[i]);  
+              userDistance.push(results[3].user_metrics[i]);
             } else {
               twoWeeksAgoDuration.push(results[0].user_metrics[i]);
               twoWeeksAgoMedianSpeed.push(results[1].user_metrics[i]);
@@ -446,6 +447,9 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
           var aggMedianSpeed = results[1].aggregate_metrics.slice(7);
           var aggCount = results[2].aggregate_metrics.slice(7);
           var aggDistance = results[3].aggregate_metrics.slice(7);
+          console.log("twoWeeksAgoDuration = "+twoWeeksAgoDuration);
+          console.log("twoWeeksAgoMedianSpeed = "+twoWeeksAgoMedianSpeed);
+          console.log("twoWeeksAgoDistance = "+twoWeeksAgoDistance);
         } else {
           var userDuration = results[0].user_metrics;
           var usedMedianSpeed = results[1].user_metrics;
@@ -489,7 +493,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
           } else {
             var met = CalorieCal.getMet(durationData[i].key, speedData[i].values);
           }
-          $scope.caloriesData.userCalories += 
+          $scope.caloriesData.userCalories +=
             Math.round(CalorieCal.getuserCalories(durationData[i].values / 3600, met)) //+ ' cal'
         }
         $scope.numberOfCookies = Math.floor($scope.caloriesData.userCalories/food.chocolateChip);
@@ -529,7 +533,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
           for (var i in userCarbonData) {
             //$scope.carbonData.userCarbon.push({key: userCarbonData[i].key, values: FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key)});
             if (userCarbonData[i].key === "IN_VEHICLE") {
-              $scope.carbonData.userCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);              
+              $scope.carbonData.userCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
               $scope.carbonData.optimalCarbon = FootprintHelper.getFootprint(optimalDistance, userCarbonData[i].key);
               $scope.carbonData.worstCarbon = FootprintHelper.getFootprint(worstDistance, userCarbonData[i].key);
               lastWeekCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
@@ -556,8 +560,8 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
             var userCarbonData = getSummaryDataRaw(twoWeeksAgoDistance, 'distance');
             for (var i in userCarbonData) {
               if (userCarbonData[i].key === "IN_VEHICLE") {
-                twoWeeksAgoCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);              
-                twoWeeksAgoCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);              
+                twoWeeksAgoCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
+                twoWeeksAgoCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
               }
             }
           }
@@ -581,35 +585,52 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
             } else {
               var met = CalorieCal.getMet(durationData[i].key, speedData[i].values);
             }
-            twoWeeksAgoCalories += 
+            twoWeeksAgoCalories +=
               Math.round(CalorieCal.getuserCalories(durationData[i].values / 3600, met));
           }
 
           var change = "";
+          console.log("Running calculation with "
+                        + (lastWeekCarbonInt[0] + lastWeekCarbonInt[1])
+                        + " and "
+                        + (twoWeeksAgoCarbonInt[0] + twoWeeksAgoCarbonInt[1]))
           var calculation = (((lastWeekCarbonInt[0] + lastWeekCarbonInt[1]) / 2)
                             / ((twoWeeksAgoCarbonInt[0] + twoWeeksAgoCarbonInt[1]) / 2))
                             * 100 - 100;
-          
-          if(lastWeekCarbonInt[0] > twoWeeksAgoCarbonInt[0]){
-            $scope.carbonData.change = " increase over a week";
-            $scope.carbonUp = true;
-            $scope.carbonDown = false;
-          } else {
-            $scope.carbonData.change = " decrease over a week"
-            $scope.carbonUp = false;
-            $scope.carbonDown = true;
-          }
-          $scope.carbonData.changeInPercentage = Math.abs(Math.round(calculation)) + "%"
 
-          $scope.caloriesData.changeInPercentage = Math.abs(Math.round((lastWeekCalories/twoWeeksAgoCalories) * 100 - 100)) + "%";
-          if(lastWeekCalories > twoWeeksAgoCalories){
-            $scope.caloriesData.change = " increase over a week";
-            $scope.caloriesUp = true;
-            $scope.caloriesDown = false;
-          } else {
-            $scope.caloriesData.change = " decrease over a week"
-            $scope.caloriesUp = false;
-            $scope.caloriesDown = true;
+          // TODO: Refactor this so that we can filter out bad values ahead of time
+          // instead of having to work around it here
+          if (Number.isFinite(calculation)) {
+              if(lastWeekCarbonInt[0] > twoWeeksAgoCarbonInt[0]){
+                $scope.carbonData.change = " increase over a week";
+                $scope.carbonUp = true;
+                $scope.carbonDown = false;
+              } else {
+                $scope.carbonData.change = " decrease over a week"
+                $scope.carbonUp = false;
+                $scope.carbonDown = true;
+              }
+              $scope.carbonData.changeInPercentage = Math.abs(Math.round(calculation)) + "%"
+          }
+
+          console.log("Running calorieData with "
+                        + (lastWeekCalories)
+                        + " and "
+                        + (twoWeeksAgoCalories));
+          // TODO: Refactor this so that we can filter out bad values ahead of time
+          // instead of having to work around it here
+          var calorieCalculation = Math.abs(Math.round((lastWeekCalories/twoWeeksAgoCalories) * 100 - 100));
+          if (Number.isFinite(calorieCalculation)) {
+              $scope.caloriesData.changeInPercentage =  calorieCalculation + "%";
+              if(lastWeekCalories > twoWeeksAgoCalories){
+                $scope.caloriesData.change = " increase over a week";
+                $scope.caloriesUp = true;
+                $scope.caloriesDown = false;
+              } else {
+                $scope.caloriesData.change = " decrease over a week"
+                $scope.caloriesUp = false;
+                $scope.caloriesDown = true;
+              }
           }
 
           first = false; //If there is data from last week store the data only first time
@@ -617,7 +638,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
 
         $scope.uictrl.showContent = true;
 
-        if (angular.isDefined($scope.uictrl.showMe? $scope.chartDataUser: $scope.chartDataAggr)) { //Only have to check one because 
+        if (angular.isDefined($scope.uictrl.showMe? $scope.chartDataUser: $scope.chartDataAggr)) { //Only have to check one because
           $scope.$apply(function() {
             $scope.showCharts($scope.uictrl.showMe? $scope.chartDataUser: $scope.chartDataAggr);
           })
@@ -883,7 +904,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
           }
         });
     };
-    
+
     $scope.toggle = function() {
       if (!$scope.uictrl.showMe) {
         $scope.uictrl.showMe = true;
@@ -919,10 +940,15 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
 
 
   $scope.selectCtrl = {}
-  initSelect(); 
+  initSelect();
   $timeout(function() {
     getData();
   }, 1)
+
+  $scope.doRefresh = function() {
+    first = true;
+    getMetrics();
+  }
 
   $scope.modeIcon = function(key) {
     var icons = {"BICYCLING":"ion-android-bicycle",

--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -1,4 +1,4 @@
-'use strict';
+// 'use strict';
 
 angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-datepicker', 'emission.main.metrics.factory', 'angularLocalStorage'])
 
@@ -210,7 +210,9 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
     }
 
     $scope.userDataSaved = function() {
-      return CalorieCal.get().userDataSaved == true;
+      var saved_user_data = CalorieCal.get();
+      console.log("saved vals = "+JSON.stringify(saved_user_data));
+      return saved_user_data.userDataSaved == true;
     }
     $scope.options = {
         chart: {
@@ -375,7 +377,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
       return getDistance;
     }
 
-    var getMetrics = function(){
+   var getMetrics = function() {
       $ionicLoading.show({
         template: 'Loading...'
       });
@@ -407,7 +409,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
       $scope.summaryData.userSummary = [];
       $scope.chartDataUser = {};
       $scope.chartDataAggr = {};
-      var food = {
+      $scope.food = {
         'chocolateChip' : 78, //16g 1 cookie
         'vanillaIceCream' : 137, //1/2 cup
         'banana' : 105, //medium banana 118g
@@ -421,220 +423,21 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
           first = false;
           // If there is no data from last week (ex. new user)
           // Don't store the any other data as last we data
-         }
-         var seventhDayAgo = moment().utc().startOf('day').subtract(7, 'days');
-         var twoWeeksAgoDuration = [];
-         var twoWeeksAgoMedianSpeed = [];
-         var twoWeeksAgoDistance = [];
-         var userDuration = [];
-         var usedMedianSpeed = [];
-         var userCount = [];
-         var userDistance = [];
-        if(first){
-          for(var i in results[0].user_metrics) {
-            if(seventhDayAgo.isSameOrBefore(moment.unix(results[0].user_metrics[i].ts).utc())){
-              userDuration.push(results[0].user_metrics[i]);
-              usedMedianSpeed.push(results[1].user_metrics[i]);
-              userCount.push(results[2].user_metrics[i]);
-              userDistance.push(results[3].user_metrics[i]);
-            } else {
-              twoWeeksAgoDuration.push(results[0].user_metrics[i]);
-              twoWeeksAgoMedianSpeed.push(results[1].user_metrics[i]);
-              twoWeeksAgoDistance.push(results[3].user_metrics[i]);
-            }
-          }
-          var aggDuration = results[0].aggregate_metrics.slice(7);
-          var aggMedianSpeed = results[1].aggregate_metrics.slice(7);
-          var aggCount = results[2].aggregate_metrics.slice(7);
-          var aggDistance = results[3].aggregate_metrics.slice(7);
-          console.log("twoWeeksAgoDuration = "+twoWeeksAgoDuration);
-          console.log("twoWeeksAgoMedianSpeed = "+twoWeeksAgoMedianSpeed);
-          console.log("twoWeeksAgoDistance = "+twoWeeksAgoDistance);
-        } else {
-          var userDuration = results[0].user_metrics;
-          var usedMedianSpeed = results[1].user_metrics;
-          var userCount = results[2].user_metrics;
-          var userDistance = results[3].user_metrics;
-          var aggDuration = results[0].aggregate_metrics;
-          var aggMedianSpeed = results[1].aggregate_metrics;
-          var aggCount = results[2].aggregate_metrics;
-          var aggDistance = results[3].aggregate_metrics;
         }
-        $scope.summaryData.userSummary.duration = getSummaryData(userDuration, "duration");
-        $scope.summaryData.userSummary.median_speed = getSummaryData(usedMedianSpeed, "median_speed");
-        $scope.summaryData.userSummary.count = getSummaryData(userCount, "count");
-        $scope.summaryData.userSummary.distance = getSummaryData(userDistance, "distance");
-        $scope.chartDataUser.duration = userDuration? userDuration : [];
-        $scope.chartDataAggr.duration = aggDuration? aggDuration : [];
-        $scope.chartDataUser.speed = usedMedianSpeed? usedMedianSpeed : [];
-        $scope.chartDataAggr.speed = aggMedianSpeed? aggMedianSpeed : [];
-        $scope.chartDataUser.count = userCount? userCount : [];
-        $scope.chartDataAggr.count = aggCount? aggCount : [];
-        $scope.chartDataUser.distance = userDistance? userDistance : [];
-        $scope.chartDataAggr.distance = aggDistance? aggDistance : [];
+        var userResults = results.map(function(currResult) {
+            return currResult.user_metrics;
+        });
+        console.log("userResults = "+userResults);
+        var aggResults = results.map(function(currResult) {
+            return currResult.aggregate_metrics;
+        });
+        console.log("aggResults = "+aggResults);
+        $scope.fillUserValues(userResults);
+        $scope.fillAggregateValues(aggResults);
 
-        if (userDuration) {
-          var durationData = getSummaryDataRaw(userDuration, "duration");
-        }
-        if (usedMedianSpeed) {
-          var speedData = getSummaryDataRaw(usedMedianSpeed, "median_speed");
-        }
-        for (var i in durationData) {
-          if ($scope.userDataSaved()) {
-            var userDataFromStorage = CalorieCal.get();
-            var met = CalorieCal.getMet(durationData[i].key, speedData[i].values);
-            var gender = userDataFromStorage.gender;
-            var heightUnit = userDataFromStorage.heightUnit;
-            var height = userDataFromStorage.height;
-            var weightUnit = userDataFromStorage.weightUnit;
-            var weight = userDataFromStorage.weight;
-            var age = userDataFromStorage.age;
-            met = CalorieCal.getCorrectedMet(met, gender, age, height, heightUnit, weight, weightUnit);
-          } else {
-            var met = CalorieCal.getMet(durationData[i].key, speedData[i].values);
-          }
-          $scope.caloriesData.userCalories +=
-            Math.round(CalorieCal.getuserCalories(durationData[i].values / 3600, met)) //+ ' cal'
-        }
-        $scope.numberOfCookies = Math.floor($scope.caloriesData.userCalories/food.chocolateChip);
-        $scope.numberOfIceCreams = Math.floor($scope.caloriesData.userCalories/food.vanillaIceCream);
-        $scope.numberOfBananas = Math.floor($scope.caloriesData.userCalories/food.banana);
-        if(first){
-            lastWeekCalories = $scope.caloriesData.userCalories;
-        }
-        $scope.caloriesData.lastWeekUserCalories = lastWeekCalories;
-
-        if (aggDuration) {
-          var avgDurationData = getAvgSummaryDataRaw(aggDuration, "duration");
-        }
-        if (aggMedianSpeed) {
-          var avgSpeedData = getAvgSummaryDataRaw(aggMedianSpeed, "median_speed");
-        }
-        for (var i in avgDurationData) {
-
-          var met = CalorieCal.getMet(avgDurationData[i].key, avgSpeedData[i].values);
-
-          $scope.caloriesData.aggrCalories +=
-            Math.round(CalorieCal.getuserCalories(avgDurationData[i].values / 3600, met)) //+ ' cal'
-        }
-
-        if (userDistance) {
-          var userCarbonData = getSummaryDataRaw(userDistance, 'distance');
-          var optimalDistance = getOptimalFootprintDistance(userDistance);
-          var worstDistance = getWorstFootprintDistance(userDistance);
-          var date1 = $scope.selectCtrl.fromDateTimestamp;
-          var date2 = $scope.selectCtrl.toDateTimestamp;
-          var duration = moment.duration(date2.diff(date1));
-          var days = duration.asDays();
-          //$scope.ca2020 = 43.771628 / 5 * days; // kg/day
-          $scope.carbonData.ca2035 = Math.round(40.142892 / 5 * days) + ' kg CO₂'; // kg/day
-          $scope.carbonData.ca2050 = Math.round(8.28565 / 5 * days) + ' kg CO₂';
-          //$scope.carbonData.userCarbon = [];
-          for (var i in userCarbonData) {
-            //$scope.carbonData.userCarbon.push({key: userCarbonData[i].key, values: FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key)});
-            if (userCarbonData[i].key === "IN_VEHICLE") {
-              $scope.carbonData.userCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
-              $scope.carbonData.optimalCarbon = FootprintHelper.getFootprint(optimalDistance, userCarbonData[i].key);
-              $scope.carbonData.worstCarbon = FootprintHelper.getFootprint(worstDistance, userCarbonData[i].key);
-              lastWeekCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
-              if(first){
-                lastWeekCarbon = $scope.carbonData.userCarbon;
-              }
-            $scope.carbonData.lastWeekUserCarbon = lastWeekCarbon;
-            }
-          }
-        }
-        if (aggDistance) {
-          var aggrCarbonData = getAvgSummaryDataRaw(aggDistance, 'distance');
-          for (var i in aggrCarbonData) {
-            if (aggrCarbonData[i].key === "IN_VEHICLE") {
-              $scope.carbonData.aggrVehicleRange = FootprintHelper.getFootprintRaw(aggrCarbonData[i].values, aggrCarbonData[i].key);
-              $scope.carbonData.aggrCarbon = FootprintHelper.getFootprint(aggrCarbonData[i].values, aggrCarbonData[i].key);
-            }
-          }
-        }
         $scope.summaryData.defaultSummary = $scope.summaryData.userSummary;
 
-        if(first){
-          if (twoWeeksAgoDistance) {
-            var userCarbonData = getSummaryDataRaw(twoWeeksAgoDistance, 'distance');
-            for (var i in userCarbonData) {
-              if (userCarbonData[i].key === "IN_VEHICLE") {
-                twoWeeksAgoCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
-                twoWeeksAgoCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
-              }
-            }
-          }
-          if (twoWeeksAgoDuration) {
-            var durationData = getSummaryDataRaw(twoWeeksAgoDuration, "duration");
-          }
-          if (twoWeeksAgoMedianSpeed) {
-            var speedData = getSummaryDataRaw(twoWeeksAgoMedianSpeed, "median_speed");
-          }
-          for (var i in durationData) {
-            if ($scope.userDataSaved()) {
-              var userDataFromStorage = CalorieCal.get();
-              var met = CalorieCal.getMet(durationData[i].key, speedData[i].values);
-              var gender = userDataFromStorage.gender;
-              var heightUnit = userDataFromStorage.heightUnit;
-              var height = userDataFromStorage.height;
-              var weightUnit = userDataFromStorage.weightUnit;
-              var weight = userDataFromStorage.weight;
-              var age = userDataFromStorage.age;
-              met = CalorieCal.getCorrectedMet(met, gender, age, height, heightUnit, weight, weightUnit);
-            } else {
-              var met = CalorieCal.getMet(durationData[i].key, speedData[i].values);
-            }
-            twoWeeksAgoCalories +=
-              Math.round(CalorieCal.getuserCalories(durationData[i].values / 3600, met));
-          }
-
-          var change = "";
-          console.log("Running calculation with "
-                        + (lastWeekCarbonInt[0] + lastWeekCarbonInt[1])
-                        + " and "
-                        + (twoWeeksAgoCarbonInt[0] + twoWeeksAgoCarbonInt[1]))
-          var calculation = (((lastWeekCarbonInt[0] + lastWeekCarbonInt[1]) / 2)
-                            / ((twoWeeksAgoCarbonInt[0] + twoWeeksAgoCarbonInt[1]) / 2))
-                            * 100 - 100;
-
-          // TODO: Refactor this so that we can filter out bad values ahead of time
-          // instead of having to work around it here
-          if (Number.isFinite(calculation)) {
-              if(lastWeekCarbonInt[0] > twoWeeksAgoCarbonInt[0]){
-                $scope.carbonData.change = " increase over a week";
-                $scope.carbonUp = true;
-                $scope.carbonDown = false;
-              } else {
-                $scope.carbonData.change = " decrease over a week"
-                $scope.carbonUp = false;
-                $scope.carbonDown = true;
-              }
-              $scope.carbonData.changeInPercentage = Math.abs(Math.round(calculation)) + "%"
-          }
-
-          console.log("Running calorieData with "
-                        + (lastWeekCalories)
-                        + " and "
-                        + (twoWeeksAgoCalories));
-          // TODO: Refactor this so that we can filter out bad values ahead of time
-          // instead of having to work around it here
-          var calorieCalculation = Math.abs(Math.round((lastWeekCalories/twoWeeksAgoCalories) * 100 - 100));
-          if (Number.isFinite(calorieCalculation)) {
-              $scope.caloriesData.changeInPercentage =  calorieCalculation + "%";
-              if(lastWeekCalories > twoWeeksAgoCalories){
-                $scope.caloriesData.change = " increase over a week";
-                $scope.caloriesUp = true;
-                $scope.caloriesDown = false;
-              } else {
-                $scope.caloriesData.change = " decrease over a week"
-                $scope.caloriesUp = false;
-                $scope.caloriesDown = true;
-              }
-          }
-
-          first = false; //If there is data from last week store the data only first time
-        }
+        first = false; //If there is data from last week store the data only first time
 
         $scope.uictrl.showContent = true;
 
@@ -656,7 +459,252 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
         });
         console.log(error);
       });
-    };
+   };
+
+   $scope.fillUserValues = function(user_metrics_arr) {
+        var seventhDayAgo = moment().utc().startOf('day').subtract(7, 'days');
+        var twoWeeksAgoDuration = [];
+        var twoWeeksAgoMedianSpeed = [];
+        var twoWeeksAgoDistance = [];
+        var userDuration = [];
+        var userMedianSpeed = [];
+        var userCount = [];
+        var userDistance = [];
+
+        if(first){
+          for(var i in user_metrics_arr[0]) {
+            if(seventhDayAgo.isSameOrBefore(moment.unix(user_metrics_arr[0][i].ts).utc())){
+              userDuration.push(user_metrics_arr[0][i]);
+              userMedianSpeed.push(user_metrics_arr[1][i]);
+              userCount.push(user_metrics_arr[2][i]);
+              userDistance.push(user_metrics_arr[3][i]);
+            } else {
+              twoWeeksAgoDuration.push(user_metrics_arr[0][i]);
+              twoWeeksAgoMedianSpeed.push(user_metrics_arr[1][i]);
+              twoWeeksAgoDistance.push(user_metrics_arr[3][i]);
+            }
+          }
+          console.log("twoWeeksAgoDuration = "+twoWeeksAgoDuration);
+          console.log("twoWeeksAgoMedianSpeed = "+twoWeeksAgoMedianSpeed);
+          console.log("twoWeeksAgoDistance = "+twoWeeksAgoDistance);
+        } else {
+          var userDuration = user_metrics_arr[0];
+          var userMedianSpeed = user_metrics_arr[1];
+          var userCount = user_metrics_arr[2];
+          var userDistance = user_metrics_arr[3];
+        }
+        $scope.summaryData.userSummary.duration = getSummaryData(userDuration, "duration");
+        $scope.summaryData.userSummary.median_speed = getSummaryData(userMedianSpeed, "median_speed");
+        $scope.summaryData.userSummary.count = getSummaryData(userCount, "count");
+        $scope.summaryData.userSummary.distance = getSummaryData(userDistance, "distance");
+        $scope.chartDataUser.duration = userDuration? userDuration : [];
+        $scope.chartDataUser.speed = userMedianSpeed? userMedianSpeed : [];
+        $scope.chartDataUser.count = userCount? userCount : [];
+        $scope.chartDataUser.distance = userDistance? userDistance : [];
+
+        // Fill in user calorie information
+        $scope.fillCalorieCardUserVals(userDuration, userMedianSpeed,
+                                       twoWeeksAgoDuration, twoWeeksAgoMedianSpeed);
+        $scope.fillFootprintCardUserVals(userDistance, twoWeeksAgoDistance);
+   }
+
+   $scope.fillAggregateValues = function(agg_metrics_arr) {
+        if (first) {
+            var aggDuration = agg_metrics_arr[0].slice(7);
+            var aggMedianSpeed = agg_metrics_arr[1].slice(7);
+            var aggCount = agg_metrics_arr[2].slice(7);
+            var aggDistance = agg_metrics_arr[3].slice(7);
+        } else {
+            var aggDuration = agg_metrics_arr[0];
+            var aggMedianSpeed = agg_metrics_arr[1];
+            var aggCount = agg_metrics_arr[2];
+            var aggDistance = agg_metrics_arr[3];
+        }
+
+        $scope.chartDataAggr.duration = aggDuration? aggDuration : [];
+        $scope.chartDataAggr.speed = aggMedianSpeed? aggMedianSpeed : [];
+        $scope.chartDataAggr.count = aggCount? aggCount : [];
+        $scope.chartDataAggr.distance = aggDistance? aggDistance : [];
+
+        $scope.fillCalorieAggVals(aggDuration, aggMedianSpeed)
+        $scope.fillFootprintAggVals(aggDistance);
+   }
+
+   $scope.fillCalorieCardUserVals = function(userDuration, userMedianSpeed,
+                                             twoWeeksAgoDuration, twoWeeksAgoMedianSpeed) {
+       if (userDuration) {
+         var durationData = getSummaryDataRaw(userDuration, "duration");
+       }
+       if (userMedianSpeed) {
+         var speedData = getSummaryDataRaw(userMedianSpeed, "median_speed");
+       }
+       for (var i in durationData) {
+         var met = $scope.getCorrectedMetFromUserData(durationData[i], speedData[i])
+         $scope.caloriesData.userCalories +=
+           Math.round(CalorieCal.getuserCalories(durationData[i].values / 3600, met)) //+ ' cal'
+       }
+
+       if(first){
+           lastWeekCalories = $scope.caloriesData.userCalories;
+       }
+
+       $scope.numberOfCookies = Math.floor($scope.caloriesData.userCalories/
+                                           $scope.food.chocolateChip);
+       $scope.numberOfIceCreams = Math.floor($scope.caloriesData.userCalories/
+                                             $scope.food.vanillaIceCream);
+       $scope.numberOfBananas = Math.floor($scope.caloriesData.userCalories/
+                                           $scope.food.banana);
+
+       if(first){
+         if (twoWeeksAgoDuration) {
+           var durationData = getSummaryDataRaw(twoWeeksAgoDuration, "duration");
+         }
+         if (twoWeeksAgoMedianSpeed) {
+           var speedData = getSummaryDataRaw(twoWeeksAgoMedianSpeed, "median_speed");
+         }
+         for (var i in durationData) {
+           var met = $scope.getCorrectedMetFromUserData(durationData[i], speedData[i])
+           twoWeeksAgoCalories +=
+             Math.round(CalorieCal.getuserCalories(durationData[i].values / 3600, met));
+         }
+       }
+
+       if (first) {
+          $scope.caloriesData.lastWeekUserCalories = twoWeeksAgoCalories;
+       } else {
+          $scope.caloriesData.lastWeekUserCalories = ""
+       }
+
+
+       console.log("Running calorieData with "
+                    + (lastWeekCalories)
+                    + " and "
+                    + (twoWeeksAgoCalories));
+       // TODO: Refactor this so that we can filter out bad values ahead of time
+       // instead of having to work around it here
+       var calorieCalculation = Math.abs(Math.round((lastWeekCalories/twoWeeksAgoCalories) * 100 - 100));
+       if (Number.isFinite(calorieCalculation)) {
+          $scope.caloriesData.changeInPercentage =  calorieCalculation + "%";
+          if(lastWeekCalories > twoWeeksAgoCalories){
+            $scope.caloriesData.change = " increase over a week";
+            $scope.caloriesUp = true;
+            $scope.caloriesDown = false;
+          } else {
+            $scope.caloriesData.change = " decrease over a week"
+            $scope.caloriesUp = false;
+            $scope.caloriesDown = true;
+          }
+       }
+   }
+
+   $scope.fillCalorieAggVals = function(aggDuration, aggMedianSpeed) {
+       if (aggDuration) {
+         var avgDurationData = getAvgSummaryDataRaw(aggDuration, "duration");
+       }
+       if (aggMedianSpeed) {
+         var avgSpeedData = getAvgSummaryDataRaw(aggMedianSpeed, "median_speed");
+       }
+       for (var i in avgDurationData) {
+
+         var met = CalorieCal.getMet(avgDurationData[i].key, avgSpeedData[i].values);
+
+         $scope.caloriesData.aggrCalories +=
+           Math.round(CalorieCal.getuserCalories(avgDurationData[i].values / 3600, met)) //+ ' cal'
+       }
+   }
+
+   $scope.getCorrectedMetFromUserData = function(currDurationData, currSpeedData) {
+       if ($scope.userDataSaved()) {
+         var userDataFromStorage = CalorieCal.get();
+         var met = CalorieCal.getMet(currDurationData.key, currSpeedData.values);
+         var gender = userDataFromStorage.gender;
+         var heightUnit = userDataFromStorage.heightUnit;
+         var height = userDataFromStorage.height;
+         var weightUnit = userDataFromStorage.weightUnit;
+         var weight = userDataFromStorage.weight;
+         var age = userDataFromStorage.age;
+         return CalorieCal.getCorrectedMet(met, gender, age, height, heightUnit, weight, weightUnit);
+       } else {
+         return CalorieCal.getMet(currDurationData.key, currSpeedData.values);
+       }
+   };
+
+   $scope.fillFootprintCardUserVals = function(userDistance, twoWeeksAgoDistance) {
+      if (userDistance) {
+        var userCarbonData = getSummaryDataRaw(userDistance, 'distance');
+        var optimalDistance = getOptimalFootprintDistance(userDistance);
+        var worstDistance = getWorstFootprintDistance(userDistance);
+        var date1 = $scope.selectCtrl.fromDateTimestamp;
+        var date2 = $scope.selectCtrl.toDateTimestamp;
+        var duration = moment.duration(date2.diff(date1));
+        var days = duration.asDays();
+        //$scope.ca2020 = 43.771628 / 5 * days; // kg/day
+        $scope.carbonData.ca2035 = Math.round(40.142892 / 5 * days) + ' kg CO₂'; // kg/day
+        $scope.carbonData.ca2050 = Math.round(8.28565 / 5 * days) + ' kg CO₂';
+        //$scope.carbonData.userCarbon = [];
+        for (var i in userCarbonData) {
+          //$scope.carbonData.userCarbon.push({key: userCarbonData[i].key, values: FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key)});
+          if (userCarbonData[i].key === "IN_VEHICLE") {
+            $scope.carbonData.userCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
+            $scope.carbonData.optimalCarbon = FootprintHelper.getFootprint(optimalDistance, userCarbonData[i].key);
+            $scope.carbonData.worstCarbon = FootprintHelper.getFootprint(worstDistance, userCarbonData[i].key);
+            lastWeekCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
+            if(first){
+              lastWeekCarbon = $scope.carbonData.userCarbon;
+            }
+            $scope.carbonData.lastWeekUserCarbon = lastWeekCarbon;
+          }
+        }
+      }
+
+      if (first) {
+        if (twoWeeksAgoDistance) {
+          var userCarbonData = getSummaryDataRaw(twoWeeksAgoDistance, 'distance');
+          for (var i in userCarbonData) {
+            if (userCarbonData[i].key === "IN_VEHICLE") {
+              twoWeeksAgoCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
+              twoWeeksAgoCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
+            }
+          }
+        }
+      }
+
+      var change = "";
+      console.log("Running calculation with "
+                    + (lastWeekCarbonInt[0] + lastWeekCarbonInt[1])
+                    + " and "
+                    + (twoWeeksAgoCarbonInt[0] + twoWeeksAgoCarbonInt[1]))
+      var calculation = (((lastWeekCarbonInt[0] + lastWeekCarbonInt[1]) / 2)
+                        / ((twoWeeksAgoCarbonInt[0] + twoWeeksAgoCarbonInt[1]) / 2))
+                        * 100 - 100;
+
+      // TODO: Refactor this so that we can filter out bad values ahead of time
+      // instead of having to work around it here
+      if (Number.isFinite(calculation)) {
+          if(lastWeekCarbonInt[0] > twoWeeksAgoCarbonInt[0]){
+            $scope.carbonData.change = " increase over a week";
+            $scope.carbonUp = true;
+            $scope.carbonDown = false;
+          } else {
+            $scope.carbonData.change = " decrease over a week"
+            $scope.carbonUp = false;
+            $scope.carbonDown = true;
+          }
+          $scope.carbonData.changeInPercentage = Math.abs(Math.round(calculation)) + "%"
+      }
+   };
+
+   $scope.fillFootprintAggVals = function(aggDistance) {
+      if (aggDistance) {
+        var aggrCarbonData = getAvgSummaryDataRaw(aggDistance, 'distance');
+        for (var i in aggrCarbonData) {
+          if (aggrCarbonData[i].key === "IN_VEHICLE") {
+            $scope.carbonData.aggrVehicleRange = FootprintHelper.getFootprintRaw(aggrCarbonData[i].values, aggrCarbonData[i].key);
+            $scope.carbonData.aggrCarbon = FootprintHelper.getFootprint(aggrCarbonData[i].values, aggrCarbonData[i].key);
+          }
+        }
+      }
+   };
 
     $scope.showCharts = function(agg_metrics) {
       $scope.data.count = getDataFromMetrics(agg_metrics.count);

--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -1,4 +1,4 @@
-// 'use strict';
+'use strict';
 
 angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-datepicker', 'emission.main.metrics.factory', 'angularLocalStorage'])
 
@@ -211,7 +211,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
 
     $scope.userDataSaved = function() {
       var saved_user_data = CalorieCal.get();
-      console.log("saved vals = "+JSON.stringify(saved_user_data));
+      // console.log("saved vals = "+JSON.stringify(saved_user_data));
       return saved_user_data.userDataSaved == true;
     }
     $scope.options = {
@@ -649,10 +649,6 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
             $scope.carbonData.optimalCarbon = FootprintHelper.getFootprint(optimalDistance, userCarbonData[i].key);
             $scope.carbonData.worstCarbon = FootprintHelper.getFootprint(worstDistance, userCarbonData[i].key);
             lastWeekCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
-            if(first){
-              lastWeekCarbon = $scope.carbonData.userCarbon;
-            }
-            $scope.carbonData.lastWeekUserCarbon = lastWeekCarbon;
           }
         }
       }
@@ -664,6 +660,10 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
             if (userCarbonData[i].key === "IN_VEHICLE") {
               twoWeeksAgoCarbon = FootprintHelper.getFootprint(userCarbonData[i].values, userCarbonData[i].key);
               twoWeeksAgoCarbonInt = FootprintHelper.getFootprintRaw(userCarbonData[i].values, userCarbonData[i].key);
+              if(first){
+                lastWeekCarbon = twoWeeksAgoCarbon;
+              }
+              $scope.carbonData.lastWeekUserCarbon = lastWeekCarbon;
             }
           }
         }

--- a/www/templates/main-metrics.html
+++ b/www/templates/main-metrics.html
@@ -2,9 +2,14 @@
   <ion-nav-bar class="bar-stable">
     <ion-nav-back-button></ion-nav-back-button>
   </ion-nav-bar>
-  <ion-nav-buttons side="left">
+  <ion-nav-buttons side="primary">
       <button class="button button-icon" ng-click="share()">
         <i class="icon ion-share"></i>
+      </button>
+  </ion-nav-buttons>
+  <ion-nav-buttons side="secondary">
+      <button class="button button-icon" ng-click="doRefresh()">
+        <i class="icon ion-refresh"></i>
       </button>
   </ion-nav-buttons>
   <ion-content class="has-header">

--- a/www/templates/main-metrics.html
+++ b/www/templates/main-metrics.html
@@ -72,7 +72,9 @@
               </div>
               <div style="margin-top: 110px;">
                 <div class="card dashboard-list"><b>Optimal:</b> {{carbonData.optimalCarbon}}</div>
+                <!--
                 <div class="card dashboard-list"><b>Average:</b> {{carbonData.aggrCarbon}}</div>
+                -->
                 <div class="card dashboard-list"><b>Worst:</b> {{carbonData.worstCarbon}}</div>
                 <div class="card dashboard-list"><b>Last Week:</b> {{carbonData.lastWeekUserCarbon}}</div>
                 <div class="card dashboard-list"><b>CA 2035:</b> {{carbonData.ca2035}}</div>
@@ -111,7 +113,9 @@
             </div>
             </div>
             <div style="margin-top: 120px;">
+              <!--
               <div class="card dashboard-list"><b>Average:</b> {{caloriesData.aggrCalories}}</div>
+              -->
               <div class="card dashboard-list"><b>Last Week:</b> {{caloriesData.lastWeekUserCalories}}</div>
               <div style="align:center;">
                  <div class="circle" id="circle-food" ng-click="setCookie()">


### PR DESCRIPTION
This allows us to retrieve them in separate calls. Note that this also takes
the giant bolus of code that was the getMetrics function and wrestles it into
some form of submission as a set of non-overlapping, coherent functions.

Manual testing indicates that this works.