### PR TITLE
Fix the stupid force sync issue

### DIFF
--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -314,7 +314,7 @@ angular.module('emission.main.control',['emission.services',
             // only have one entry for the battery, which is the one that was
             // inserted on the last successful push.
             var isTripEnd = function(entry) {
-                if (entry.metadata.key == getEndTransition()) {
+                if (entry.metadata.key == getEndTransitionKey()) {
                     return true;
                 } else {
                     return false;


### PR DESCRIPTION
Now that we have checked in https://github.com/e-mission/e-mission-phone/commit/11734545c7b9283beeb72c63899763091363ae98 we can see the real error with the force sync.
And a simple `getEndTransition` -> `getEndTransitionKey` fixes it!