### PR TITLE
Turn off autolaunch for the goals walkthrough

### DIFF
--- a/www/js/goals.js
+++ b/www/js/goals.js
@@ -682,6 +682,4 @@ angular.module('emission.main.goals',['emission.services', 'emission.plugin.logg
     $scope.startWalkthrough = function () {
       startWalkthrough();
     }
-
-    checkGoalsTutorialDone();
 });

--- a/www/js/splash/updatecheck.js
+++ b/www/js/splash/updatecheck.js
@@ -38,6 +38,9 @@ angular.module('emission.splash.updatecheck', ['angularLocalStorage'])
       scope: $rootScope,
       buttons: []
     });
+    if ($rootScope.isDownloading) {
+      return;
+    }
     deploy.update().then(function(res) {
       window.Logger.log(window.Logger.LEVEL_INFO,
        'Ionic Deploy: Update Success! ', res);


### PR DESCRIPTION
It conflicts with the popups from the referral process, and if we have two
popups at the same time, we end up unable to click one either of them.
Also try to avoid allowing people to apply the same update twice, which will
confuse the heck out of ionic deploy.