### PR TITLE
Fix ionic deploy update progress to really work

### DIFF
--- a/www/js/splash/updatecheck.js
+++ b/www/js/splash/updatecheck.js
@@ -32,6 +32,12 @@ angular.module('emission.splash.updatecheck', ['angularLocalStorage'])
   var deploy = new Ionic.Deploy();
 
   var applyUpdate = function() {
+    $ionicPopup.show({
+      title: 'Downloading UI-only update',
+      template: '<progress class="download" value="{{progress}}" max="100"></progress>',
+      scope: $rootScope,
+      buttons: []
+    });
     deploy.update().then(function(res) {
       window.Logger.log(window.Logger.LEVEL_INFO,
        'Ionic Deploy: Update Success! ', res);
@@ -47,10 +53,13 @@ angular.module('emission.splash.updatecheck', ['angularLocalStorage'])
        $ionicPopup.alert({template: 'Error during update'});
     }, function(prog) {
       console.log('Ionic Deploy: Progress... ', prog);
-      $rootScope.progress = prog;
-      $rootScope.isDownloading = true;
-      if(prog==100)
-        $rootScope.isDownloading = false;
+      $rootScope.$apply(function(){
+          $rootScope.progress = prog;
+          $rootScope.isDownloading = true;
+          if(prog==100) {
+            $rootScope.isDownloading = false;
+          }
+      });
     })
   };
 

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -1,7 +1,4 @@
 <ion-view view-title="Profile" ng-class="ionViewBackgroundClass()">
-   <div>
-    <progress ng-if="isDownloading" class=" has-header download" value="{{progress}}" max="100"></progress>
-  </div>
   <ion-content>
     <div class="control-list-item">
       <div class="control-list-text">{{settings.auth.email}}</div>

--- a/www/templates/intro/intro.html
+++ b/www/templates/intro/intro.html
@@ -1,7 +1,4 @@
 <ion-view hide-nav-bar="true" class="intro-view">
-    <div>
-        <progress ng-if="isDownloading" class=" has-header download" value="{{progress}}" max="100"></progress>
-    </div>
     <ion-slide-box delegate-handle="intro-box" on-slide-changed="slideChanged(index)" show-pager="false">
       <ion-slide>
         <ng-include src="'templates/intro/summary.html'"></ng-include>

--- a/www/templates/main.html
+++ b/www/templates/main.html
@@ -4,9 +4,6 @@ Each tab's child <ion-nav-view> directive will have its own
 navigation history that also transitions its views in and out.
 -->
 <ion-view>
-   <div>
-    <progress ng-if="isDownloading" class=" has-header download" value="{{progress}}" max="100"></progress>
-  </div>
 <ion-tabs ng-class="tabsCustomClass()">
 
   <!-- Diary Tab -->


### PR DESCRIPTION
The prior solution required the introduction of a progress element in every
screen - otherwise the transparent overlay meant that the progress bar was not
actually visible on (say) the trip list screen.

This solution moves the progress bar into a `$ionicPopup`. This ensures that:
- all the code can be isolated to the update check class
- the user visually sees that the update is happening, and does not kill the app. and if she does, she understands why it no longer works :)
- there is a clearer indication when the progress is done and the screen is re-loaded