### PR TITLE
Create a "Fix Map" button for the diary list as well

### DIFF
--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -290,11 +290,19 @@ angular.module('emission.main.diary.list',['ui-leaflet',
       {
         target: '.diary-entry',
         content: 'Click on the map to see more details about each trip.'
+      },
+      {
+        target: '.refresh-tiles',
+        content: 'Use this to fix the map tiles if they have not loaded properly.'
       }]
     };
 
     var startWalkthrough = function () {
       nzTour.start(tour);
+    };
+
+    $scope.refreshTiles = function() {
+      $scope.$broadcast('invalidateSize');
     };
 
     /*

--- a/www/templates/diary/list.html
+++ b/www/templates/diary/list.html
@@ -15,6 +15,9 @@
          <ion-nav-buttons side="right">
              <button class="button button-icon ion-help" ng-click="startWalkthrough()"></button>
          </ion-nav-buttons>
+         <ion-nav-buttons side="left">
+             <button class="button refresh-tiles" ng-click="refreshTiles()">Fix Map</button>
+         </ion-nav-buttons>
     </ion-nav-bar>
     <div style="background-color: transparent; border-left-style: solid; border-left-width: 0.5px; border-left-color: #212121; margin-left: 10%; position: absolute; float: left; height: 100%;"></div>
 	<ion-content class="diary-entry">


### PR DESCRIPTION
We added "Fix Map" buttons to all the screens to fix loading issues.
However, @immesys has reported that they don't work on the list view.
This is probably because on the list view we reload data and fix the tiles at
the same time. We may be able to use $timeout after the load to fix the tiles
if that is the problem. But let us add a button to this screen for now anyway
and if it works, experiment with the screen load.
    
https://github.com/e-mission/e-mission-phone/issues/75
