### PR TITLE
Rk unsw

### DIFF
--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -214,12 +214,19 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     }
 
     $scope.populateBasicClasses = function(tripgj) {
-        tripgj.display_start_time = DiaryHelper.getLocalTimeString(tripgj.data.properties.start_local_dt);
-        tripgj.display_end_time = DiaryHelper.getLocalTimeString(tripgj.data.properties.end_local_dt);
+        const start_dt = Object.assign({}, tripgj.data.properties.start_local_dt);
+        const end_dt = Object.assign({}, tripgj.data.properties.end_local_dt);
+        tripgj.isDraft = $scope.isDraft(tripgj);
+        // Fix "Invalid date" for processed trips
+        if (!tripgj.isDraft) {
+          start_dt.month = start_dt.month - 1;
+          end_dt.month = end_dt.month - 1;
+        }
+        tripgj.display_start_time = DiaryHelper.getLocalTimeString(start_dt);
+        tripgj.display_end_time = DiaryHelper.getLocalTimeString(end_dt);
         tripgj.display_distance = $scope.getFormattedDistance(tripgj.data.properties.distance);
         tripgj.display_time = $scope.getFormattedTimeRange(tripgj.data.properties.start_ts,
                                 tripgj.data.properties.end_ts);
-        tripgj.isDraft = $scope.isDraft(tripgj);
         tripgj.background = DiaryHelper.getTripBackground(tripgj);
         tripgj.listCardClass = $scope.listCardClass(tripgj);
         tripgj.percentages = $scope.getPercentages(tripgj)

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -15,6 +15,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
                                       'emission.tripconfirm.services',
                                       'emission.services',
                                       'emission.survey.enketo.launch',
+                                      'emission.enketo-survey.service',
                                       'ng-walkthrough', 'nzTour', 'emission.plugin.kvstore',
     'emission.plugin.logger'
   ])
@@ -25,7 +26,7 @@ angular.module('emission.main.diary.list',['ui-leaflet',
                                     $ionicActionSheet,
                                     ionicDatePicker,
                                     leafletData, Timeline, CommonGraph, DiaryHelper,
-    Config, PostTripManualMarker, ConfirmHelper, nzTour, KVStore, Logger, UnifiedDataLoader, $ionicPopover, $ionicModal, EnketoSurveyLaunch, $translate) {
+    Config, PostTripManualMarker, ConfirmHelper, nzTour, KVStore, Logger, UnifiedDataLoader, $ionicPopover, $ionicModal, EnketoSurvey, EnketoSurveyLaunch, CommHelper, $translate) {
   console.log("controller DiaryListCtrl called");
     var MODE_CONFIRM_KEY = "manual/mode_confirm";
     var PURPOSE_CONFIRM_KEY = "manual/purpose_confirm";
@@ -706,6 +707,20 @@ angular.module('emission.main.diary.list',['ui-leaflet',
             $scope.value2entryPurpose = purposeMaps[1];
         });
     });
+
+    $scope.$on('$ionicView.afterEnter', function() {
+      CommHelper.getUser().then(function(user) {
+        const uuid = user.user_id['$uuid'];
+        return EnketoSurvey.getAllSurveyAnswers('manual/user_profile_survey'
+        ).then(function(answers){
+            return EnketoSurvey.getFirstUserProfile({ uuid }, answers);
+        }).then(function(userProfile){
+          if (userProfile && userProfile.data.timestamp) {
+            $scope.datepickerObject.from = moment(userProfile.data.timestamp).startOf('day').toDate();
+          }
+        });
+      });
+    })
 
     $scope.storeMode = function (mode, isOther) {
       if(isOther) {

--- a/www/js/survey/enketo-survey-service.js
+++ b/www/js/survey/enketo-survey-service.js
@@ -64,6 +64,15 @@ angular.module('emission.enketo-survey.service', [
         null;
   }
 
+  function getFirstUserProfile(user_properties, answers) {
+    const potentialCandidates = answers.filter(function(answer) {
+        return answer.data.user_uuid = user_properties.uuid;
+    });
+    return potentialCandidates.length ?
+        potentialCandidates[potentialCandidates.length - 1] :
+        null;
+  }
+
   function _restoreAnswer(answers) {
     let answer = null;
     if (__trip) {
@@ -170,6 +179,7 @@ angular.module('emission.enketo-survey.service', [
     getAllSurveyAnswers: getAllSurveyAnswers,
     getState: getState,
     getUserProfile: getUserProfile,
+    getFirstUserProfile: getFirstUserProfile,
     populateLabels: populateLabels,
     makeAnswerFromAnswerData: makeAnswerFromAnswerData,
   };


### PR DESCRIPTION
Features
1. Fix invalid date displayed for processed trips

Apparently, the date stored in `tripgj.data.properties.start_local_dt` and `tripgj.data.properties.end_local_dt` use a `1-12` month value while `moment` needs `0-11` month value. The test was done on December which translated to value `12`. Hence moment throw `Invalid date`. However, this problem does not persist for `draft trip` so we skip the fix for those trips.

Before:
<img width="433" alt="Screen Shot 2563-01-01 at 21 00 50" src="https://user-images.githubusercontent.com/5247367/71642428-804ac600-2cdd-11ea-990f-b52444e23b79.png">

After:
<img width="431" alt="Screen Shot 2563-01-01 at 21 00 25" src="https://user-images.githubusercontent.com/5247367/71642431-8771d400-2cdd-11ea-88ea-fae7e0c4262b.png">


2. Limit date picker to the day the user register (we use timestamp from the oldest user profile survey record)

Example: I answered on January 1st, 2020
<img width="438" alt="Screen Shot 2563-01-01 at 21 24 36" src="https://user-images.githubusercontent.com/5247367/71642436-a3757580-2cdd-11ea-9a48-c3d36ca542fc.png">
