### PR TITLE
Ensure that the L+ version has the biggest code

### DIFF
--- a/bin/sign_and_align_keys.sh
+++ b/bin/sign_and_align_keys.sh
@@ -6,7 +6,8 @@ if [[ $# -eq 0 ]]; then
 fi
 
 # Sign and release the L+ version
-cordova build android --release -- --minSdkVersion=21
+# Make sure the highest supported version has the biggest version code
+cordova build android --release -- --minSdkVersion=21 --gradleArg=-PcdvVersionCode=${1}9
 cp platforms/android/build/outputs/apk/release/android-release-unsigned.apk platforms/android/build/outputs/apk/android-L+-release-signed-unaligned.apk
 jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-L+-release-signed-unaligned.apk androidproductionkey
 ~/Library/Android/sdk/build-tools/27.0.3/zipalign -v 4 platforms/android/build/outputs/apk/android-L+-release-signed-unaligned.apk emission-L+-build-$1.apk
@@ -14,19 +15,26 @@ jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infras
 # Re-add the plugin
 cordova plugin add cordova-plugin-crosswalk-webview
 
-# Remove the game screen
-rm -r www/common
-cp www/templates/main.html.nogame www/templates/main.html
+# Copy the workaround to make it ready to build with gradle
+cp bin/xwalk6-workaround.gradle platforms/android/cordova-plugin-crosswalk-webview
+python bin/gradle_workaround.py -a
 
-# Rebuild the backup generic apk
-cordova build android --release -- --gradleArg=-PcdvVersionCode=${1}0
+# Rebuild the entries with crosswalk
+cordova build android --release
 
-# Sign and release generic pre-L+ version
-cp platforms/android/build/outputs/apk/release/android-release-unsigned.apk platforms/android/build/outputs/apk/android-pre-L-release-signed-unaligned.apk
-jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-pre-L-release-signed-unaligned.apk androidproductionkey
-~/Library/Android/sdk/build-tools/27.0.3/zipalign -v 4 platforms/android/build/outputs/apk/android-pre-L-release-signed-unaligned.apk emission-pre-L-build-$1.apk
+# Sign and release arm7
+cp platforms/android/build/outputs/apk/armv7/release/android-armv7-release-unsigned.apk platforms/android/build/outputs/apk/android-arm7-release-signed-unaligned.apk
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-arm7-release-signed-unaligned.apk androidproductionkey
+~/Library/Android/sdk/build-tools/27.0.3/zipalign -v 4 platforms/android/build/outputs/apk/android-arm7-release-signed-unaligned.apk emission-arm7-build-$1.apk
+ 
+# Sign and release x86
+cp platforms/android/build/outputs/apk/x86/release/android-x86-release-unsigned.apk platforms/android/build/outputs/apk/android-x86-release-signed-unaligned.apk
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/build/outputs/apk/android-x86-release-signed-unaligned.apk androidproductionkey
+~/Library/Android/sdk/build-tools/27.0.3/zipalign -v 4 platforms/android/build/outputs/apk/android-x86-release-signed-unaligned.apk emission-x86-build-$1.apk
 
-# Re-remove the plugin
+# Remove the plugin
 cordova plugin remove cordova-plugin-crosswalk-webview
-git checkout HEAD www/common
-git checkout www/templates/main.html
+
+# Remove the build workarounds
+python bin/gradle_workaround.py -r
+rm platforms/android/cordova-plugin-crosswalk-webview/xwalk6-workaround.gradle

--- a/bin/xwalk6-workaround.gradle
+++ b/bin/xwalk6-workaround.gradle
@@ -1,0 +1,3 @@
+android { 
+    flavorDimensions "default"
+} 


### PR DESCRIPTION
Consistent with the multi-APK documentation, change the android build so that
the L+ version is base+9, while the native pre-L versions are base+2 and
base+4.

This also means that we can do native versions of pre-L and don't have to
remove the game functionality. We need to check in a new gradle build file to avoid the flavors error.
https://stackoverflow.com/a/47418102/4040267