### PR TITLE
Show choose mode and purpose prompt after the trip with the trip map

### DIFF
--- a/www/js/incident/post-trip-map-display.js
+++ b/www/js/incident/post-trip-map-display.js
@@ -207,7 +207,7 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet', 'ng-walkthrough',
   });
   /* END: ng-walkthrough code */
 
-   $scope.chosen = {mode:'',purpose:'',other:''};
+   $scope.chosen = {mode:'',purpose:'',other:'', other_to_store:''};
 
    var checkOtherOption = function(choice) {
     if(choice == 'other_mode' || choice == 'other_purpose') {
@@ -229,10 +229,10 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet', 'ng-walkthrough',
                            e.preventDefault();
                      } else {
                         if(choice == 'other_mode') {
-                          $scope.chosen.mode = $scope.chosen.other;
+                          $scope.chosen.other_to_store = $scope.chosen.other;
                           $scope.chosen.other = '';
                         } else {
-                          $scope.chosen.purpose = $scope.chosen.other;
+                          $scope.chosen.other_to_store = $scope.chosen.other;
                           $scope.chosen.other = '';
                         }
                         return $scope.chosen.other;
@@ -260,7 +260,12 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet', 'ng-walkthrough',
   $scope.secondSlide = false;
 
   $scope.nextSlide = function() {
-    if($scope.chosen.mode.length > 0){
+    if($scope.chosen.mode == "other_mode" && $scope.chosen.other_to_store.length > 0) {
+      $scope.secondSlide = true;
+      console.log($scope.chosen.other_to_store);
+      // store other_to_store here
+      $ionicSlideBoxDelegate.next();
+    } else if ($scope.chosen.mode != "other_mode" && $scope.chosen.mode.length > 0) {
       $scope.secondSlide = true;
       console.log($scope.chosen.mode);
       // store mode here
@@ -269,7 +274,11 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet', 'ng-walkthrough',
   };
 
   $scope.doneSlide = function() {
-    if($scope.chosen.purpose.length > 0){
+    if($scope.chosen.purpose == "other_purpose" && $scope.chosen.other_to_store.length > 0) {
+      console.log($scope.chosen.other_to_store);
+      // store other_to_store here
+      $scope.closeView();
+    } else if ($scope.chosen.purpose != "other_purpose" && $scope.chosen.purpose.length > 0) {
       console.log($scope.chosen.purpose);
       // store purpose here
       $scope.closeView();

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -123,7 +123,7 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
   var displayCompletedTrip = function(notification, state, data) {
     Logger.log("About to display completed trip");
 
-    /*
+    
     promptReport(notification, state, data).then(function(res) {
       if (res == true) {
         console.log("About to go to incident map page");
@@ -132,11 +132,11 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
         console.log("Skipped incident reporting");
       }
     });
-    */
+    
 
-    Logger.log("About to go to diary, which now displays draft information");
+    /*Logger.log("About to go to diary, which now displays draft information");
     $rootScope.displayingIncident = true;
-    $state.go("root.main.diary");
+    $state.go("root.main.diary");*/
   };
 
   var checkCategory = function(notification) {

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -93,13 +93,13 @@
     </div-->
 
 
-    <!--div class="control-list-item">
+    <div class="control-list-item">
       <div class="control-list-text">Developer zone</div>
       <div ng-click="expandDeveloperZone()" class="control-icon-button"><i ng-class="getExpandButtonClass()" id="expandButton"></i></div>
-    </div-->
+    </div>
 
     <!-- Begin developer zone -->
-    <!--div class="" ng-show="collectionExpanded()">
+    <div class="" ng-show="collectionExpanded()">
       <div class="control-list-item">
         <div class="control-list-text">Refresh</div>
         <div ng-click="refreshScreen()" class="control-icon-button"><i class="ion-refresh"></i></div>
@@ -170,6 +170,6 @@
         </ion-item>
       </ion-list>
 
-    </div-->
+    </div>
   </ion-content>
 </ion-view>

--- a/www/templates/incident/map.html
+++ b/www/templates/incident/map.html
@@ -2,25 +2,60 @@
     <ion-nav-buttons side="right">
       <button class="button button-icon ion-help" ng-click="startWalkthrough()"></button>
     </ion-nav-buttons>
-    <ion-nav-buttons side="left">
+    <!--ion-nav-buttons side="left">
       <button class="button button-icon ion-close" ng-click="closeView()"></button>
-    </ion-nav-buttons>
+    </ion-nav-buttons-->
     <ion-nav-title>{{ getFormattedDate(mapCtrl.start_ts) }}</ion-nav-title> 
     <ion-content class="has-header" overflow-scroll="true" padding="true">
-        <div class="row" style="text-align: center">
-            <div class="col-30" style="font-size: 1em; padding-top: 5px; padding-bottom: 5px;">{{getFormattedTime(mapCtrl.start_ts)}}</div>
-            <div class="col-30" style="font-size: 1em; padding-top: 5px; padding-bottom: 5px;"> &rarr; </div>
-            <div class="col-30" style="font-size: 1em; padding-top: 5px; padding-bottom: 5px;"> &nbsp; {{getFormattedTime(mapCtrl.end_ts)}} &nbsp; </div>
+        <div class="row" style="text-align: center;display: block;">
+            <div style="font-size: 1em;color: #303030;opacity: 0.7;">Recent trip from: {{getFormattedTime(mapCtrl.start_ts)}}  &rarr;  to: {{getFormattedTime(mapCtrl.end_ts)}}</div>
         </div>
         <div style="height: 10px;"></div>
             <leaflet geojson="mapCtrl.geojson" id="incident" defaults="mapCtrl.defaults" 
-                height="75%" width="100%" data-tap-disabled="true">
+                height="30%" width="100%" data-tap-disabled="true">
             </leaflet>
-        <div style="" class="button-bar">
+        <div class="row" style="height: 10px;width: 75%;margin: auto;margin-top: 10px;">
+            <div class="col-50" style="background-color: #01D0A7;margin: 2px;border-radius: 10%;"></div>
+            <div ng-if="!secondSlide" class="col-50" style="background-color: #A6A6A6;margin: 2px;border-radius: 10%;"></div>
+            <div ng-if="secondSlide" class="col-50" style="background-color: #01D0A7;margin: 2px;border-radius: 10%;"></div>
+        </div>
+         <ion-slide-box show-pager="false" ng-init="disableSwipe()" style="background: transparent !important;">
+            <ion-slide id="modes">
+                    <div style="padding: 5px; font-size: 1.25em;color: #303030;opacity: 0.7;">
+                    How did you get here?
+                    </div>
+                    <div style="height: 100%; padding-top: 10px;" >
+                        <ion-scroll style="height: 40%;" id=mode_list>
+                            <ion-list ng-repeat="mode in modeOptions">
+                                <ion-radio ng-click="chooseMode()" ng-model="chosen.mode" ng-value="mode.value" style="color: #585858 !important ;">{{mode.text}}</ion-radio>
+                            </ion-list>
+                        </ion-scroll>
+                    </div>
+            </ion-slide>
+            <ion-slide id="modes">
+                    <div style="padding: 5px;font-size: 1.25em;color: #303030;opacity: 0.7;">
+                    Why did you come here?
+                    </div>
+                    <div style="height: 100%;padding-top: 10px;">
+                        <ion-scroll style="height: 40%;">
+                            <ion-list ng-repeat="purpose in purposeOptions">
+                                <ion-radio ng-click="choosePurpose()" ng-value="purpose.value" ng-model="chosen.purpose" style="color: #585858 !important ;">{{purpose.text}}</ion-radio>
+                            </ion-list>
+                        </ion-scroll>
+                    </div>
+            </ion-slide>
+        </ion-slide-box>
+        <div style="text-align: center;width: 100%;position: absolute;left: 0;bottom: 0;" ng-if="!secondSlide">
+            <button style="width: 100%;color: #585858;border: 0px;" class="button" ng-click="nextSlide()">Continue</button>
+        </div>
+        <div style="text-align: center;width: 100%;position: absolute;left: 0;bottom: 0;" ng-if="secondSlide">
+            <button style="width: 100%;color: #585858;border: 0px;" class="button" ng-click="doneSlide()">Done</button>
+        </div>
+        <!--div style="" class="button-bar">
             <button class="button button-stable button-block icon ion-refresh"
                 ng-click="refreshWholeMap()">Refresh</button>
             <button class="button button-stable button-block"
                 ng-click="refreshTiles()">Fix Map</button>
-        </div>
+        </div-->
     </ion-content>
 </ion-view>


### PR DESCRIPTION
Changes done:
- Decreased the height of the map to fit the prompt
- Used slider to prompt choose mode and choose purpose.
- Unable to slide the slider unless user picks a mode and presses continue 
- After a mode is chosen, the slider slides to second prompt
- Store the mode and purpose only after user presses continue or done, not when they click one of the options in the radio list.
- The radio list is scrollable
- Walkthrough tells the user that the radio list is scrollable 

Testing done on both Android and iOS devices:
- Walkthrough highlights the radio list
- Mode and purpose stored to a variable, test done with console log 
- Tested on phones with different screen size

Screenshots:
<img width="377" alt="screen shot 2017-08-03 at 7 22 45 pm" src="https://user-images.githubusercontent.com/17379613/28952547-b821c406-7886-11e7-9387-b02ca48618a1.png">
<img width="376" alt="screen shot 2017-08-03 at 7 45 07 pm" src="https://user-images.githubusercontent.com/17379613/28952548-bdef605a-7886-11e7-9138-49eed8e7a005.png">
<img width="375" alt="screen shot 2017-08-03 at 7 45 25 pm" src="https://user-images.githubusercontent.com/17379613/28952549-bfd3dfcc-7886-11e7-8f74-c8e538529589.png">
<img width="375" alt="screen shot 2017-08-03 at 7 45 35 pm" src="https://user-images.githubusercontent.com/17379613/28952552-c4a15110-7886-11e7-8e95-56c357350e59.png">
<img width="376" alt="screen shot 2017-08-03 at 8 03 18 pm" src="https://user-images.githubusercontent.com/17379613/28952559-d2fb0102-7886-11e7-9d5a-15094ae3f62d.png">






