### PR TITLE
Add support for a trip-specific qualtrics survey

### DIFF
--- a/www/js/survey/launch.js
+++ b/www/js/survey/launch.js
@@ -21,11 +21,91 @@ angular.module('emission.survey.launch', ['emission.services',
             Logger.log("inserting user id into survey. userId = "+ uuid
                         +" element id = "+uuidElementId);
             var codeTemplate = scriptText.data;
-            var codeString = codeTemplate.replace("SCRIPT_REPLACE_UUID", uuid)
+            var codeString = codeTemplate.replace("SCRIPT_REPLACE_VALUE", uuid)
                                 .replace("SCRIPT_REPLACE_ELEMENT_ID", uuidElementId);
             $cordovaInAppBrowser.executeScript({ code: codeString });
           });
     };
+
+    var replace_time = function(tsElementId, fmtTimeElementId, ts, label) {
+        // we don't need to get the user because we have the timestamp right here
+        return Promise.all([$http.get("js/survey/time_insert.js")])
+          .then(function([scriptText]) {
+            // alert("finished loading script");
+            Logger.log(scriptText.data);
+            // I tried to use http://stackoverflow.com/posts/23387583/revisions
+            // for the idea on how to invoke the function in the script
+            // file, but the callback function was never invoked. So I edit the
+            // script file directly and insert the userId.
+            Logger.log("inserting ts into survey. ts = "+ ts
+                        +" element id = "+tsElementId
+                        +" fmtTime"+moment.unix(ts).format()
+                        +" element id = "+fmtTimeElementId);
+            var codeTemplate = scriptText.data;
+            var tsCodeString = codeTemplate.replace("SCRIPT_REPLACE_VALUE", ts)
+                                .replace("SCRIPT_REPLACE_ELEMENT_ID", tsElementId)
+                                .replace(/LABEL/g, label+"Ts");
+            Logger.log("After ts replace" + tsCodeString);
+            $cordovaInAppBrowser.executeScript({ code: tsCodeString });
+            var fmtTimeCodeString = codeTemplate.replace("SCRIPT_REPLACE_VALUE", moment.unix(ts).format())
+                                .replace("SCRIPT_REPLACE_ELEMENT_ID", fmtTimeElementId)
+                                .replace(/LABEL/g, label+"FmtTime");
+            Logger.log("After fmtTimeCode replace" + tsCodeString);
+            $cordovaInAppBrowser.executeScript({ code: fmtTimeCodeString });
+          });
+    };
+    
+
+    // BEGIN: startSurveyForCompletedTrip
+    surveylaunch.startSurveyForCompletedTrip = function (url, uuidElementId, 
+                                                         startTsElementId,
+                                                         endTsElementId,
+                                                         startFmtTimeElementId,
+                                                         endFmtTimeElementId,
+                                                         startTs,
+                                                         endTs) {
+      var options = {
+        location: 'no',
+        clearcache: 'no',
+        toolbar: 'yes'
+      };
+
+      // THIS LINE FOR inAppBrowser
+      $cordovaInAppBrowser.open(url, '_blank', options)
+          .then(function(event) {
+            console.log("successfully opened page with result "+JSON.stringify(event));
+            // success
+            Promise.all([replace_uuid(uuidElementId),
+                         replace_time(startTsElementId, startFmtTimeElementId, startTs, "Start"),
+                         replace_time(endTsElementId, endFmtTimeElementId, endTs, "End")])
+            .catch(function(error) { // catch for all promises
+              $ionicPopup.alert({"template": "Relaunching survey - while replacing uuid, got error "+ JSON.stringify(error)})
+              .then(function() {
+                surveylaunch.startSurvey(url, uuidElementId,
+                    startTsElementId, endTsElementId,
+                    startFmtTimeElementId, endTsElementId,
+                    startTs, endTs);
+              });
+            });
+          })
+          .catch(function(event) {
+            // error
+          });
+      $rootScope.$on('$cordovaInAppBrowser:loadstart', function(e, event) {
+        console.log("started loading, event = "+JSON.stringify(event));
+        /*
+        if (event.url == 'https://bic2cal.eecs.berkeley.edu/') {
+            $cordovaInAppBrowser.close();
+        }
+        */
+      });
+      $rootScope.$on('$cordovaInAppBrowser:exit', function(e, event) {
+        console.log("exiting, event = "+JSON.stringify(event));
+        // we could potentially restore the close-on-bic2cal functionality above
+        // if we unregistered here
+      });
+    }
+    // END: startSurveyForCompletedTrip
 
     surveylaunch.startSurvey = function (url, uuidElementId) {
       var options = {

--- a/www/js/survey/time_insert.js
+++ b/www/js/survey/time_insert.js
@@ -1,22 +1,22 @@
-var populateId = function(userId) {
-  var curriedPI = function() {
-    populateId(userId);
+var populateIdLABEL = function(time) {
+  var curriedPILABEL = function() {
+    populateIdLABEL(time);
   };
   if (document == null) {
 //     alert('document == '+document);
-     setTimeout(curriedPI, 1000);
+     setTimeout(curriedPILABEL, 1000);
   } else {
     var el = document.getElementById('SCRIPT_REPLACE_ELEMENT_ID');
 //    alert('document = '+document+ ' element = '+ el);
     if (el == null) {
 //      alert('element == null!');
-      setTimeout(curriedPI, 1000);
+      setTimeout(curriedPILABEL, 1000);
     } else {
-      el.value += userId;
+      el.value += time;
     }
   }
 };
 
 // alert("executing script");
-populateId('SCRIPT_REPLACE_VALUE');
+populateIdLABEL('SCRIPT_REPLACE_VALUE');
 // alert("done executing script");


### PR DESCRIPTION
Add support for launching a qualtrics survey with auto-completable start and
end times as well. This allows the survey results to be associated with trips
later.

We should really refactor `uuid_insert` and `time_insert` into a single file.
But given the tight schedule here, I copy to avoid regressions.
This should be fixed later.