### PR TITLE
incident state show on main view

### DIFF
--- a/www/js/cci-about/about.js
+++ b/www/js/cci-about/about.js
@@ -2,8 +2,12 @@
 
 angular.module('emission.main.cci-about', ['emission.plugin.logger'])
 
-.controller('CCIAboutCtrl', function($scope, $state, $cordovaEmailComposer, $ionicPopup) {
+.controller('CCIAboutCtrl', function($scope, $state, $cordovaEmailComposer, $ionicPopup, $ionicNavBarDelegate) {
 
+  $scope.hideBackButton = function() {
+    $ionicNavBarDelegate.showBackButton(false);
+  };
+  
 	$scope.emailCCI = function() {
         var email = {
             to: ['cci@berkeley.edu'],

--- a/www/js/incident/post-trip-map-display.js
+++ b/www/js/incident/post-trip-map-display.js
@@ -195,7 +195,7 @@ angular.module('emission.incident.posttrip.map',['ui-leaflet', 'ng-walkthrough',
   }
 
   $scope.closeView = function () {
-    $state.go('root.main.control');
+    $state.go('root.main.cci-about');
   }
 
   $scope.$on('$ionicView.afterEnter', function(ev) {

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -109,7 +109,7 @@ angular.module('emission.main', ['emission.main.recent',
         end_ts: null
       },
       views: {
-        'main-control': {
+        'main-cci-about': {
           templateUrl: "templates/incident/map.html",
           controller: 'PostTripMapCtrl'
         }

--- a/www/templates/cci-about/about.html
+++ b/www/templates/cci-about/about.html
@@ -1,5 +1,5 @@
 <ion-view view-title="Welcome">
-	<ion-content>
+	<ion-content ng-init="hideBackButton()">
 		<img style="max-width: 100%;height: auto;width: auto\9; /* ie8 */" src="img/intro/splash.png">
 		<p style="font-size: 15px;text-align: center;padding: 5px 10px 5px 10px;">
 			Thank you for participating in our UCB study: Assessing the Travel Demand and Co-Benefit Impacts of Affordable Transit-Oriented Development!

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -93,13 +93,13 @@
     </div-->
 
 
-    <div class="control-list-item">
+    <!--div class="control-list-item">
       <div class="control-list-text">Developer zone</div>
       <div ng-click="expandDeveloperZone()" class="control-icon-button"><i ng-class="getExpandButtonClass()" id="expandButton"></i></div>
-    </div>
+    </div-->
 
     <!-- Begin developer zone -->
-    <div class="" ng-show="collectionExpanded()">
+    <!--div class="" ng-show="collectionExpanded()">
       <div class="control-list-item">
         <div class="control-list-text">Refresh</div>
         <div ng-click="refreshScreen()" class="control-icon-button"><i class="ion-refresh"></i></div>
@@ -170,6 +170,6 @@
         </ion-item>
       </ion-list>
 
-    </div>
+    </div-->
   </ion-content>
 </ion-view>


### PR DESCRIPTION
Changes done:
- Show incident in main view 
- Hid back button in main view, after the prompt is done users won't be able to go back to the prompt screen
- Disabled developer mode

Testing done:
- On Android
     - Started the trip, killed the app, and waited 5 minutes for the notification. The pop up shows up in main screen.
- On iOS:
     - Started the trip, manually stopped the trip, the pop up shows up and takes the user to prompt.