### PR TITLE
add the required manifest field for apps that target API 28 and want …

### DIFF
--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -86,6 +86,9 @@
         <splash density="port-xhdpi" src="resources/android/splash/drawable-port-xhdpi-screen.png" />
         <splash density="port-xxhdpi" src="resources/android/splash/drawable-port-xxhdpi-screen.png" />
         <splash density="port-xxxhdpi" src="resources/android/splash/drawable-port-xxxhdpi-screen.png" />
+        <config-file parent="/manifest/application" target="AndroidManifest.xml">
+            <uses-library android:name="org.apache.http.legacy" android:required="false" />
+        </config-file>
     </platform>
     <icon src="resources/android/icon/drawable-xhdpi-icon.png" />
     <plugin name="phonegap-plugin-push" spec="=2.1.2">


### PR DESCRIPTION
Beginning with Android 9, there is an error:

```java
2020-01-13 13:00:07.586 7070-7551/com.transway.weflow E/AndroidRuntime: FATAL EXCEPTION: pool-2-thread-3
    Process: com.transway.weflow, PID: 7070
    java.lang.NoClassDefFoundError: Failed resolution of: Lorg/apache/http/client/methods/HttpPost;
        at edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper.pushGetJSON(CommunicationHelper.java:84)
        at edu.berkeley.eecs.emission.cordova.comm.CommunicationHelperPlugin$1.run(CommunicationHelperPlugin.java:27)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.ClassNotFoundException: Didn't find class "org.apache.http.client.methods.HttpPost" on path: DexPathList[[zip file "/data/app/com.transway.weflow-NCsRDbNfqa4kWUPSGF3VJQ==/base.apk"],nativeLibraryDirectories=[/data/app/com.transway.weflow-NCsRDbNfqa4kWUPSGF3VJQ==/lib/arm64, /system/lib64]]
        at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:196)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
        at edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper.pushGetJSON(CommunicationHelper.java:84) 
        at edu.berkeley.eecs.emission.cordova.comm.CommunicationHelperPlugin$1.run(CommunicationHelperPlugin.java:27) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:919) 
```

that can be fixed by a [manifest update](https://developer.android.com/about/versions/pie/android-9.0-changes-28#apache-p).

https://stackoverflow.com/questions/52549112/failed-resolution-of-lorg-apache-http-client-methods-httppost
