### PR TITLE
Using $rootScope.displayingIncident to fix startpref and notification race

### DIFF
--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -38,15 +38,6 @@ angular.module('emission.main.diary.list',['ui-leaflet',
       readAndUpdateForDay($rootScope.barDetailDate);
       $rootScope.barDetail = false;
     };
-    if($rootScope.displayingIncident == true) {
-      if (angular.isDefined(Timeline.data.currDay)) {
-          // page was already loaded, reload it automatically
-          readAndUpdateForDay(Timeline.data.currDay);
-      } else {
-         Logger.log("currDay is not defined, load not complete");
-      }
-      $rootScope.displayingIncident = false;
-    }
   });
 
   readAndUpdateForDay(moment().startOf('day'));

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -121,12 +121,9 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
   };
 
   var displayCompletedTrip = function(notification, state, data) {
-    Logger.log("About to display completed trip");
-    $rootScope.displayingIncident = true;
-    $state.go("root.main.incident", notification.data);
-    /*Logger.log("About to go to diary, which now displays draft information");
-    $rootScope.displayingIncident = true;
-    $state.go("root.main.diary");*/
+      $rootScope.displayingIncident = true;
+      Logger.log("About to display completed trip from Notification");
+      $state.go("root.main.incident", notification.data);
   };
 
   var checkCategory = function(notification) {

--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -122,6 +122,7 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
 
   var displayCompletedTrip = function(notification, state, data) {
     Logger.log("About to display completed trip");
+    $rootScope.displayingIncident = true;
     $state.go("root.main.incident", notification.data);
     /*Logger.log("About to go to diary, which now displays draft information");
     $rootScope.displayingIncident = true;

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -185,6 +185,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
           if (temp == 'goals') {
             return 'root.main.goals';
           } else if ($rootScope.displayingIncident == true) {
+            logger.log("Showing incident from startprefs");
             $rootScope.displayingIncident = false;
             return 'root.main.incident';
           } else if (angular.isDefined($rootScope.redirectTo)) {

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -186,7 +186,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
             return 'root.main.goals';
           } else if ($rootScope.displayingIncident == true) {
             $rootScope.displayingIncident = false;
-            return 'root.main.diary';
+            return 'root.main.incident';
           } else if (angular.isDefined($rootScope.redirectTo)) {
             var redirState = $rootScope.redirectTo;
             $rootScope.redirectTo = undefined;


### PR DESCRIPTION
Changes done:
- Added `$rootScope.displayingIncident` to `displayCompletedTrip` in notification to direct to incident screen, even if the startprefs.js runs after  post-trip-prompt.js 
- Removed `readAndUpdateForDay` if `$rootScope.displayingIncident` is true from list.js because `displayingIncident` is used for incident. If the app is not kill and is on list screen this code can `readAndUpdateForDay`

Testing:
- Will report when testing is done after deploy