### PR TITLE
Import fixes to the plugin javascript

### DIFF
--- a/www/js/control/collect-settings.js
+++ b/www/js/control/collect-settings.js
@@ -128,11 +128,13 @@ angular.module('emission.main.control.collection', [])
 
     cch.forceTransition = function(transition) {
         cch.forceTransitionWrapper(transition).then(function(result) {
-            $rootScope.$broadcast('control.update.complete', 'forceTransition');
-            $ionicPopup.alert({template: 'success -> '+result});
+            $ionicPopup.alert({template: 'success -> '+result}).then(function() {
+                $rootScope.$broadcast('control.update.complete', 'forceTransition');
+            });
         }, function(error) {
-            $rootScope.$broadcast('control.update.complete', 'forceTransition');
-            $ionicPopup.alert({template: 'error -> '+error});
+            $ionicPopup.alert({template: 'error -> '+error}).then(function() {
+                $rootScope.$broadcast('control.update.complete', 'forceTransition');
+            });
         });
     };
 
@@ -171,7 +173,7 @@ angular.module('emission.main.control.collection', [])
             if (ionic.Platform.isIOS()) {
                 cch.new_config.accuracy = cch.accuracyOptions["kCLLocationAccuracyBest"];
             } else if (ionic.Platform.isAndroid()) {
-                accuracy = cch.accuracyOptions["PRIORITY_HIGH_ACCURACY"];
+                cch.new_config.accuracy = cch.accuracyOptions["PRIORITY_HIGH_ACCURACY"];
             }
         } else {
             if (ionic.Platform.isIOS()) {


### PR DESCRIPTION
The plugin javascript is not checked in to `www/js` for obvious reasons.
But we need it in the www directory that is downloaded for ionic.
So we copy it over and check it into this new branch.
As we make changes to the plugin javascript, we need to reflect it here.