### PR TITLE
Broke up the output further in line with changes on emission/core/wra…

### DIFF
--- a/www/js/diary/detail.js
+++ b/www/js/diary/detail.js
@@ -54,8 +54,10 @@ angular.module('emission.main.diary.detail',['ui-leaflet', 'ng-walkthrough',
     CommHelper.getSingleTripSuggestion($stateParams.tripId).then(function(result) {
       console.log(result);
       $ionicLoading.hide();
-      $scope.name = result.message;
-      $scope.mode = result.method;
+      $scope.message = result.message;
+      $scope.question = result.question;
+      $scope.loc = result.suggested_loc;
+      $scope.mode = "Also try " + result.method + " instead.";
       $scope.bid = result.businessid;
       $scope.stars = result.rating;
     }).catch(function(err) {

--- a/www/js/recommendations.js
+++ b/www/js/recommendations.js
@@ -10,10 +10,13 @@ angular.module('emission.main.recommendations',['emission.services', 'emission.p
                                 $window, $http, $ionicPopup, $timeout, storage, ReferralHandler, ReferHelper, Logger, $cordovaInAppBrowser, SurveyLaunch) {
 
 
-    $scope.name = "Cannot Retrieve Suggestion";
+    $scope.message = "Cannot Retrieve Suggestion, Please Refresh";
+    $scope.question = "";
+    $scope.loc = "";
     $scope.mode = "Cannot Retrieve Mode";
     $scope.bid = "yalis-stanley-hall-cafe-berkeley";
     $scope.stars = 4.5;
+    $scope.rating = "";
     $http.get('json/yelpfusion.json').then(function(result) {
           $scope.yelp = result.data;
         }
@@ -47,10 +50,13 @@ angular.module('emission.main.recommendations',['emission.services', 'emission.p
       CommHelper.getSuggestion().then(function(result) {
         $ionicLoading.hide();
         console.log(result);
-        $scope.name = result.message;
-        $scope.mode = result.method;
+        $scope.message = result.message;
+        $scope.question = result.question;
+        $scope.loc = result.suggested_loc;
+        $scope.mode = "Also try " + result.method + " instead";
         $scope.bid = result.businessid;
         $scope.stars = result.rating;
+        $scope.rating = "img/small/small_"+$scope.stars+".png";
      }).catch(function(err) {
       console.log("Error while getting suggestion" + err);
     });

--- a/www/templates/diary/detail.html
+++ b/www/templates/diary/detail.html
@@ -47,16 +47,11 @@
 
         <!--
          <div id="sectionList" class="col button-small">
-
               <div class="row" ng-repeat="section in trip.sections" style="padding: 2px; border-bottom-width: 1px; border-bottom-style: solid; border-bottom-color: #eeeeee; margin-top: 15px;">
                   <div class="col" style="font-size: 15px;line-height: 15px; margin-left:20px;"><p style="margin-bottom: 0; font-weight: 500;">{{getFormattedTime(section.properties.start_ts)}}</p><p>{{getFormattedTimeRange(section.properties.end_ts, section.properties.start_ts)}}</p>
-
                   </div>
-
-
                   <div class="col" style="font-size: 22px;">{{getFormattedDistance(section.properties.distance)}} km</div>
                   <div class="col" style="text-align: center"><i class="{{getIcon(section)}}", style="font-size: 25px;"></i></div>
-
               </div>
           </div>
           -->
@@ -67,15 +62,24 @@
                 ng-click="refreshMap()">Refresh</button>
             <button class="button button-stable button-block"
                 ng-click="getIndividualSuggestion()">Get Suggestion</button>
+<<<<<<< HEAD
             <button class="button button-stable button-block"
                 ng-click="clickReview()">Get Reviews</button>
+=======
+>>>>>>> 525d42a... Broke up the output further in line with changes on emission/core/wrapper/suggestion_sys.py
         </div>
         <div class = "grid_layout">
           <div class = "grid_item" id = "suggestion_title"> Suggestion </div>
           <div class = "grid_item" id = "mode_title"> Mode </div>
-          <div class = "grid_item"> {{name}} </div>
+          <div class = "grid_item">
+            {{message}}<br />
+            {{question}}<br />
+            {{loc}}<br />
+            {{loc}}
+          </div>
           <div class = "grid_item"> {{mode}} </div>
         </div>
+<<<<<<< HEAD
         <div align="left">
             <h4>Reviews<br /></h4>
             <img src="img/small/small_{{stars}}.png" width="75" /><br />
@@ -85,5 +89,7 @@
           </li>
            </div>
               <button class="button button-block button-balanced button-outline back" ng-click="clickX()">Back</button>
+=======
+>>>>>>> 525d42a... Broke up the output further in line with changes on emission/core/wrapper/suggestion_sys.py
     </ion-content>
 </ion-view>

--- a/www/templates/diary/detail.html
+++ b/www/templates/diary/detail.html
@@ -60,13 +60,14 @@
         <div style="" class="button-bar">
             <button class="button button-stable button-block icon ion-refresh"
                 ng-click="refreshMap()">Refresh</button>
-            <button class="button button-stable button-block"
-                ng-click="getIndividualSuggestion()">Get Suggestion</button>
-<<<<<<< HEAD
-            <button class="button button-stable button-block"
-                ng-click="clickReview()">Get Reviews</button>
-=======
->>>>>>> 525d42a... Broke up the output further in line with changes on emission/core/wrapper/suggestion_sys.py
+        </div>
+        <div style="" class="button-bar">
+          <button class="button button-stable button-block"
+              ng-click="getIndividualSuggestion()">Get Suggestion</button>
+        </div>
+        <div style="" class="button-bar">
+          <button class="button button-stable button-block"
+              ng-click="clickReview()">Get Reviews</button>
         </div>
         <div class = "grid_layout">
           <div class = "grid_item" id = "suggestion_title"> Suggestion </div>
@@ -74,22 +75,17 @@
           <div class = "grid_item">
             {{message}}<br />
             {{question}}<br />
-            {{loc}}<br />
             {{loc}}
           </div>
           <div class = "grid_item"> {{mode}} </div>
         </div>
-<<<<<<< HEAD
         <div align="left">
-            <h4>Reviews<br /></h4>
-            <img src="img/small/small_{{stars}}.png" width="75" /><br />
-            <li ng-repeat='r in revs'>
-            {{r.text}}
-            <img src="img/small/small_{{r.rating}}.png" width="50" /> - {{r.user.name}}
-          </li>
-           </div>
-              <button class="button button-block button-balanced button-outline back" ng-click="clickX()">Back</button>
-=======
->>>>>>> 525d42a... Broke up the output further in line with changes on emission/core/wrapper/suggestion_sys.py
+           <h4>Reviews<br /></h4>
+           <img src={{rating}} width="75" /><br />
+           <li ng-repeat='r in revs'>
+           {{r.text}}
+           <img src="img/small/small_{{r.rating}}.png" width="50" /> - {{r.user.name}}
+         </li>
+       </div>
     </ion-content>
 </ion-view>

--- a/www/templates/main-recommendations.html
+++ b/www/templates/main-recommendations.html
@@ -12,9 +12,11 @@
      <center><div id="dashboard-recommend" class="card">
        <h4 class="dashboard-headers"> Current Recommendation </h4>
        <h4>
-         {{name}}<br />
+         {{message}}<br />
+         {{question}}<br />
+         {{loc}}<br />
          {{mode}}<br />
-           <img src="img/small/small_{{stars}}.png" width="75" />
+           <img src="{{rating}}" width="75" />
              <button class="button button-block button-balanced button-outline" ng-click="clickReview(0)">Reviews</button>
          </h4>
      </div></center>
@@ -23,7 +25,7 @@
      <div class="modal-content">
        <div align="left">
        <h4>Reviews<br /></h4>
-       <img src="img/small/small_{{stars}}.png" width="75" /><br />
+       <img src={{rating}} width="75" /><br />
        <li ng-repeat='r in revs'>
        {{r.text}}
        <img src="img/small/small_{{r.rating}}.png" width="50" /> - {{r.user.name}}
@@ -45,4 +47,3 @@
   </script>
 
 </ion-content>
-</ion-view>


### PR DESCRIPTION
…pper/suggestion_sys.py
- Broke up messages in accordance with changes on server, message now more detailed and controlled from clientside:
Testing Done:
Client w/o Suggestion (error message)
<img width="375" alt="Screen Shot 2019-04-20 at 2 09 23 AM" src="https://user-images.githubusercontent.com/35517530/56456031-4ab2a800-631b-11e9-9f74-5142c146d15f.png">
<img width="375" alt="Screen Shot 2019-04-20 at 2 09 30 AM" src="https://user-images.githubusercontent.com/35517530/56456032-4f775c00-631b-11e9-8ca1-da327f8e3d85.png">
On Diary Page:
<img width="375" alt="Screen Shot 2019-04-20 at 2 15 57 AM" src="https://user-images.githubusercontent.com/35517530/56456034-5605d380-631b-11e9-8661-4db0b91a0642.png">
With Hard-coded test suggestion:
<img width="375" alt="Screen Shot 2019-04-20 at 2 26 57 AM" src="https://user-images.githubusercontent.com/35517530/56456044-70d84800-631b-11e9-8a84-a521ee21929e.png">
Reviews:
<img width="375" alt="Screen Shot 2019-04-20 at 2 30 25 AM" src="https://user-images.githubusercontent.com/35517530/56456047-79c91980-631b-11e9-99e6-d560c3080601.png">
On Diary:
<img width="375" alt="Screen Shot 2019-04-20 at 2 33 54 AM" src="https://user-images.githubusercontent.com/35517530/56456049-82215480-631b-11e9-87cc-f7c900d7d13d.png">
Reviews:
<img width="375" alt="Screen Shot 2019-04-20 at 2 34 06 AM" src="https://user-images.githubusercontent.com/35517530/56456054-8baabc80-631b-11e9-9412-b673c4da406b.png">



:
