### PR TITLE
Unregister the trip listeners for cci

### DIFF
--- a/www/js/incident/post-trip-prompt.js
+++ b/www/js/incident/post-trip-prompt.js
@@ -59,19 +59,19 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
     return reportNotifyConfig;
   }
 
-  ptap.registerTripEnd = function() {
-    Logger.log( "registertripEnd received!" );
+  ptap.unregisterTripEnd = function() {
+    Logger.log( "unregistertripEnd received!" );
     // iOS
     var notifyPlugin = $window.cordova.plugins.BEMTransitionNotification;
-    notifyPlugin.addEventListener(notifyPlugin.TRIP_END, getTripEndReportNotification())
+    notifyPlugin.removeEventListener(notifyPlugin.TRIP_END, getTripEndReportNotification())
         .then(function(result) {
             // $window.broadcaster.addEventListener("TRANSITION_NAME",  function(result) {
-            Logger.log("Finished registering "+notifyPlugin.TRIP_END+" with result "+JSON.stringify(result));
+            Logger.log("Finished unregistering "+notifyPlugin.TRIP_END+" with result "+JSON.stringify(result));
         })
         .catch(function(error) {
             Logger.log(JSON.stringify(error));
             $ionicPopup.alert({
-                title: "Unable to register notifications for trip end",
+                title: "Unable to unregister notifications for trip end",
                 template: JSON.stringify(error)
             });
         });;
@@ -134,8 +134,8 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
     }
   }
 
-  ptap.registerUserResponse = function() {
-    Logger.log( "registerUserResponse received!" );
+  ptap.unregisterUserResponse = function() {
+    Logger.log( "unregisterUserResponse received!" );
     $window.cordova.plugins.notification.local.on('action', function (notification, state, data) {
       if (!checkCategory(notification)) {
           Logger.log("notification "+notification+" is not an mode choice, returning...");
@@ -192,13 +192,14 @@ angular.module('emission.incident.posttrip.prompt', ['emission.plugin.logger'])
   };
 
   /*
-   * Commenting out the post-trip notification for cci-berkeley
-   * because they want to make it opt-in
+   * Unregister the post-trip notification for cci-berkeley
+   * because they want to make it opt-in. Since the base app registers by
+   * default, we need to explicitly unregister, not just comment out.
+   */
   $ionicPlatform.ready().then(function() {
-    ptap.registerTripEnd();
-    ptap.registerUserResponse();
+    ptap.unregisterTripEnd();
+    ptap.unregisterUserResponse();
   });
-  */
 
   return ptap;
 

--- a/www/js/splash/localnotify.js
+++ b/www/js/splash/localnotify.js
@@ -70,7 +70,7 @@ angular.module('emission.splash.localnotify', ['emission.plugin.logger',
   }
 
   localNotify.registerRedirectHandler = function() {
-    Logger.log( "registerUserResponse received!" );
+    Logger.log( "registerRedirectHandler received!" );
     $window.cordova.plugins.notification.local.on('action', function (notification, state, data) {
       localNotify.handleNotification(notification, state, data);
     });


### PR DESCRIPTION
It is insufficient to merely skip the register, since the base version will
register by default. So if we switch to cci after the base version is launched,
then we will still get notifications. Instead, we need to actually unregister
any registered values.