### PR TITLE
Minor changes to get the cci berkeley refuse screen to work

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -124,17 +124,17 @@ angular.module('emission.main', ['emission.main.recent',
         controller: 'logCtrl'
       }
     }
-  });
+  })
 
   .state('root.main.refuse', {
     url: '/refuse',
     views: {
-      'refuse': {
+      'main-cci-about': {
         templateUrl: 'templates/intro/refuse.html',
-        controller: 'refuseCtrl'
+        controller: 'CCIAboutCtrl'
       }
     }
-  })
+  });
 
   $ionicConfigProvider.tabs.style('standard')
   $ionicConfigProvider.tabs.position('bottom');

--- a/www/templates/intro/refuse.html
+++ b/www/templates/intro/refuse.html
@@ -1,6 +1,8 @@
+<ion-view view-title="Refuse" class="ion-view-background">
 <ion-content>
 <div class="conset-title">
 Thank you for your participation.
 <div class="intro-space" href="#/root/main/refuse"></div>
 </div>
 </ion-content>
+</ion-view>


### PR DESCRIPTION
Minor changes to @jenny3248's PR https://github.com/e-mission/e-mission-phone/pull/283 to actually get it to work. Note that #283 includes the merges from master, so only @jenny3248's commits are relevant. Alternatively, look at the commits in #281 
- Change the new "refuse" state to use an existing view and controller
- Add an <ion-view> element to the refuse HTML