### PR TITLE
Support automatic redirection based on local notifications

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -69,6 +69,7 @@
     <script src="js/splash/updatecheck.js"></script>
     <script src="js/splash/startprefs.js"></script>
     <script src="js/splash/pushnotify.js"></script>
+    <script src="js/splash/localnotify.js"></script>
     <script src="js/controllers.js"></script>
     <script src="js/services.js"></script>
     <script src="js/intro.js"></script>

--- a/www/js/control.js
+++ b/www/js/control.js
@@ -268,6 +268,10 @@ angular.module('emission.main.control',['emission.services',
         });
     }
 
+    $scope.$on('$ionicView.afterEnter', function() {
+        $scope.refreshScreen();
+    })
+
     $scope.refreshScreen = function() {
         $scope.settings = {};
         $scope.settings.collect = {};

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -4,6 +4,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
                                         'emission.splash.startprefs',
                                         'emission.splash.referral',
                                         'emission.splash.pushnotify',
+                                        'emission.splash.localnotify',
                                         'emission.survey.launch',
                                         'emission.stats.clientstats',
                                         'emission.incident.posttrip.prompt',
@@ -15,7 +16,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope, 
     CustomURLScheme, UpdateCheck, StartPrefs, ReferralHandler, PushNotify,
-    ClientStats, PostTripAutoPrompt, SurveyLaunch)  {
+    LocalNotify, ClientStats, PostTripAutoPrompt, SurveyLaunch)  {
   console.log('SplashCtrl invoked');
   // alert("attach debugger!");
   // PushNotify.startupInit();

--- a/www/js/splash/localnotify.js
+++ b/www/js/splash/localnotify.js
@@ -1,0 +1,99 @@
+/*
+ * We think that a common pattern is to generate a prompt to notify the user
+ * about something and then to re-route them to the appropriate tab. An
+ * existing example is the notification prompt. So let's write a standard
+ * factory to make that easier.
+ */
+
+angular.module('emission.splash.localnotify', ['emission.plugin.logger',
+                                              'emission.splash.startprefs',
+                                              'angularLocalStorage'])
+.factory('LocalNotify', function($window, $ionicPlatform, $ionicPopup,
+    $state, $rootScope, storage,
+    Logger) {
+  var localNotify = {};
+
+  /*
+   * Return the state to redirect to, undefined otherwise
+   */
+  localNotify.getRedirectState = function(notification) {
+    // TODO: Think whether this should be in data or in category
+    if (angular.isDefined(notification.data)) {
+      return notification.data.redirectTo;
+    }
+    return undefined;
+  }
+
+  localNotify.handleLaunch = function(targetState) {
+    $rootScope.redirectTo = targetState;
+    $state.go(targetState);
+  }
+
+  localNotify.handlePrompt = function(notification, targetState) {
+    Logger.log("Prompting for notification "+notification.title+" and text "+notification.text);
+    var promptPromise = $ionicPopup.show({title: notification.title,
+        template: notification.text,
+        buttons: [{
+          text: 'Handle',
+          type: 'button-positive',
+          onTap: function(e) {
+            // e.preventDefault() will stop the popup from closing when tapped.
+            return true;
+          }
+        }, {
+          text: 'Ignore',
+          type: 'button-positive',
+          onTap: function(e) {
+            return false;
+          }
+        }]
+    });
+    promptPromise.then(function(handle) {
+      if (handle == true) {
+        localNotify.handleLaunch(targetState);
+      } else {
+        Logger.log("Ignoring notification "+notification.title+" and text "+notification.text);
+      }
+    });
+  }
+
+  localNotify.handleNotification = function(notification,state,data) {
+    var targetState = localNotify.getRedirectState(notification);
+    Logger.log("targetState = "+targetState);
+    if (angular.isDefined(targetState)) {
+      if (state == "foreground") {
+        localNotify.handlePrompt(notification, targetState);
+      } else {
+        localNotify.handleLaunch(targetState);
+      }
+    }
+  }
+
+  localNotify.registerRedirectHandler = function() {
+    Logger.log( "registerUserResponse received!" );
+    $window.cordova.plugins.notification.local.on('action', function (notification, state, data) {
+      localNotify.handleNotification(notification, state, data);
+    });
+    $window.cordova.plugins.notification.local.on('clear', function (notification, state, data) {
+        // alert("notification cleared, no report");
+    });
+    $window.cordova.plugins.notification.local.on('cancel', function (notification, state, data) {
+        // alert("notification cancelled, no report");
+    });
+    $window.cordova.plugins.notification.local.on('trigger', function (notification, state, data) {
+        Logger.log("triggered, no action");
+        if ($ionicPlatform.is('ios')) {
+          localNotify.handleNotification(notification, state, data);
+        }
+    });
+    $window.cordova.plugins.notification.local.on('click', function (notification, state, data) {
+      localNotify.handleNotification(notification, state, data);
+    });
+  }
+
+  $ionicPlatform.ready().then(function() {
+    localNotify.registerRedirectHandler();
+  });
+
+  return localNotify;    
+});

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -185,6 +185,10 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
           } else if ($rootScope.displayingIncident == true) {
             $rootScope.displayingIncident = false;
             return 'root.main.diary';
+          } else if (angular.isDefined($rootScope.redirectTo)) {
+            var redirState = $rootScope.redirectTo;
+            $rootScope.redirectTo = undefined;
+            return redirState;
           } else {
             return 'root.main.metrics';
           }


### PR DESCRIPTION
Support automatically redirecting to a new state when the user clicks on a
local notification of a particular form. This is used to navigate to the
profile screen when the user needs to login
(see https://github.com/e-mission/cordova-jwt-auth/pull/13 and in particular,
https://github.com/e-mission/cordova-jwt-auth/pull/13/commits/cfa54573fb611d1c82feeeecf1ec6ca8720450ad)

In addition, reload the page when navigating back to the control screen so that
the user can be seen to be logged in.