### PR TITLE
Follow-up fix to really change the email address for the cci study

### DIFF
--- a/www/js/cci-about/about.js
+++ b/www/js/cci-about/about.js
@@ -4,6 +4,8 @@ angular.module('emission.main.cci-about', ['emission.plugin.logger'])
 
 .controller('CCIAboutCtrl', function($scope, $state, $cordovaEmailComposer, $ionicPopup, SurveyLaunch) {
 
+  $scope.studyEmail = "cci.vmt@gmail.com";
+
   $scope.startSurvey = function () {
       SurveyLaunch.startSurvey('https://berkeley.qualtrics.com/jfe/form/SV_eQBjPXx10yaAScl', 'QR~QID3');
       startSurvey();
@@ -11,7 +13,7 @@ angular.module('emission.main.cci-about', ['emission.plugin.logger'])
 	
   $scope.emailCCI = function() {
         var email = {
-            to: ['cci@berkeley.edu'],
+            to: [$scope.studyEmail],
             subject: 'Question from Emission User',
             body: ''
         }

--- a/www/templates/cci-about/about.html
+++ b/www/templates/cci-about/about.html
@@ -14,7 +14,7 @@
 		</p>
 		<div id="call-cci" class="button icon icon-left ion-ios-telephone cci-contact-button">(510)-982-1731
         </div>
-		<button ng-click="emailCCI()" id="email-cci" class="button icon icon-left ion-email cci-contact-button">cci.vmt@gmail.com
+		<button ng-click="emailCCI()" id="email-cci" class="icon icon-left ion-email cci-contact-button">{{studyEmail}}
         </button>
 	</ion-content>
 </ion-view>


### PR DESCRIPTION
Original fix was 1394337f9f194e68f7f84285a3f2fbca028403df
Follow up:
- changes the destination email in the javascript as well
- removes the "button" class so that the email address is displayed
if the button class is retained and the email address has a `.` in it -
`cci.vmt@gmail.com`, the email address is not displayed on the screen.
I have no idea why this happens, but it is 100% reproducible