### PR TITLE
Enable performant aggregate calculations as well

### DIFF
--- a/www/templates/main-metrics.html
+++ b/www/templates/main-metrics.html
@@ -29,7 +29,7 @@
       <div class="metric-second-half">
           <i class="icon ion-ios-person metric-icon"></i>
           <label ng-click="toggle()" class="toggle metric-me-toggle">
-            <input type="checkbox" ng-checked="!uictrl.showMe"> <!-- me on left, off -->
+            <input type="checkbox" ng-checked="!uictrl.showMe" ng-disabled="!uictrl.hasAggr"> <!-- me on left, off -->
             <div class="track toggle-color">
               <div class="handle"></div>
             </div>
@@ -72,9 +72,7 @@
               </div>
               <div style="margin-top: 110px;">
                 <div class="card dashboard-list"><b>Optimal:</b> {{carbonData.optimalCarbon}}</div>
-                <!--
                 <div class="card dashboard-list"><b>Average:</b> {{carbonData.aggrCarbon}}</div>
-                -->
                 <div class="card dashboard-list"><b>Worst:</b> {{carbonData.worstCarbon}}</div>
                 <div class="card dashboard-list"><b>Last Week:</b> {{carbonData.lastWeekUserCarbon}}</div>
                 <div class="card dashboard-list"><b>CA 2035:</b> {{carbonData.ca2035}}</div>
@@ -113,9 +111,7 @@
             </div>
             </div>
             <div style="margin-top: 120px;">
-              <!--
               <div class="card dashboard-list"><b>Average:</b> {{caloriesData.aggrCalories}}</div>
-              -->
               <div class="card dashboard-list"><b>Last Week:</b> {{caloriesData.lastWeekUserCalories}}</div>
               <div style="align:center;">
                  <div class="circle" id="circle-food" ng-click="setCookie()">


### PR DESCRIPTION
The aggregate calculations are launched in a separate promise and fill in the
aggregate/average values when the calculations complete. Still see values, does
not affect responsiveness...

This makes #153 bearable for now. 