### PR TITLE
Remove unused code that breaks the file

### DIFF
--- a/www/js/cci-about/about.js
+++ b/www/js/cci-about/about.js
@@ -25,6 +25,4 @@ angular.module('emission.main.cci-about', ['emission.plugin.logger'])
                "CCI email cancel reported, seems to be an error on android");
         });
   };
-  var SURVEY_DONE_KEY = 'survey_done';
-  storage.remove(SURVEY_DONE_KEY);
 })


### PR DESCRIPTION
cannot use `storage` without adding it as a dependency