### PR TITLE
Switch to the old build system so that cordova can continue to work

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "release": {
+      "buildFlag": [
+        "-UseModernBuildSystem=0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is the e-mission-phone equivalent of
https://github.com/e-mission/e-mission-base/pull/13

With this change, I still cannot build from the command line - the build
terminates after

```
Building project: /Users/shankari/e-mission/e-mission-phone/platforms/ios/emission.xcworkspace
	Configuration: Debug
	Platform: emulator
Build settings from command line:
...
i    PODS_BUILD_DIR = $BUILD_DIR
    PODS_CONFIGURATION_BUILD_DIR = $PODS_BUILD_DIR/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
    PODS_PODFILE_DIR_PATH = ${SRCROOT}/.
    PODS_ROOT = ${SRCROOT}/Pods
    SWIFT_OBJC_BRIDGING_HEADER = $(PROJECT_DIR)/$(PROJECT_NAME)/Bridging-Header.h

(emission) C02KT61MFFT0:e-mission-phone shankari$ ^Ap^An
```

I am not quite sure why since the base app builds fine. But this does build
properly using the Xcode UI. Will experiment with this some more, otherwise
just document in the `README` and move on