### PR TITLE
Create a new custom UI for zephyr

### DIFF
--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -15,6 +15,11 @@ angular.module('emission.intro', ['emission.splash.startprefs',
     url: '/reconsent',
     templateUrl: 'templates/intro/reconsent.html',
     controller: 'IntroCtrl'
+  })
+  .state('root.refuse', {
+    url: '/refuse',
+    templateUrl: 'templates/intro/refuse.html',
+    controller: 'IntroCtrl'
   });
 })
 
@@ -45,7 +50,7 @@ angular.module('emission.intro', ['emission.splash.startprefs',
   };
 
   $scope.disagree = function() {
-    $state.go('root.main.heatmap');
+    $state.go('root.refuse');
   };
 
   $scope.agree = function() {

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -192,7 +192,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
             $rootScope.redirectTo = undefined;
             return redirState;
           } else {
-            return 'root.main.metrics';
+            return 'root.main.control';
           }
         } else {
           return result;

--- a/www/templates/intro/consent.html
+++ b/www/templates/intro/consent.html
@@ -4,20 +4,23 @@
 </div>
 <div class="consent-text">
 <h3>Introduction and Purpose</h3>
-This app is part of a travel behavior research platform developed at the
-University of California, Berkeley. The platform development is being led by <a
+All data collected by this app will be sent to a public server that will make
+it available openly.  The server is maintained by <a
 href="http://www.cs.berkeley.edu/~shankari">K. Shankari</a> under the
 supervision of <a href="http://www.cs.berkeley.edu/~culler/">Prof. David
-Culler</a>. Our goal is to collect information from users about travel behavior
-across all modes, and use the aggregate information for better transportation
-infrastructure planning.
+Culler</a>. The data can be downloaded via standard REST APIs and be used for
+any purpose whatsoever. There is also a public ipython server that allows the
+world to explore the data directly. This open data, along with published
+notebooks that manipulate the data, will aid reproducibility. For more details,
+see https://github.com/e-mission/e-mission-server/blob/master/README.zephyr.md
 
 <h3>What we collect</h3>
-We automatically track your location, accelerometer, device-generated activity
-recognition, and battery usage. We also allow you to optionally enter your
-experiences and feedback during travel through the app. Since our code is
-open source, you can inspect the data that we collect in the background at
-<a
+If you leave the tracking on, we automatically track the phone's location,
+accelerometer, device-generated activity recognition, and battery usage. If you
+turn tracking off, we only track battery usage. We also allow you to optionally
+enter your experiences and feedback during travel through the app. Since our
+code is open source, you can inspect the data that we collect in the background
+at <a
 href="https://github.com/e-mission/e-mission-data-collection.git">https://github.com/e-mission/e-mission-data-collection.git</a>,
 explore the prompts for optional sentiment reporting at <a
 href="https://github.com/e-mission/e-mission-phone.git">https://github.com/e-mission/e-mission-phone.git</a>,
@@ -25,82 +28,27 @@ and see the analysis that we perform at <a
 href="https://github.com/e-mission/e-mission-server.git">https://github.com/e-mission/e-mission-server.git</a>
 
 <h3>How we associate it with you</h3>
-You log in to the app using a valid gmail address. We map the gmail address to
-a unique UUID and associate all collected data with the UUID. In general, the
-mapping between the email address and the UUID will only be made available to
-the lead researcher for the platform (Shankari). If you are not comfortable
-sharing your real gmail adress, you can create a fake one to use for this
-platform. The only reason we use an email address is so that we can ensure that
-your data is only available to somebody logged in as you, and remains available
-even if you switch phones.
+You log in to the app using label that you create. We map the label to a unique
+UUID and associate all collected data with the UUID. The mapping between the
+label and the UUID is publicly available, and any user can retrieve all data
+associated with a particular label. This is not secure against malicious users
+- since all labels are public, a malicious user can also send data with an
+existing label using the REST API. Ensure that your published notebooks always
+use time ranges for the data that you sent.
 
 <h3>Who gets to see it</h3>
-Individually identified, real-time data is only available to the lead
-researcher for the study (Shankari). The data may be shared for aggregate
-analysis under two scenarios as described below. It will not be used for
-marketing or advertising purposes.
-<ul>
-<li> Aggregate views of the collected data (both automatic and optional) that
-do not show individual trajectories (e.g. heatmaps) will be made publicly
-available through the platform website and on the phone app. You can explore
-this data on the "aggregate" tab of this app before consenting to data
-collection.
-<li> Time-delayed subsets of individual trajectory data, associated with their
-UUIDs but not email addresses, may by shared with collaborators, or released as
-research datasets to the community from time to time. If this is done, the time
-delay for sharing with collaborators will be at least one month, and the time
-delay for releasing to the community will be at least one year. Both
-collaborators and researchers will be asked to agree that they will publish
-only aggregate, non personally identifiable results, and will not re-share the
-data with others.
-</ul>
-
-<h3>Benefits and Compensation</h3>
-You will not be directly compensated for contributing your data to this
-platform.
-<p>
-However, we will use this information to provide you with a personalized travel
-profile that can be compared with the travel profiles of our other users, and
-with state and federal goals for daily exercise and GHG emission reduction. In
-addition, we will display aggregate travel patterns and aggregate crowdsourced
-safe/unsafe zones that you can use while making travel choices. You will have a
-chance to see the aggregate data generated before choosing to provide your own.
-
-<h3>Studies lead by other researchers</h3>
-If this platform is being used to collect data for a study conducted by another
-researcher, for example, from a Transportation Engineering Department, then you
-will be asked to assent to a separate document outlining the data association,
-retention and sharing policies for that study, <b>in addition to the policies
-above</b>. We will make all data, including the mapping between the email
-address and the UUID, directly available to the lead researcher for the main
-study. This will allow them to associate the automatically gathered information
-with demographic data, and any pre and post surveys that they conduct as part
-of their study. The other researcher may also choose to compensate you for your
-time, as described in the protocol document for that study.
-
-<h3>Your rights</h3>
-<b><i>Participation in research is completely voluntary</i></b>.  You have the
-right to decline to participate or to withdraw at any point in this study
-without penalty or loss of benefits to which you are otherwise entitled.
+The data is open and publicly available.
 
 <h3>Questions</h3>
-If you have any questions about this research, please feel free to contact us.
+If you have any questions about this platform, please feel free to contact us.
 For the quickest response, you can send email to the entire team at <a
 href="mailto:e-mission@lists.eecs.berkeley.edu">e-mission@lists.eecs.berkeley.edu</a>.
 If you want to contact only the lead researcher or the PI, you can use their
 profiles above.
 
-If you have any questions about your rights or treatment as a research
-participant using this platform, please contact the University of California at
-Berkeley's Committee for Protection of Human Subjects at 510-642-7461, or
-e-mail <a href="mailto:subjects@berkeley.edu">subjects@berkeley.edu</a>.
-
-If you agree to contribute your data to the platform, please click "I agree"
-below to proceed. If you do not wish to contribute your data to the platform,
-please click "I disagree" below to return to the aggregate views. This notice
-is also available <a
-href="https://e-mission.eecs.berkeley.edu/consent">online</a> in case you need
-to read it again in the future.
+If you agree to contribute your data publicly, please click "I agree"
+below to proceed. If you do not wish to contribute your data publicly,
+please click "I disagree" below to read the terms again.
 
 <div class="row" style="margin-top: 20px;">
   <div class="col" style="margin-right: 5px">

--- a/www/templates/intro/login.html
+++ b/www/templates/intro/login.html
@@ -3,12 +3,11 @@
 <center><h3>Login via google</h3></center></div>
 
 <div class="intro-text">
-Currently, we only support logging in via google, since they support techniques
-such as two factor authentication for greater security. Participants at UC
-Berkeley can choose to login using either their CalNet ID or a personal gmail
-account.
+Choose a label to associate with your data. In order to avoid conflicts, use
+your university, lab, or project name as part of the label (e.g.
+`ucb.sdb.android.1` or `nexus7itu01`)
 <div class="intro-space"></div>
-<button class="button button-block button-balanced" ng-click="login()">Login via Google</button>
+<button class="button button-block button-balanced" ng-click="login()">Create a label</button>
 </div>
 
 

--- a/www/templates/intro/refuse.html
+++ b/www/templates/intro/refuse.html
@@ -1,0 +1,10 @@
+<ion-view view-title="Refuse" class="ion-view-background">
+    <ion-content>
+        <div class="consent-title">
+        Too bad! If you'd like to tell us why you refused, please send email to 
+        the maintainer, <a href="http://www.cs.berkeley.edu/~shankari">K.  Shankari</a>, or her supervisor, <a href="http://www.cs.berkeley.edu/~culler/">Prof. David Culler</a>.  Otherwise, just uninstall the app.
+
+        Thank you for your consideration!
+        </div>
+    </ion-content>
+</ion-view>

--- a/www/templates/intro/summary.html
+++ b/www/templates/intro/summary.html
@@ -5,17 +5,14 @@
 	</div>
 	<!-- <div class="intro-space"></div> -->
 	<div class="intro-text">
-	E-Mission is designed to:
+	Zephyr is designed to:
 	<div class="intro-space"></div>
 	<ol>
-	<li> <b>Automatically calculate</b> your transportation carbon footprint and
-	compare it against California targets
+	<li> Collect <b>cross-platform</b> battery measurements
 	<div class="intro-space"></div>
-	<li> Give you <b>suggestions on how to change</b> your travel patterns to reduce your
-	footprint (coming soon)
+	<li> Use it to estimate differences in <b>SoCCR</b>
 	<div class="intro-space"></div>
-	<li> Provide <b>aggregate data on travel patterns</b> so that cities can improve their
-	land use and transportation planning.
+	<li> Evaluate <b>power/accuracy tradeoffs</b> under realistic conditions.
 	</ol>
 	</div>
 </ion-content>

--- a/www/templates/main.html
+++ b/www/templates/main.html
@@ -11,25 +11,25 @@ navigation history that also transitions its views in and out.
     <ion-nav-view name="main-diary"></ion-nav-view>
   </ion-tab>
 
-  <!-- Game Tab  -->
+  <!-- Game Tab
   <ion-tab title="Goals" icon="ion-android-checkbox" href="#/root/main/goals">
     <ion-nav-view name="main-goals"></ion-nav-view>
-  </ion-tab>
+  </ion-tab>  -->
 
   <!-- Common Patterns Tab
   <ion-tab title="Common" icon="ion-star" href="#/root/main/common/map">
     <ion-nav-view name="main-common"></ion-nav-view>
   </ion-tab> -->
 
-  <!-- Dashboard Tab -->
+  <!-- Dashboard Tab
   <ion-tab title="Dashboard" icon="ion-ios-analytics" href="#/root/main/metrics">
     <ion-nav-view name="main-metrics"></ion-nav-view>
-  </ion-tab>
+  </ion-tab> -->
 
-  <!-- Heatmap Tab -->
+  <!-- Heatmap Tab
   <ion-tab title="Heatmap" icon="ion-fireball" href="#/root/main/heatmap">
     <ion-nav-view name="main-heatmap"></ion-nav-view>
-  </ion-tab>
+  </ion-tab>  -->
 
   <!-- Debug Tab -->
 <!--   <ion-tab title="Recent" icon="ion-android-stopwatch" href="#/root/main/recent/log">


### PR DESCRIPTION
This is also a example of all the changes required to change the set of tabs in
the UI.

Concretely:
- Change the summary text (`www/templates/intro/summary.html`)
- Change the consent text (`www/templates/intro/consent.html`)
- Change the login text (`www/templates/intro/login.html`)
- Remove everything except the diary and control tabs (`www/templates/main.html`)

Changes due to modifying the set of tabs
- Change the startup tab to control/profile tab (`www/js/splash/startprefs.js`)
  https://github.com/e-mission/e-mission-phone/wiki/Changes-needed-when-the-set-of-tabs-changes#what-should-the-initial-tab-be
- Change the disagree behavior (`www/js/intro.js` and `www/templates/intro/refuse.html`)
  https://github.com/e-mission/e-mission-phone/wiki/Changes-needed-when-the-set-of-tabs-changes#what-to-do-if-the-user-disagrees

Since we just removed and did not add any tabs, we did not need to change the
list of states with personalized information.
https://github.com/e-mission/e-mission-phone/wiki/Changes-needed-when-the-set-of-tabs-changes#check-the-list-of-states-that-display-personalized-information