### PR TITLE
Another potential fix for the race in displaying the trip confirmation

### DIFF
--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -754,6 +754,11 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
 
           var filteredLocationList = sortedLocationList.filter(retainInRange);
 
+          // Fix for https://github.com/e-mission/e-mission-docs/issues/417
+          if (filteredLocationList.length == 0) {
+            return undefined;
+          }
+
           var tripStartPoint = filteredLocationList[0];
           var tripEndPoint = filteredLocationList[filteredLocationList.length-1];
           Logger.log("tripStartPoint = "+JSON.stringify(tripStartPoint)+"tripEndPoint = "+JSON.stringify(tripEndPoint));

--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -166,20 +166,21 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
         if (result == null) {
           var temp = ReferralHandler.getReferralNavigation();
           if (temp == 'goals') {
-            return 'root.main.goals';
-          } else if ($rootScope.displayingIncident == true) {
+            return {state: 'root.main.goals', params: {}};
+          } else if ($rootScope.tripConfirmParams) {
             logger.log("Showing tripconfirm from startprefs");
-            $rootScope.displayingIncident = false;
-            return 'root.main.tripconfirm';
+            var startEndParams = $rootScope.tripConfirmParams;
+            $rootScope.tripConfirmParams = angular.undefined;
+            return {state: 'root.main.tripconfirm', params: startEndParams};
           } else if (angular.isDefined($rootScope.redirectTo)) {
             var redirState = $rootScope.redirectTo;
             $rootScope.redirectTo = undefined;
-            return redirState;
+            return {state: redirState, params: {}};
           } else {
-            return 'root.main.metrics';
+            return {state: 'root.main.metrics', params: {}};
           }
         } else {
-          return result;
+          return {state: result, params: {}};
         }
       });
     };
@@ -190,10 +191,10 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
         // TODO: Fix this the right way when we fix the FSM
         // https://github.com/e-mission/e-mission-phone/issues/146#issuecomment-251061736
         var reload = false;
