### PR TITLE
Really fix the trip diary load

### DIFF
--- a/www/js/common/services.js
+++ b/www/js/common/services.js
@@ -46,7 +46,8 @@ angular.module('emission.main.common.services', [])
      * Returns the common trip corresponding to the specified tripId
      */
     commonGraph.trip2Common = function(tripId) {
-        if (angular.isDefined(commonGraph.data)) {
+        if (angular.isDefined(commonGraph.data) && 
+            angular.isDefined(commonGraph.data.trip2CommonMap)) {
           return commonGraph.data.trip2CommonMap[tripId];
         } else {
           // return undefined because that is what the invoking locations expect


### PR DESCRIPTION
The prior fix 58adfe4c3b58073cd6d2c6ca4ee416275d88b9a2 did not actually fix
everything because when the data is loaded from the cache, commonGraph is
defined, and commonGraph.data is defined, but commonGraph.data.trip2CommonMap
is not defined.

This additional check finally fixes #111.

Verified by pulling today's data into the cache and then navigating to the diary.

Without this fix, got a blank screen.
With this fix, got the diary.