### PR TITLE
Display unprocessed (draft) data in the diary as well

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -934,7 +934,7 @@ button.button.back-button.buttons.button-clear.header-item {
   background-color: #ffffff; 
 }
 .bg-unprocessed {
-  background-color: #22ee11; 
+  background-color: #9eb2aa; 
 }
 .list-card-sm {
   width: 95%;

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -924,11 +924,17 @@ button.button.back-button.buttons.button-clear.header-item {
   right: 16px;
   top: 16px;
 }
-.list-card-dark {
-  margin: 16px 0; background-color: #424242; box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
-}
 .list-card {
-  margin: 16px 0; background-color: #fff; box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  margin: 16px 0; box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+.bg-dark {
+  background-color: #424242; 
+}
+.bg-light {
+  background-color: #ffffff; 
+}
+.bg-unprocessed {
+  background-color: #22ee11; 
 }
 .list-card-sm {
   width: 95%;

--- a/www/js/control.js
+++ b/www/js/control.js
@@ -13,7 +13,7 @@ angular.module('emission.main.control',['emission.services',
                $state, $ionicPopup, $ionicActionSheet, $ionicPopover,
                $rootScope, storage, ionicDatePicker,
                StartPrefs, ControlHelper, UpdateCheck,
-               CalorieCal, ClientStats) {
+               CalorieCal, ClientStats, CommHelper) {
 
     var datepickerObject = {
       todayLabel: 'Today',  //Optional

--- a/www/js/diary/detail.js
+++ b/www/js/diary/detail.js
@@ -4,7 +4,7 @@ angular.module('emission.main.diary.detail',['ui-leaflet', 'ng-walkthrough',
                                       'emission.services', 'emission.plugin.logger',
                                       'emission.incident.posttrip.manual'])
 
-.controller("DiaryDetailCtrl", function($scope, $window, $stateParams, $ionicActionSheet,
+.controller("DiaryDetailCtrl", function($scope, $rootScope, $window, $stateParams, $ionicActionSheet,
                                         leafletData, leafletMapEvents, nzTour, storage,
                                         Logger, Timeline, DiaryHelper, Config,
                                         CommHelper, PostTripManualMarker) {
@@ -66,6 +66,10 @@ angular.module('emission.main.diary.detail',['ui-leaflet', 'ng-walkthrough',
   $scope.getTripDetails = DiaryHelper.getTripDetails
   $scope.tripgj = DiaryHelper.directiveForTrip($scope.trip);
 
+  $scope.getTripBackground = function() {
+     var ret_val = DiaryHelper.getTripBackground($rootScope.dark_theme, $scope.tripgj);
+     return ret_val;
+  }
 
   console.log("trip.start_place = " + JSON.stringify($scope.trip.start_place));
 

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -28,7 +28,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     // TODO: Convert the usercache calls into promises so that we don't have to
     // do this juggling
     Timeline.updateForDay(day);
-    CommonGraph.updateCurrent();
+    // CommonGraph.updateCurrent();
   };
 
   $scope.$on('$ionicView.afterEnter', function() {

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -36,6 +36,15 @@ angular.module('emission.main.diary.list',['ui-leaflet',
       readAndUpdateForDay($rootScope.barDetailDate);
       $rootScope.barDetail = false;
     };
+    if($rootScope.displayingIncident == true) {
+      if (angular.isDefined(Timeline.data.currDay)) {
+          // page was already loaded, reload it automatically
+          readAndUpdateForDay(Timeline.data.currDay);
+      } else {
+         Logger.log("currDay is not defined, load not complete");
+      }
+      $rootScope.displayingIncident == false;
+    }
   });
 
   readAndUpdateForDay(moment().startOf('day'));

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -43,7 +43,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
       } else {
          Logger.log("currDay is not defined, load not complete");
       }
-      $rootScope.displayingIncident == false;
+      $rootScope.displayingIncident = false;
     }
   });
 

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -158,7 +158,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     }
 
     $scope.$on(Timeline.UPDATE_DONE, function(event, args) {
-      console.log("Got event with args "+JSON.stringify(args));
+      console.log("Got timeline update done event with args "+JSON.stringify(args));
       $scope.$apply(function() {
           $scope.data = Timeline.data;
           $scope.datepickerObject.inputDate = Timeline.data.currDay.toDate();
@@ -172,7 +172,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     });
 
     $scope.$on(CommonGraph.UPDATE_DONE, function(event, args) {
-      console.log("Got event with args "+JSON.stringify(args));
+      console.log("Got common graph update done event with args "+JSON.stringify(args));
       $scope.$apply(function() {
           // If we don't have the trip wrappers yet, then we can just bail because
           // the counts will be filled in when that is done. If the currDayTripWrappers

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -91,13 +91,14 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     }
     $scope.datePickerClass = function() {
     }
-    $scope.listCardClass = function() {
+    $scope.listCardClass = function(tripgj) {
+      var background = DiaryHelper.getTripBackground($scope.dark_theme, tripgj);
       if ($window.screen.width <= 320) {
-        return ($scope.dark_theme)? "list card list-card-dark list-card-sm" : "list card list-card list-card-sm";
+        return "list card list-card "+ background +" list-card-sm";
       } else if ($window.screen.width <= 375) {
-        return ($scope.dark_theme)? "list card list-card-dark list-card-md" : "list card list-card list-card-md";
+        return "list card list-card "+ background +" list-card-md";
       } else {
-        return ($scope.dark_theme)? "list card list-card-dark list-card-lg" : "list card list-card list-card-lg";
+        return "list card list-card "+background+" list-card-lg";
       }
 
     }
@@ -268,9 +269,13 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     $scope.arrowColor = DiaryHelper.arrowColor;
     $scope.getArrowClass = DiaryHelper.getArrowClass;
     $scope.isCommon = DiaryHelper.isCommon;
+    $scope.isDraft = DiaryHelper.isDraft;
     // $scope.expandEarlierOrLater = DiaryHelper.expandEarlierOrLater;
     // $scope.increaseRestElementsTranslate3d = DiaryHelper.increaseRestElementsTranslate3d;
 
+    $scope.makeCurrent = function() {
+        $ionicPopup.alert({template: "Coming soon, after Shankari's quals in early March!"});
+    }
 
     $scope.userModes = [
         "walk", "bicycle", "car", "bus", "train", "unicorn"

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -393,7 +393,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
 
 })
 .factory('Timeline', function(CommHelper, $http, $ionicLoading, $window, $ionicPopup,
-    $rootScope, CommonGraph, UnifiedDataLoader) {
+    $rootScope, CommonGraph, UnifiedDataLoader, Logger) {
   var timeline = {};
     // corresponds to the old $scope.data. Contains all state for the current
     // day, including the indication of the current day
@@ -827,8 +827,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
     }
 
     var processOrDisplayNone = function(day, tripList) {
-      console.log("processOrDisplayName("+day+", "+tripList.length+") called");
-      if (tripList.length != 0) {
+      if (angular.isDefined(tripList) && tripList.length != 0) {
         console.log("trip count = "+tripList.length+", calling processTripsForDay");
         processTripsForDay(day, tripList);
       } else {
@@ -874,7 +873,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
         $ionicLoading.hide();
         localCacheReadFn(day).then(function(processedTripList) {
           var tripList = processedTripList;
-          timeline.readUnprocessedTrips(day, processedTripList)
+          return timeline.readUnprocessedTrips(day, processedTripList)
             .then(function(unprocessedTripList) {
               Logger.log("tripList.length = "+tripList.length
                          +"unprocessedTripList.length = "+unprocessedTripList.length);

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -683,6 +683,11 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
       }
     }
 
+    var tsEntrySort = function(e1, e2) {
+      // compare timestamps
+      return e1.data.ts - e2.data.ts;
+    }
+
     var trip2Geojson = function(trip) {
       var tripStartTransition = trip[0];
       var tripEndTransition = trip[1];
@@ -694,13 +699,14 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
         + moment.unix(tripStartTransition.data.ts).toString() + " -> " 
         + moment.unix(tripEndTransition.data.ts).toString());
       return UnifiedDataLoader.getUnifiedSensorDataForInterval("background/filtered_location", tq).then(function(locationList) {
-          var tripStartPoint = locationList[0];
-          var tripEndPoint = locationList[locationList.length-1];
+          var sortedLocationList = locationList.sort(tsEntrySort);
+          var tripStartPoint = sortedLocationList[0];
+          var tripEndPoint = sortedLocationList[sortedLocationList.length-1];
           Logger.log("tripStartPoint = "+JSON.stringify(tripStartPoint)+"tripEndPoint = "+JSON.stringify(tripEndPoint));
           var features = [
             place2Geojson(trip, tripStartPoint, startPlacePropertyFiller),
             place2Geojson(trip, tripEndPoint, endPlacePropertyFiller),
-            points2Geojson(trip, locationList)
+            points2Geojson(trip, sortedLocationList)
           ];
           var section_gj = features[2];
           var trip_gj = {
@@ -786,10 +792,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
             return [];
           } else {
             Logger.log("Found "+transitionList.length+" transitions. yay!");
-            var sortedTransitionList = transitionList.sort(function(t1, t2) {
-              // get the start transition for each trip and compare their timestamps
-              return t1.data.ts - t2.data.ts;
-            });
+            var sortedTransitionList = transitionList.sort(tsEntrySort);
             /*
             sortedTransitionList.forEach(function(transition) {
                 console.log(JSON.stringify(transition));

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -772,6 +772,9 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
        * Logic for start_ts described at
        * https://github.com/e-mission/e-mission-phone/issues/214#issuecomment-284312004
        */
+        $ionicLoading.show({
+          template: 'Reading unprocessed data...'
+        });
        if (tripListForDay.length == 0) {
          var last_processed_ts = moment(day).startOf("day").unix();
        } else {
@@ -823,6 +826,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
                     var last_processed_trip = tripListForDay[tripListForDay.length - 1]
                     linkTrips(last_processed_trip, trip_gj_list[0]);
                 }
+                $ionicLoading.hide();
                 return trip_gj_list;
             });
           }

--- a/www/js/incident/post-trip-manual.js
+++ b/www/js/incident/post-trip-manual.js
@@ -31,7 +31,9 @@ angular.module('emission.incident.posttrip.manual', ['emission.plugin.logger',
   var getSectionPoints = function(section) {
     Logger.log("Called getSection points with list of size "+section.geometry.coordinates.length);
     var mappedPoints = section.geometry.coordinates.map(function(currCoords, index) {
-      Logger.log("About to map point"+ JSON.stringify(currCoords)+" at index "+index);
+      if (index % 100 == 0) {
+        Logger.log("About to map point"+ JSON.stringify(currCoords)+" at index "+index);
+      }
       var currMappedPoint = {loc: currCoords,
         latlng: L.GeoJSON.coordsToLatLng(currCoords),
         ts: section.properties.times[index]}

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -127,11 +127,9 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
     });
     */
 
-    Logger.log("About to go to incident map page");
-    $state.go("root.main.control", notification.data).then(function(result) {
-       Logger.log("result of moving to control screen = "+result);
-       $state.go("root.main.incident", notification.data); 
-    });
+    Logger.log("About to go to diary, which now displays draft information");
+    $rootScope.displayingIncident = true;
+    $state.go("root.main.diary");
   };
 
   var checkCategory = function(notification) {
@@ -179,7 +177,6 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
           if (res == true) {
             Logger.log("About to go to incident map page");
             displayCompletedTrip(notification, state, data);
-            $state.go("root.main.incident", notification.data);
           } else {
             Logger.log("Skipped incident reporting");
           }

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('emission.services', [])
+angular.module('emission.services', ['emission.plugin.logger'])
 
 .service('CommHelper', function($http) {
     var getConnectURL = function(successCallback, errorCallback) {
@@ -154,7 +154,7 @@ angular.module('emission.services', [])
     //}*/
     }
 })
-.service('UnifiedDataLoader', function($window, CommHelper) {
+.service('UnifiedDataLoader', function($window, CommHelper, Logger) {
     var combineWithDedup = function(list1, list2) {
       var combinedList = list1.concat(list2);
       return combinedList.filter(function(value, i, array) {
@@ -183,7 +183,10 @@ angular.module('emission.services', [])
               if (localError && remoteError) {
                 reject([localError, remoteError]);
               } else {
+                Logger.log("About to dedup localResult = "+localResult.length
+                    +"remoteResult = "+remoteResult.length);
                 var dedupedList = combiner(localResult, remoteResult);
+                Logger.log("Deduped list = "+dedupedList.length);
                 resolve(dedupedList);
               }
             }

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -26,9 +26,11 @@ angular.module('emission.services', [])
         });
     };
 
-    this.getTimelineForDay = function(date, successCallback, errorCallback) {
-        var dateString = date.startOf('day').format('YYYY-MM-DD');
-        window.cordova.plugins.BEMServerComm.getUserPersonalData("/timeline/getTrips/"+dateString, successCallback, errorCallback);
+    this.getTimelineForDay = function(date) {
+        return new Promise(function(resolve, reject) {
+          var dateString = date.startOf('day').format('YYYY-MM-DD');
+          window.cordova.plugins.BEMServerComm.getUserPersonalData("/timeline/getTrips/"+dateString, resolve, reject);
+        });
     };
 
     /*

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -126,6 +126,13 @@ angular.module('emission.services', [])
           window.cordova.plugins.BEMServerComm.pushGetJSON("/datastreams/find_entries/timestamp", msgFiller, resolve, reject);
       });
     };
+
+    this.getPipelineCompleteTs = function() {
+      return new Promise(function(resolve, reject) {
+          console.log("getting pipeline complete timestamp");
+          window.cordova.plugins.BEMServerComm.getUserPersonalData("/pipeline/get_complete_ts", resolve, reject);
+      });
+    };
 })
 
 .service('ReferHelper', function($http) {
@@ -174,6 +181,16 @@ angular.module('emission.services', [])
     };
 
     this.getUnifiedMessagesForInterval = function(key, tq, withMetadata) {
+        return new Promise(function(resolve, reject) {
+          var localPromise = $window.cordova.plugins.BEMUserCache.getMessagesForInterval(key, tq, true);
+          var remotePromise = CommHelper.getRawEntries([key], tq.startTs, tq.endTs);
+          Promise.all([localPromise, remotePromise])
+            .then(function(resultList) {
+              var dedupedList = combineWithDedup(resultList[0], resultList[1].phone_data);
+              resolve(dedupedList);
+            })
+            .catch(reject);
+        })
     }
 })
 .service('ControlHelper', function($cordovaEmailComposer,

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -182,6 +182,9 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
           var temp = ReferralHandler.getReferralNavigation();
           if (temp == 'goals') {
             return 'root.main.goals';
+          } else if ($rootScope.displayingIncident == true) {
+            $rootScope.displayingIncident = false;
+            return 'root.main.diary';
           } else {
             return 'root.main.metrics';
           }

--- a/www/templates/diary/detail.html
+++ b/www/templates/diary/detail.html
@@ -1,9 +1,9 @@
-<ion-view style="">
+<ion-view ng-class="getTripBackground()">
     <ion-nav-title>{{ getFormattedDate(tripgj.data.properties.start_ts) }}</ion-nav-title> 
     <ion-nav-buttons side="right">
          <button class="button button-icon ion-help" ng-click="startWalkthrough()"></button>
     </ion-nav-buttons>
-    <ion-content class="has-header" overflow-scroll="true" padding="true">
+    <ion-content class="has-header" ng-class="getTripBackground" overflow-scroll="true" padding="true">
         <div class="row" style="">
 
             <div class="col-30">

--- a/www/templates/diary/list.html
+++ b/www/templates/diary/list.html
@@ -47,7 +47,7 @@
                 </div>
 
 
-                <div ng-class="listCardClass()">
+                <div ng-class="listCardClass(tripgj)">
                 <!-- <i class="icon ion-ios-star" style="font-size: 24px; position: absolute; right: 5px; top: 5px; color: {{ starColor(tripgj.common_count) }};"></i> -->
 
                 <div class="row">
@@ -61,6 +61,9 @@
                     <div ng-class="listColRightClass()">
                         <div>
                             <i class="{{mode}}" ng-repeat="mode in getPercentages(tripgj)[0]" style="font-size: 0.9em; margin-left: 0.4em; margin-right: 1em; margin-top: 0.2em;" ng-style="setColor(mode)"></i>
+                            <div ng-if="isDraft(tripgj)" ng-class="listTextClass()" style="font-size: 0.6em; margin-right: 0.4em;"> (draft) 
+                              <button ng-click="makeCurrent()" style="font-size: 0.6em;"> Update now </button>
+                            </div>
                         </div>
                         <div style="margin-top: -5px;">
                             <a ng-class="listTextClass()" ng-repeat="percentage in getPercentages(tripgj)[1]" style="font-size: 0.6em; margin-right: 0.4em;">{{percentage}}%</a>


### PR DESCRIPTION
This fixes #214.
Details in there.
High level design:
- read transitions after trip end
- walk through transitions and make trips
- for each trip, pull raw data
- convert this into a trip geojson
- add it to the existing geojson objects

The hardest part of this was the fiddly work of getting the geojson format consistent with the values sent from the server. But now we can potentially send only the trips instead of the full timeline for the day from the server to the client.