-        if (($state.$current == destState) && ($state.$current.name == 'root.main.goals')) {
+        if (($state.$current == destState.state) && ($state.$current.name == 'root.main.goals')) {
           reload = true;
         }
-        $state.go(destState).then(function() {
+        $state.go(destState.state, destState.params).then(function() {
             if (reload) {
               $rootScope.$broadcast("RELOAD_GOAL_PAGE_FOR_REFERRAL")
             }

--- a/www/js/tripconfirm/post-trip-map-display.js
+++ b/www/js/tripconfirm/post-trip-map-display.js
@@ -26,8 +26,10 @@ angular.module('emission.tripconfirm.posttrip.map',['ui-leaflet', 'ng-walkthroug
 
   $scope.mapCtrl.start_ts = $stateParams.start_ts;
   $scope.mapCtrl.end_ts = $stateParams.end_ts;
-  if (($scope.mapCtrl.start_ts == 0) || ($scope.mapCtrl.end_ts == 0)) {
-    Logger.log("BUG 413 check: stateParams = "+JSON.stringify($stateParams));
+  if (($scope.mapCtrl.start_ts == null) || ($scope.mapCtrl.end_ts == null)
+       || ($scope.mapCtrl.start_ts == 0) || ($scope.mapCtrl.end_ts == 0)) {
+    Logger.log("BUG 413 check: stateParams = "+JSON.stringify($stateParams)+
+        " mapCtrl = "+$state.mapCtrl.start_ts+","+$state.mapCtrl.end_ts);
   }
 
   $scope.$on('$ionicView.enter', function() {
@@ -39,8 +41,10 @@ angular.module('emission.tripconfirm.posttrip.map',['ui-leaflet', 'ng-walkthroug
         $stateParams.start_ts+" end = "+$stateParams.end_ts);
     $scope.mapCtrl.start_ts = $stateParams.start_ts;
     $scope.mapCtrl.end_ts = $stateParams.end_ts;
-    if (($scope.mapCtrl.start_ts == 0) || ($scope.mapCtrl.end_ts == 0)) {
-      Logger.log("BUG 413 check: stateParams = "+JSON.stringify($stateParams));
+    if (($scope.mapCtrl.start_ts == null) || ($scope.mapCtrl.end_ts == null)
+         || ($scope.mapCtrl.start_ts == 0) || ($scope.mapCtrl.end_ts == 0)) {
+      Logger.log("BUG 413 check: stateParams = "+JSON.stringify($stateParams)+
+        " mapCtrl = "+$state.mapCtrl.start_ts+","+$state.mapCtrl.end_ts);
     }
     $scope.draftMode = {"start_ts": $stateParams.start_ts, "end_ts": $stateParams.end_ts};
     $scope.draftPurpose = {"start_ts": $stateParams.start_ts, "end_ts": $stateParams.end_ts};

--- a/www/js/tripconfirm/post-trip-prompt.js
+++ b/www/js/tripconfirm/post-trip-prompt.js
@@ -117,7 +117,7 @@ angular.module('emission.tripconfirm.posttrip.prompt', ['emission.plugin.logger'
   };
 
   var displayCompletedTrip = function(notification, state, data) {
-    $rootScope.displayingIncident = true;
+    $rootScope.tripConfirmParams = notification.data;
       Logger.log("About to display completed trip from notification "+
         JSON.stringify(notification.data));
       $state.go("root.main.tripconfirm", notification.data);


### PR DESCRIPTION
Additional details in 
https://github.com/e-mission/e-mission-docs/issues/413#issuecomment-508837272

Changes:
- additional logging in `post-trip-map-display.js`
- set the params in `post-trip-prompt.js`
- read the params in `startpref.js`. Also change the getNextState to return the
  state and the params, and change `changeState` to pass in the params to `$state.go`

Testing done:
- Tested trip confirmation popups in the iOS emulator; going directly from the
    profile -> tripconfirm page works fine and does not have a regression.
    ```
    [Log] Finished changing state from {"url":"/control","views":{"main-control":{"templateUrl":"templates/control/main-control.html","controller":"ControlCtrl"}},"name":"root.main.control"} to {"url":"/tripconfirm","params":{"start_ts":null,"end_ts":null},"views":{"main-control":{"templateUrl":"templates/tripconfirm/map.html","controller":"PostTripMapCtrl"}},"name":"root.main.tripconfirm"} (index.html, line 131)
    [Log] DEBUG:controller PostTripMapDisplay called with params = {"start_ts":1562356812.635469,"end_ts":1562356812.635469} (index.html, line 131)
    [Log] DEBUG:About to query buffer for {"key":"write_ts","startTs":1562356812.635469,"endTs":1562356812.635469} (index.html, line 131)
    [Log] getRawEntries: about to get pushGetJSON for the timestamp (index.html, line 131)
    [Log] About to return message {"key_list":["background/filtered_location"],"start_time":1562356812.635469,"end_time":1562356812.635469} (index.html, line 131)
    [Log] DEBUG:About to dedup localResult = 0remoteResult = 0 (index.html, line 131)
    [Log] DEBUG:Deduped list = 0 (index.html, line 131)
    [Log] DEBUG:Read data of length 0 (index.html, line 131)
    [Log] DEBUG:entered post-trip map screen, resetting start = 1562356812.635469 end = 1562356812.635469 (index.html, line 131)
    [Log] {value: "walk"} (index.html, line 131)
    [Log] DEBUG:in storeMode, after setting mode_val = walk, draftMode = {"start_ts":1562356812.635469,"end_ts":1562356812.635469,"label":"walk"} (index.html, line 131)
    [Log] {value: "school"} (index.html, line 131)
    [Log] DEBUG:in storePurpose, after setting purpose_val = school, draftPurpose = {"start_ts":1562356812.635469,"end_ts":1562356812.635469,"label":"school"} (index.html, line 131)
    [Log] Finished changing state from {"url":"/tripconfirm","params":{"start_ts":null,"end_ts":null},"views":{"main-control":{"templateUrl":"templates/tripconfirm/map.html","controller":"PostTripMapCtrl"}},"name":"root.main.tripconfirm"} to {"url":"/control","views":{"main-control":{"templateUrl":"templates/control/main-control.html","controller":"ControlCtrl"}},"name":"root.main.control"} (index.html, line 131)
    ```
- Have not been able to reproduce the race and am not sure whether this fixes it although I am optimistic