### PR TITLE
Add support for displaying a prompt at the end of a trip

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "leaflet": "^0.7.7",
     "ui-leaflet": "^1.0.0",
     "Leaflet.awesome-markers": "^2.0.2",
-    "ionic-datepicker": "^0.9.0",
+    "ionic-datepicker": "git://github.com/rajeshwarpatlolla/ionic-datepicker.git#d87c2ffc09d31d0468740ddff6b91e8b2c0635d1",
     "ionic-platform-web-client": "^0.7.1"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -55,9 +55,10 @@
     },
     "cordova-plugin-app-version",
     "cordova-plugin-file",
+    "cordova-plugin-compat",
     {
       "locator": "https://github.com/shankari/cordova-plugin-email-composer.git",
-      "id": "de.appplant.cordova.plugin.email-composer"
+      "id": "cordova-plugin-email-composer"
     },
     {
       "locator": "https://github.com/e-mission/cordova-server-sync.git",
@@ -76,7 +77,16 @@
       "locator": "https://github.com/EddyVerbruggen/Custom-URL-scheme.git",
       "id": "cordova-plugin-customurlscheme"
     },
-    "cordova-plugin-inappbrowser"
+    "cordova-plugin-inappbrowser",
+    "cordova-plugin-registerusernotificationsettings",
+    {
+      "locator": "https://github.com/shankari/cordova-plugin-local-notifications.git",
+      "id": "de.appplant.cordova.plugin.local-notification-ios9-fix"
+    },
+    {
+      "locator": "https://github.com/e-mission/e-mission-transition-notify.git",
+      "id": "edu.berkeley.eecs.emission.cordova.transitionnotify"
+    }
   ],
   "cordovaPlatforms": [
     "ios",

--- a/www/index.html
+++ b/www/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com http://nominatim.openstreetmap.org https://e-mission.eecs.berkeley.edu https://berkeley.qualtrics.com https://jfe-cdn.qualtrics.com emission:;
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com http://nominatim.openstreetmap.org https://e-mission.eecs.berkeley.edu https://berkeley.qualtrics.com https://jfe-cdn.qualtrics.com emission: 'unsafe-eval';
             style-src 'self' 'unsafe-inline';
-            script-src 'self' 'unsafe-inline' https://berkeley.qualtrics.com https://jfe-cdn.qualtrics.com;
+            script-src 'self' 'unsafe-inline' https://berkeley.qualtrics.com https://jfe-cdn.qualtrics.com 'unsafe-eval';
             img-src 'self' data: http://*.tile.openstreetmap.org http://tile.stamen.com 
             'unsafe-inline'">
     <title></title>
@@ -73,6 +73,7 @@
     <script src="js/main.js"></script>
     <script src="js/recent.js"></script>
     <script src="js/incident/post-trip-manual.js"></script>
+    <script src="js/incident/post-trip-prompt.js"></script>
     <script src="js/diary.js"></script>
     <script src="js/diary/list.js"></script>
     <script src="js/diary/detail.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -74,6 +74,7 @@
     <script src="js/recent.js"></script>
     <script src="js/incident/post-trip-manual.js"></script>
     <script src="js/incident/post-trip-prompt.js"></script>
+    <script src="js/incident/post-trip-map-display.js"></script>
     <script src="js/diary.js"></script>
     <script src="js/diary/list.js"></script>
     <script src="js/diary/detail.js"></script>

--- a/www/js/control.js
+++ b/www/js/control.js
@@ -1,6 +1,8 @@
 'use strict';
 
 angular.module('emission.main.control',['emission.services',
+                                        'ionic-datepicker',
+                                        'ionic-datepicker.provider',
                                         'emission.splash.startprefs',
                                         'emission.splash.updatecheck',
                                         'emission.main.metrics.factory',
@@ -9,8 +11,35 @@ angular.module('emission.main.control',['emission.services',
 
 .controller('ControlCtrl', function($scope, $window, $ionicScrollDelegate,
                $state, $ionicPopup, $ionicActionSheet, $ionicPopover,
-               $rootScope, storage, StartPrefs, ControlHelper, UpdateCheck,
+               $rootScope, storage, ionicDatePicker,
+               StartPrefs, ControlHelper, UpdateCheck,
                CalorieCal, ClientStats) {
+
+    var datepickerObject = {
+      todayLabel: 'Today',  //Optional
+      closeLabel: 'Close',  //Optional
+      setLabel: 'Set',  //Optional
+      titleLabel: 'One week of data from',
+      setButtonType : 'button-positive',  //Optional
+      todayButtonType : 'button-stable',  //Optional
+      closeButtonType : 'button-stable',  //Optional
+      inputDate: moment().subtract(1, 'week').toDate(),  //Optional
+      from: new Date(2015, 1, 1),
+      to: new Date(),
+      mondayFirst: true,  //Optional
+      templateType: 'popup', //Optional
+      showTodayButton: 'true', //Optional
+      modalHeaderColor: 'bar-positive', //Optional
+      modalFooterColor: 'bar-positive', //Optional
+      callback: ControlHelper.getMyData, //Mandatory
+      dateFormat: 'dd MMM yyyy', //Optional
+      closeOnSelect: true //Optional
+    }
+
+    $scope.openDatePicker = function(){
+      ionicDatePicker.openDatePicker(datepickerObject);
+    };
+
     $scope.emailLog = ControlHelper.emailLog;
     $scope.dark_theme = $rootScope.dark_theme;
     $scope.userData = []
@@ -491,7 +520,7 @@ angular.module('emission.main.control',['emission.services',
             template: 'Consented to protocol {{consentDoc.protocol_id}}, {{consentDoc.approval_date}}',
             scope: $scope,
             title: "Consent found!",
-            buttons: [ 
+            buttons: [
             // {text: "<a href='https://e-mission.eecs.berkeley.edu/consent'>View</a>",
             //  type: 'button-calm'},
             {text: "<b>OK</b>",

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -14,7 +14,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope, $ionicPlatform,
     CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler, ClientStats, PostTripAutoPrompt)  {
   console.log('SplashCtrl invoked');
-  // alert("attach debugger!");
+  alert("attach debugger!");
   CustomURLScheme.onLaunch(function(event, url){
     console.log("GOT URL:"+url);
 
@@ -32,7 +32,6 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
     // Here's where we initialize all the native code
     // Theoretically, this should let us remove the $timeout hacks
     StartPrefs.checkNativeConsent();
-    PostTripAutoPrompt.registerTripEnd();
   });
 
   $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -14,7 +14,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope, $ionicPlatform,
     CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler, ClientStats, PostTripAutoPrompt)  {
   console.log('SplashCtrl invoked');
-  alert("attach debugger!");
+  // alert("attach debugger!");
   CustomURLScheme.onLaunch(function(event, url){
     console.log("GOT URL:"+url);
 

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -4,6 +4,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
                                         'emission.splash.startprefs',
                                         'emission.splash.referral',
                                         'emission.stats.clientstats',
+                                        'emission.incident.posttrip.prompt',
                                         'customURLScheme'])
 
 .controller('RootCtrl', function($scope) {})
@@ -11,7 +12,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('DashCtrl', function($scope) {})
 
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope, $ionicPlatform,
-    CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler, ClientStats) {
+    CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler, ClientStats, PostTripAutoPrompt)  {
   console.log('SplashCtrl invoked');
   // alert("attach debugger!");
   CustomURLScheme.onLaunch(function(event, url){
@@ -31,6 +32,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
     // Here's where we initialize all the native code
     // Theoretically, this should let us remove the $timeout hacks
     StartPrefs.checkNativeConsent();
+    PostTripAutoPrompt.registerTripEnd();
   });
 
   $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -9,6 +9,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
                                     $ionicScrollDelegate, $ionicPopup,
                                     $ionicLoading,
                                     $ionicActionSheet,
+                                    ionicDatePicker,
                                     leafletData, Timeline, CommonGraph, DiaryHelper,
                                     Config, PostTripManualMarker, nzTour, storage) {
   console.log("controller DiaryListCtrl called");
@@ -148,9 +149,13 @@ angular.module('emission.main.diary.list',['ui-leaflet',
       modalHeaderColor: 'bar-positive', //Optional
       modalFooterColor: 'bar-positive', //Optional
       callback: $scope.setCurrDay, //Mandatory
-      dateFormat: 'dd MMMM yyyy', //Optional
+      dateFormat: 'dd MMM yyyy', //Optional
       closeOnSelect: true //Optional
     };
+
+    $scope.pickDay = function() {
+      ionicDatePicker.openDatePicker($scope.datepickerObject);
+    }
 
     $scope.$on(Timeline.UPDATE_DONE, function(event, args) {
       console.log("Got event with args "+JSON.stringify(args));

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -256,7 +256,7 @@ angular.module('emission.main.diary.services', ['emission.services',
     retVal.data = trip;
     retVal.style = style_feature;
     retVal.onEachFeature = onEachFeature;
-    retVal.pointToLayer = pointFormat;
+    retVal.pointToLayer = dh.pointFormat;
     retVal.start_place = trip.start_place;
     retVal.end_place = trip.end_place;
     retVal.stops = trip.stops;
@@ -323,7 +323,7 @@ angular.module('emission.main.diary.services', ['emission.services',
     }
 };
 
-  var pointFormat = function(feature, latlng) {
+  dh.pointFormat = function(feature, latlng) {
     switch(feature.properties.feature_type) {
       case "start_place": return L.marker(latlng, {icon: startIcon});
       case "end_place": return L.marker(latlng, {icon: stopIcon});

--- a/www/js/incident/post-trip-manual.js
+++ b/www/js/incident/post-trip-manual.js
@@ -22,20 +22,36 @@ angular.module('emission.incident.posttrip.manual', ['emission.plugin.logger',
    * INTERNAL FUNCTION, not part of factory
    *
    * Returns objects of the form: {
-   * gj: geojson representation,
+   * loc: geojson representation,
    * latlng: latlng representation,
    * ts: timestamp
    * }
    */
 
   var getSectionPoints = function(section) {
+    console.log("Called getSection points with list of size "+section.geometry.coordinates.length);
     var mappedPoints = section.geometry.coordinates.map(function(currCoords, index) {
-      var currMappedPoint = {gj: currCoords,
+      Logger.log("About to map point"+ JSON.stringify(currCoords)+" at index "+index);
+      var currMappedPoint = {loc: currCoords,
         latlng: L.GeoJSON.coordsToLatLng(currCoords),
         ts: section.properties.times[index]}
       if (index % 100 == 0) {
         Logger.log("Mapped point "+ JSON.stringify(currCoords)+" to "+currMappedPoint);
       }
+      return currMappedPoint;
+    });
+    return mappedPoints;
+  }
+
+  ptmm.addLatLng = function(locEntryList) {
+    console.log("called addLatLng with list of length "+locEntryList.length);
+    var mappedPoints = locEntryList.map(function(currEntry) {
+      var currMappedPoint = {loc: currEntry.data.loc,
+        latlng: L.GeoJSON.coordsToLatLng(currEntry.data.loc),
+        ts: currEntry.data.ts}
+      // if (index % 100 == 0) {
+        Logger.log("Mapped point "+ JSON.stringify(currEntry)+" to "+currMappedPoint);
+      // }
       return currMappedPoint;
     });
     return mappedPoints;
@@ -202,9 +218,9 @@ angular.module('emission.incident.posttrip.manual', ['emission.plugin.logger',
    */
 
   var showSheet = function(featureArray, latlng, ts, marker, e, map) {
-    var safe_suck_cancel_actions = [{text: "Safe",
+    var safe_suck_cancel_actions = [{text: "<i class='ion-heart icon-action'></i>",
                                      action: addSafeEntry},
-                                    {text: "Suck",
+                                    {text: "<i class='ion-heart-broken icon-action'></i>",
                                      action: addSuckEntry},
                                     {text: "Cancel",
                                      action: cancelTempEntry}]
@@ -300,7 +316,7 @@ angular.module('emission.incident.posttrip.manual', ['emission.plugin.logger',
 
   ptmm.startAddingIncidentToPoints = function(layer, allPoints, geojsonFeatureArray) {
       Logger.log("points "+getFormattedTime(allPoints[0].ts)
-                  + " -> "+getFormattedTime(allPoints[allPoints.length -1])
+                  + " -> "+getFormattedTime(allPoints[allPoints.length -1].ts)
                   + " bound incident addition ");
 
       return function(e) {

--- a/www/js/incident/post-trip-map-display.js
+++ b/www/js/incident/post-trip-map-display.js
@@ -1,0 +1,135 @@
+'use strict';
+angular.module('emission.incident.posttrip.map',['ui-leaflet',
+                                      'emission.services', 'emission.plugin.logger',
+                                      'emission.main.diary.services',
+                                      'emission.incident.posttrip.manual'])
+
+.controller("PostTripMapCtrl", function($scope, $window,
+                                        $stateParams, $ionicActionSheet,
+                                        leafletData, leafletMapEvents, Logger,
+                                        Timeline, DiaryHelper, Config, CommHelper,
+                                        PostTripManualMarker) {
+  console.log("controller PostTripMapDisplay called with params = "+
+    JSON.stringify($stateParams));
+  $scope.mapCtrl = {};
+  angular.extend($scope.mapCtrl, {
+    defaults: {}
+  });
+  angular.extend($scope.mapCtrl.defaults, Config.getMapTiles());
+  var LOC_KEY = "background/filtered_location";
+
+  $scope.mapCtrl.start_ts = $stateParams.start_ts;
+  $scope.mapCtrl.end_ts = $stateParams.end_ts;
+
+  /*
+  var mapEvents = leafletMapEvents.getAvailableMapEvents();
+  for (var k in mapEvents) {
+    var eventName = 'leafletDirectiveMap.incident.' + mapEvents[k];
+    $scope.$on(eventName, function(event, data){
+        console.log("in mapEvents, event = "+JSON.stringify(event.name)+
+              " leafletEvent = "+JSON.stringify(data.leafletEvent.type)+
+              " leafletObject = "+JSON.stringify(data.leafletObject.getBounds()));
+        $scope.eventDetected = event.name;
+    });
+  }
+  */
+
+  $scope.refreshMap = function(start_ts, end_ts) {
+    var db = $window.cordova.plugins.BEMUserCache;
+    var tq = {key: "write_ts",
+              startTs: start_ts,
+              endTs: end_ts};
+    $scope.mapCtrl.cache = {};
+    $scope.mapCtrl.server = {};
+    // Clear everything before we start loading new data
+    $scope.mapCtrl.geojson = {};
+    $scope.mapCtrl.geojson.pointToLayer = DiaryHelper.pointFormat;
+    $scope.mapCtrl.geojson.data = {
+        type: "Point",
+        coordinates: [-122, 37]
+    };
+    console.log("About to query buffer for "+JSON.stringify(tq));
+    $window.cordova.plugins.BEMUserCache.getSensorDataForInterval(LOC_KEY, tq, true)
+      // .then(PostTripManualMarker.addLatLng)
+      .then(function(resultList) {
+        console.log("Read data of length "+resultList.length);
+        if (resultList.length > 0) {
+          // $scope.mapCtrl.cache.points = PostTripManualMarker.addLatLng(resultList);
+          // $scope.mapCtrl.cache.points = resultList;
+          // console.log("Finished adding latlng");
+          var pointCoords = resultList.map(function(locEntry) {
+            return [locEntry.data.longitude, locEntry.data.latitude];
+          });
+          var pointTimes = resultList.map(function(locEntry) {
+            return locEntry.data.ts;
+          });
+          $scope.mapCtrl.cache.features = [{
+            type: "Feature",
+            geometry: {
+              type: "LineString",
+              coordinates: pointCoords,
+              properties: {
+                times: pointTimes
+              }
+            }
+          }];
+          $scope.mapCtrl.cache.data = {
+            type: "FeatureCollection",
+            features: $scope.mapCtrl.cache.features,
+            properties: {
+              start_ts: start_ts,
+              end_ts: end_ts
+            }
+          };
+
+          console.log("About to get section points");
+          var points = resultList.map(function(locEntry) {
+            var coords = [locEntry.data.longitude, locEntry.data.latitude];
+            // console.log("coords = "+coords);
+            return {loc: coords,
+                latlng: L.GeoJSON.coordsToLatLng(coords),
+                ts: locEntry.data.ts};
+          });
+          /*
+          var points = PostTripManualMarker.addLatLng(resultList);
+          */
+          $scope.mapCtrl.cache.points = points;
+          console.log("Finished getting section points");
+              /*
+          $scope.mapCtrl.cache.points = resultList.map(function(locEntry) {
+              console.log("locEntry = "+JSON.serialize(locEntry));
+              var currMappedPoint = {loc: locEntry.data.loc,
+                latlng: L.GeoJSON.coordsToLatLng(locEntry.data.loc),
+                ts: locEntry.data.ts};
+              Logger.log("Mapped point "+ JSON.stringify(locEntry)+" to "+currMappedPoint);
+              return currMappedPoint;
+             return locEntry.data.ts;
+          });
+          console.log("Finished getting section points");
+              */
+            
+          $scope.mapCtrl.cache.loaded = true;
+          $scope.$apply(function() {
+            // data is in the cache, so we can just load it from there
+            // console.log("About to set geojson = "+JSON.stringify($scope.mapCtrl.cache.data));
+            $scope.mapCtrl.geojson.data = $scope.mapCtrl.cache.data;
+          });
+
+          leafletData.getMap('incident').then(function(map) {
+            console.log("registered click receiver");
+            map.on('click', PostTripManualMarker.startAddingIncidentToPoints(map,
+                $scope.mapCtrl.cache.points,
+                $scope.mapCtrl.cache.features));
+          });
+
+        }
+    });
+  }
+
+  $scope.refreshWholeMap = function() {
+    $scope.refreshMap($scope.mapCtrl.start_ts, $scope.mapCtrl.end_ts);
+  }
+
+  $scope.getFormattedDate = DiaryHelper.getFormattedDate;
+  $scope.refreshMap($scope.mapCtrl.start_ts, $scope.mapCtrl.end_ts);
+});

--- a/www/js/incident/post-trip-map-display.js
+++ b/www/js/incident/post-trip-map-display.js
@@ -7,7 +7,7 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet',
 .controller("PostTripMapCtrl", function($scope, $window,
                                         $stateParams, $ionicActionSheet,
                                         leafletData, leafletMapEvents, Logger,
-                                        Timeline, DiaryHelper, Config, CommHelper,
+                                        Timeline, DiaryHelper, Config, UnifiedDataLoader,
                                         PostTripManualMarker) {
   console.log("controller PostTripMapDisplay called with params = "+
     JSON.stringify($stateParams));
@@ -46,10 +46,13 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet',
     $scope.mapCtrl.geojson.pointToLayer = DiaryHelper.pointFormat;
     $scope.mapCtrl.geojson.data = {
         type: "Point",
-        coordinates: [-122, 37]
+        coordinates: [-122, 37],
+        properties: {
+          feature_type: "location"
+        }
     };
     console.log("About to query buffer for "+JSON.stringify(tq));
-    $window.cordova.plugins.BEMUserCache.getSensorDataForInterval(LOC_KEY, tq, true)
+    UnifiedDataLoader.getUnifiedSensorDataForInterval(LOC_KEY, tq)
       // .then(PostTripManualMarker.addLatLng)
       .then(function(resultList) {
         console.log("Read data of length "+resultList.length);
@@ -107,7 +110,7 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet',
           });
           console.log("Finished getting section points");
               */
-            
+
           $scope.mapCtrl.cache.loaded = true;
           $scope.$apply(function() {
             // data is in the cache, so we can just load it from there

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -1,61 +1,72 @@
 'use strict';
 
 angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
-.factory("PostTripAutoPrompt", function($window, Logger) {
+.factory("PostTripAutoPrompt", function($window, $ionicPlatform, Logger) {
   var ptap = {};
+  var REPORT = 737678; // REPORT on the phone keypad
 
   var showTripEndNotification = function() {
-    var actions = [ {
-        identifier: 'SIGN_IN',
-        title: 'Yes',
-        icon: 'res://ic_signin',
-        activationMode: 'background',
-        destructive: false,
-        authenticationRequired: true
-    },
-    {
-       identifier: 'MORE_SIGNIN_OPTIONS',
-       title: 'More Options',
+    var actions = [{
+       identifier: 'MUTE',
+       title: 'Mute',
        icon: 'res://ic_moreoptions',
        activationMode: 'foreground',
        destructive: false,
        authenticationRequired: false
-    },
-    {
-       identifier: 'PROVIDE_INPUT',
-       title: 'Provide Input',
-       icon: 'ic_input',
-       activationMode: 'background',
-       destructive: false,
-       authenticationRequired: false,
-       behavior: 'textInput',
-       textInputSendTitle: 'Reply'
+    }, {
+        identifier: 'REPORT',
+        title: 'Yes',
+        icon: 'res://ic_signin',
+        activationMode: 'foreground',
+        destructive: false,
+        authenticationRequired: false
     }];
 
     console.log("About to show notification");
     $window.cordova.plugins.notification.local.schedule({
-      id: 1,
+      id: REPORT,
       title: "Trip just ended",
       text: "Incident to report?",
       actions: [actions[0], actions[1]],
-      category: 'SIGN_IN_TO_CLASS'
+      category: 'REPORT_INCIDENT'
     });
   }
 
   ptap.registerTripEnd = function() {
-    console.log( "register tripEnd received!" );
+    console.log( "registertripEnd received!" );
     // Android
     $window.broadcaster.addEventListener("local.transition.stopped_moving", function( e ) {
       showTripEndNotification();
     });
 
     // iOS
-    $window.broadcaster.addEventListener("TRANSITION_NAME", function( e ) {
+    $window.broadcaster.addEventListener("TRANSITION_NAME", function(e) {
       console.log("Received TRANSITION_NAME event"+JSON.stringify(e));
       showTripEndNotification();
     });
   }
 
+  ptap.registerUserResponse = function() {
+    console.log( "registerUserResponse received!" );
+    $window.cordova.plugins.notification.local.on('action', function (notification, state, data) {
+      if (data.identifier === 'REPORT') {
+          alert("About to report");
+      } else if (data.identifier === 'MUTE') {
+          alert('About to mute');
+      }
+    });
+    $window.cordova.plugins.notification.local.on('click', function (notification, state, data) {
+      alert("swiped, no action");
+    });
+  }
+
+  $ionicPlatform.ready().then(function() {
+    ptap.registerTripEnd();
+    ptap.registerUserResponse();
+  });
+
   return ptap;
 
 });
+
+// UIMutableUserNotificationAction

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -27,7 +27,8 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
       title: "Trip just ended",
       text: "Incident to report?",
       actions: [actions[0], actions[1]],
-      category: 'REPORT_INCIDENT'
+      category: 'REPORT_INCIDENT',
+      autoClear: true
     };
     Logger.log("Returning notification config "+JSON.stringify(reportNotifyConfig));
     return reportNotifyConfig;
@@ -58,6 +59,9 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
       } else if (data.identifier === 'MUTE') {
           alert('About to mute');
       }
+    });
+    $window.cordova.plugins.notification.local.on('clear', function (notification, state, data) {
+        alert("notification cleared, no report");
     });
     $window.cordova.plugins.notification.local.on('click', function (notification, state, data) {
       alert("clicked, no action");

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -40,9 +40,10 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
     });
 
     // iOS
-    $window.broadcaster.addEventListener("TRANSITION_NAME", function(e) {
-      console.log("Received TRANSITION_NAME event"+JSON.stringify(e));
-      showTripEndNotification();
+    $window.cordova.plugins.BEMTransitionNotification.addEventListener("TRANSITION_NAME",  {test: "me"}).then(function(result) {
+    // $window.broadcaster.addEventListener("TRANSITION_NAME",  function(result) {
+      console.log("Finished registering TRANSITION_NAME event"+JSON.stringify(result));
+      // showTripEndNotification();
     });
   }
 
@@ -69,4 +70,3 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
 
 });
 
-// UIMutableUserNotificationAction

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -22,7 +22,7 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
         authenticationRequired: false
     }];
 
-    reportNotifyConfig = {
+    var reportNotifyConfig = {
       id: REPORT,
       title: "Trip just ended",
       text: "Incident to report?",
@@ -37,6 +37,7 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
     console.log( "registertripEnd received!" );
     // iOS
     var notifyPlugin = $window.cordova.plugins.BEMTransitionNotification;
+    notifyPlugin.TRIP_END = "trip_ended";
     notifyPlugin.addEventListener(notifyPlugin.TRIP_END, getTripEndReportNotification())
         .then(function(result) {
             // $window.broadcaster.addEventListener("TRANSITION_NAME",  function(result) {
@@ -59,7 +60,10 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
       }
     });
     $window.cordova.plugins.notification.local.on('click', function (notification, state, data) {
-      alert("swiped, no action");
+      alert("clicked, no action");
+    });
+    $window.cordova.plugins.notification.local.on('trigger', function (notification, state, data) {
+      alert("triggered, no action");
     });
   }
 

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -1,0 +1,61 @@
+'use strict';
+
+angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
+.factory("PostTripAutoPrompt", function($window, Logger) {
+  var ptap = {};
+
+  var showTripEndNotification = function() {
+    var actions = [ {
+        identifier: 'SIGN_IN',
+        title: 'Yes',
+        icon: 'res://ic_signin',
+        activationMode: 'background',
+        destructive: false,
+        authenticationRequired: true
+    },
+    {
+       identifier: 'MORE_SIGNIN_OPTIONS',
+       title: 'More Options',
+       icon: 'res://ic_moreoptions',
+       activationMode: 'foreground',
+       destructive: false,
+       authenticationRequired: false
+    },
+    {
+       identifier: 'PROVIDE_INPUT',
+       title: 'Provide Input',
+       icon: 'ic_input',
+       activationMode: 'background',
+       destructive: false,
+       authenticationRequired: false,
+       behavior: 'textInput',
+       textInputSendTitle: 'Reply'
+    }];
+
+    console.log("About to show notification");
+    $window.cordova.plugins.notification.local.schedule({
+      id: 1,
+      title: "Trip just ended",
+      text: "Incident to report?",
+      actions: [actions[0], actions[1]],
+      category: 'SIGN_IN_TO_CLASS'
+    });
+  }
+
+  ptap.registerTripEnd = function() {
+    console.log( "register tripEnd received!" );
+    // Android
+    $window.broadcaster.addEventListener("local.transition.stopped_moving", function( e ) {
+      showTripEndNotification();
+    });
+
+    // iOS
+    $window.broadcaster.addEventListener("TRANSITION_NAME", function( e ) {
+      console.log("Received TRANSITION_NAME event"+JSON.stringify(e));
+      showTripEndNotification();
+    });
+  }
+
+  return ptap;
+
+});

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -7,6 +7,7 @@ angular.module('emission.main', ['emission.main.recent',
                                  'emission.main.common',
                                  'emission.main.heatmap',
                                  'emission.main.metrics',
+                                 'emission.incident.posttrip.map',
                                  'emission.services'])
 
 .config(function($stateProvider, $ionicConfigProvider, $urlRouterProvider) {
@@ -69,6 +70,7 @@ angular.module('emission.main', ['emission.main.recent',
       }
     }
   })
+
   .state('root.main.sensed', {
     url: "/sensed",
     views: {
@@ -78,6 +80,7 @@ angular.module('emission.main', ['emission.main.recent',
       }
     }
   })
+
   .state('root.main.map', {
       url: "/map",
       views: {
@@ -87,15 +90,29 @@ angular.module('emission.main', ['emission.main.recent',
         }
       }
   })
+
+  .state('root.main.incident', {
+      url: "/incident",
+      params: {
+        start_ts: null,
+        end_ts: null
+      },
+      views: {
+        'main-control': {
+          templateUrl: "templates/incident/map.html",
+          controller: 'PostTripMapCtrl'
+        }
+      }
+  })
+
   .state('root.main.log', {
     url: '/log',
     views: {
-        'main-control': {
-          templateUrl: 'templates/recent/log.html',
-          controller: 'logCtrl'
-        }
+      'main-control': {
+        templateUrl: 'templates/recent/log.html',
+        controller: 'logCtrl'
+      }
     }
-
   });
 
   $ionicConfigProvider.tabs.style('standard')

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -47,7 +47,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
       // mark in native storage
       return readConsentState().then(writeConsentToNative).then(function(response) {
           // mark in local storage
-          storage.set(startprefs.DATA_COLLECTION_CONSENTED_PROTOCOL,
+          storage.set(DATA_COLLECTION_CONSENTED_PROTOCOL,
             $rootScope.req_consent);
           // mark in local variable as well
           $rootScope.curr_consented = angular.copy($rootScope.req_consent);
@@ -101,7 +101,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
                   $rootScope.req_consent = startupConfigResult.data.emSensorDataCollectionProtocol;
                   logger.log("required consent version = " + JSON.stringify($rootScope.req_consent));
                   $rootScope.curr_consented = storage.get(
-                    startprefs.DATA_COLLECTION_CONSENTED_PROTOCOL);
+                    DATA_COLLECTION_CONSENTED_PROTOCOL);
           });
       }
     }

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -45,10 +45,20 @@
       <div class="control-list-text">Check for UI updates</div>
       <div ng-click="checkUpdates()" class="control-icon-button"><i class="ion-android-download"></i></div>
     </div>
+
+    <div class="control-list-item">
+      <div class="control-list-text">Download json dump</div>
+      <div ng-click="openDatePicker()" class="control-icon-button">
+        <i class="ion-ios-calendar-outline" style="font-size: 16px !important;"></i>
+      </div>
+      <!-- <div ng-click="getMyData()" class="control-icon-button"><i class="ion-android-mail"></i></div> -->
+    </div>
+
     <div class="control-list-item">
       <div class="control-list-text">Email log</div>
       <div ng-click="emailLog()" class="control-icon-button"><i class="ion-android-mail"></i></div>
     </div>
+
     <div class="control-list-item" ng-show="userDataSaved()">
       <div class="control-list-text">User data</div>
       <div ng-click="toggleUserData()" class="control-icon-button"><i ng-class="getUserDataExpandButtonClass()" id="userDataButton"></i></div>

--- a/www/templates/diary/list.html
+++ b/www/templates/diary/list.html
@@ -4,9 +4,9 @@
                 <div class="buttons" style="text-align:center; background-color: transparent !important;" id="toget">
                     <button class="button button-icon icon ion-arrow-left-b date-picker-arrow" ng-click="prevDay()">
                     </button>
-                    <ionic-datepicker class="pickerdate" input-obj="datepickerObject" style="color: white;">
-                      <button class="button date-picker-button"> {{datepickerObject.inputDate | date:datepickerObject.dateFormat}} <i class="ion-ios-calendar-outline" style="font-size: 16px !important;"></i></button>
-                    </ionic-datepicker>
+                    <!-- <ionic-datepicker class="pickerdate" input-obj="datepickerObject" style="color: white;"> -->
+                    <button class="button date-picker-button" ng-click="pickDay()"> {{datepickerObject.inputDate | date:datepickerObject.dateFormat}} <i class="ion-ios-calendar-outline" style="font-size: 16px !important;"></i></button>
+                    <!-- </ionic-datepicker> -->
 
                     <button class="button button-icon icon ion-arrow-right-b ion-arrow-left-b date-picker-arrow" ng-click="nextDay()">
                     </button>

--- a/www/templates/incident/map.html
+++ b/www/templates/incident/map.html
@@ -1,0 +1,22 @@
+<ion-view style="" title="Map">
+    <ion-nav-title>{{ getFormattedDate(mapCtrl.start_ts) }}</ion-nav-title> 
+    <ion-content class="has-header" overflow-scroll="true" padding="true">
+        <div class="row" style="">
+            <div class="col-30">
+                <div style="font-size: 1em; padding-top: 5px; padding-bottom: 5px;">{{getFormattedTime(mapCtrl.start_ts)}}</div>
+                <div style="font-size: 1em; padding-top: 5px; padding-bottom: 5px;">{{getFormattedTime(mapCtrl.end_ts)}}
+                </div>
+            </div>
+            <div style="height: 10px;"></div>
+        </div>
+            <leaflet geojson="mapCtrl.geojson" id="incident" defaults="mapCtrl.defaults" 
+                height="75%" width="100%" data-tap-disabled="true">
+            </leaflet>
+        <div style="" class="button-bar">
+            <button class="button button-stable button-block icon ion-refresh"
+                ng-click="refreshWholeMap()">Refresh</button>
+            <button class="button button-stable button-block"
+                ng-click="refreshTiles()">Fix Map</button>
+        </div>
+    </ion-content>
+</ion-view>


### PR DESCRIPTION
- Add a new native plugin to generate callbacks on various state transitions
- Listen to the end trip transition and generate a notification
- If notification is clicked, display locations in a map to allow user to choose incident spot
- Add support for displaying locations in various stages of processing

Couple of minor, misc fixes/enhancements
- Add support for people to email their raw data to themselves, one week at a time (using the new support to read timeseries values directly)
- Upgrade the datepicker to the most recent version
- Fix the key used to store the consent in localstorage