### PR TITLE
Add the modal to show the credentials

### DIFF
--- a/www/templates/goals/creds-modal.html
+++ b/www/templates/goals/creds-modal.html
@@ -1,0 +1,14 @@
+<ion-list>
+    <ion-item class="row responsive-sm">
+        <div class="col timestamp"> Username: </div>
+        <div class="col detail"> {{profile.auth.local.username}} </div>
+    </ion-item>
+    <ion-item class="row responsive-sm">
+        <div class="col timestamp"> Email: </div>
+        <div class="col detail"> {{profile.auth.local.email}} </div>
+    </ion-item>
+    <ion-item class="row responsive-sm">
+        <div class="col timestamp"> Password: </div>
+        <div class="col detail"> {{profile.auth.local.password}} </div>
+    </ion-item>
+</ion-list>


### PR DESCRIPTION
Without this fix, a freshly checked out version will not work.
We've been getting away with it so far because I've been deploying from my local repo...