### PR TITLE
One-line fix to fix one place we weren't passing in the metric2val

### DIFF
--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -850,7 +850,7 @@ angular.module('emission.main.metrics',['nvd3', 'emission.services', 'ionic-date
     }
 
     var getSummaryDataRaw = function(metrics, metric) {
-        var data = getDataFromMetrics(metrics);
+        var data = getDataFromMetrics(metrics, metric2valUser);
         for (var i = 0; i < data.length; i++) {
           var temp = 0;
           for (var j = 0; j < data[i].values.length; j++) {


### PR DESCRIPTION
Fix stupid bug introduced by 21cb9d73b0c117dc8d4357e4ff3bb893bdae5aa5
When I unified the implementations, I ensured that all calls to
getDataForMetrics passed in a metric2val function. However, I had inadvertently
deleted `getSummaryRaw` when I deleted the duplicate function, so that got
missed. I restored it during testing, but I forgot to change the
`getDataForMetrics`. And when I did the final testing, I tested the aggregate
code path and assumed that everything worked since the code paths were unified.

I should have tested the user specific code path too, since it calls
`getSummaryRaw` which needs to now call `getDataForMetrics` with the correct
`metrics2val` function.

Fixed and tested.