### PR TITLE
Minor install and ci fixes

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -37,13 +37,15 @@ jobs:
     - name: Setup the cordova environment
       shell: bash -l {0}
       run: |
-        source setup/setup_android_native.sh
+        bash setup/setup_android_native.sh
+        source setup/activate_native.sh
         npx cordova -version
         npx ionic -version
 
     - name: Access cordova with a specified shell
       shell: bash -l {0}
       run: |
+        source setup/activate_native.sh
         npx cordova -version
         which gradle
         gradle -version
@@ -54,8 +56,8 @@ jobs:
         echo $PATH
         which gradle
         gradle -version
-        echo "Let's rerun the sdkman again"
-        source ~/.sdkman/bin/sdkman-init.sh
+        echo "Let's rerun the activation"
+        source setup/activate_native.sh
         echo $PATH
         which gradle
         gradle --version

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -41,22 +41,27 @@ jobs:
     - name: Setup the cordova environment
       shell: bash -l {0}
       run: |
-        source setup/setup_ios_native.sh
+        bash setup/setup_ios_native.sh
+        source setup/activate_native.sh
         npx cordova -version
         npx ionic -version
+
+    - name: Access cordova with a specified shell
+      shell: bash -l {0}
+      run: |
+        source setup/activate_native.sh
+        npx cordova -version
 
     - name: Access cordova directly
       run: npx cordova -version
 
-    - name: Access cordova with a specified shell
-      shell: bash -l {0}
-      run: npx cordova -version
-
     - name: Build ios
       shell: bash -l {0}
-      run: npx cordova build ios
+      run: |
+        source setup/activate_native.sh
+        npx cordova build ios
 
     - name: Cleanup the cordova environment
       shell: bash -l {0}
-      run: source setup/teardown_ios_native.sh
+      run: bash setup/teardown_ios_native.sh
 

--- a/.github/workflows/serve-install.yml
+++ b/.github/workflows/serve-install.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Setup the serve environment
       shell: bash -l {0}
       run: |
-        source setup/setup_serve.sh
+        bash setup/setup_serve.sh
+        source setup/activate_serve.sh
         npx cordova -version
         npx ionic --version
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Pre-requisites
 - the version of xcode used by the CI
     - to install a particular version, use [xcode-select](https://www.unix.com/man-page/OSX/1/xcode-select/)
     - or this [supposedly easier to use repo](https://github.com/xcpretty/xcode-install)
-    - **NOTE**: the basic xcode install was messed up for me due to issues with the command line tools. [These workarounds helped](https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md).
-    - **NOTE**: although Catalina has a `/usr/bin/java`, trying to run it gives the error `No Java runtime present, requesting install.`. Installed [OpenJDK using AdoptOpenJDK](https://adoptopenjdk.net/releases.html) to be consistent with the CI.
+    - **NOTE**: the basic xcode install on Catalina was messed up for me due to a prior installation of command line tools. [These workarounds helped](https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md).
 - git
 - the most recent version of android studio
+    - **NOTE**: although Catalina has a `/usr/bin/java`, trying to run it gives the error `No Java runtime present, requesting install.`. Installed [OpenJDK 1.8 using AdoptOpenJDK](https://adoptopenjdk.net/releases.html) to be consistent with the CI.
 
 Important
 ---

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Updating the UI only
 
 If you want to make only UI changes, (as opposed to modifying the existing plugins, adding new plugins, etc), you can use the **new and improved** (as of June 2018) e-mission dev app. 
 
-### Installing
+### Installing (one-time)
 
 Run the setup script
 
 ```
-$ source setup/setup_serve.sh
+$ bash setup/setup_serve.sh
 ```
 
 **(optional)** Configure by changing the files in `www/json`.
@@ -41,6 +41,12 @@ Defaults are in `www/json/*.sample`
 $ ls www/json/*.sample
 $ cp www/json/startupConfig.json.sample www/json/startupConfig.json
 $ cp ..... www/json/connectionConfig.json
+```
+
+### Activation (after install, and in every new shell)
+
+```
+$ source setup/activate_serve.sh
 ```
   
 ### Running
@@ -69,7 +75,6 @@ $ cp ..... www/json/connectionConfig.json
 
 **Note1**: You may need to scroll up, past all the warnings about `Content Security Policy has been added` to find the port that the server is listening to.
 
-
 End to end testing
 ---
 A lot of the visualizations that we display in the phone client come from the server. In order to do end to end testing, we need to run a local server and connect to it. Instructions for:
@@ -95,6 +100,8 @@ Pre-requisites
 - the version of xcode used by the CI
     - to install a particular version, use [xcode-select](https://www.unix.com/man-page/OSX/1/xcode-select/)
     - or this [supposedly easier to use repo](https://github.com/xcpretty/xcode-install)
+    - **NOTE**: the basic xcode install was messed up for me due to issues with the command line tools. [These workarounds helped](https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md).
+    - **NOTE**: although Catalina has a `/usr/bin/java`, trying to run it gives the error `No Java runtime present, requesting install.`. Installed [OpenJDK using AdoptOpenJDK](https://adoptopenjdk.net/releases.html) to be consistent with the CI.
 - git
 - the most recent version of android studio
 
@@ -110,14 +117,14 @@ have now:
 If you have setup failures, please compare the configuration in the passing CI
 builds with your configuration. That is almost certainly the source of the error.
 
-Installing
+Installing (one time only)
 ---
 Run the setup script for the platform you want to build
 
 ```
-$ source setup/setup_android_native.sh
+$ bash setup/setup_android_native.sh
 AND/OR
-$ source setup/setup_ios_native.sh
+$ bash setup/setup_ios_native.sh
 ```
 
 **(optional)** Configure by changing the files in `www/json`.
@@ -128,6 +135,14 @@ $ ls www/json/*.sample
 $ cp www/json/startupConfig.json.sample www/json/startupConfig.json
 $ cp ..... www/json/connectionConfig.json
 ```
+
+### Activation (after install, and in every new shell)
+
+```
+$ source setup/activate_native.sh
+```
+
+
 
 Run in the emulator
 

--- a/setup/activate_native.sh
+++ b/setup/activate_native.sh
@@ -1,0 +1,17 @@
+# Setup the development environment
+source setup/activate_shared.sh
+
+echo "Adding cocoapods to the path"
+export PATH=$RUBY_PATH:$PATH
+
+echo "Verifying $ANDROID_HOME or $ANDROID_SDK_ROOT is set"
+if [ -z $ANDROID_HOME ] && [ -z $ANDROID_SDK_ROOT ];
+then
+    echo "ANDROID_HOME and ANDROID_SDK_ROOT not set, android SDK not found"
+fi
+
+echo "Activating sdkman, and by default, gradle"
+source "/Users/kshankar/.sdkman/bin/sdkman-init.sh"
+
+echo "Configuring the repo for building native code"
+./bin/configure_xml_and_json.js cordovabuild

--- a/setup/activate_serve.sh
+++ b/setup/activate_serve.sh
@@ -1,0 +1,4 @@
+source setup/activate_shared.sh
+
+echo "Configuring the repo for UI development"
+./bin/configure_xml_and_json.js serve

--- a/setup/activate_shared.sh
+++ b/setup/activate_shared.sh
@@ -1,0 +1,12 @@
+source setup/export_shared_dep_versions.sh
+
+echo "Activating nvm"
+
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+echo "Using version $NODE_VERSION"
+nvm use $NODE_VERSION
+
+CURR_NPM_VERSION=`npm --version`
+echo "npm version = $CURR_NPM_VERSION"

--- a/setup/export_shared_dep_versions.sh
+++ b/setup/export_shared_dep_versions.sh
@@ -1,0 +1,8 @@
+export NVM_VERSION=0.35.3
+export NODE_VERSION=13.12.0
+export NPM_VERSION=6.14.4
+export RUBY_VERSION=2.6.0
+export COCOAPODS_VERSION=1.9.1
+
+export NVM_DIR="$HOME/.nvm"
+export RUBY_PATH=$HOME/.gem/ruby/$RUBY_VERSION/bin

--- a/setup/export_shared_dep_versions.sh
+++ b/setup/export_shared_dep_versions.sh
@@ -3,6 +3,7 @@ export NODE_VERSION=13.12.0
 export NPM_VERSION=6.14.4
 export RUBY_VERSION=2.6.0
 export COCOAPODS_VERSION=1.9.1
+export GRADLE_VERSION=4.10.3
 
 export NVM_DIR="$HOME/.nvm"
 export RUBY_PATH=$HOME/.gem/ruby/$RUBY_VERSION/bin

--- a/setup/setup_android_native.sh
+++ b/setup/setup_android_native.sh
@@ -33,6 +33,6 @@ curl -s "https://get.sdkman.io" | bash
 source ~/.sdkman/bin/sdkman-init.sh
 
 echo "Setting up gradle using SDKMan"
-sdk install gradle 4.1
+sdk install gradle $GRADLE_VERSION
 
 source setup/setup_shared_native.sh

--- a/setup/setup_android_native.sh
+++ b/setup/setup_android_native.sh
@@ -20,12 +20,12 @@ TARGET_SDK_VERSION=28
 # Setup the development environment
 source setup/setup_shared.sh
 
-if [ -z $ANDROID_HOME ];
+if [ -z $ANDROID_HOME ] && [ -z $ANDROID_SDK_ROOT ];
 then
-    echo "ANDROID_HOME not set, android SDK not found, exiting"
+    echo "ANDROID_HOME and ANDROID_SDK_ROOT not set, android SDK not found, exiting"
     exit 1
 else
-    echo "ANDROID_HOME found at $ANDROID_HOME"
+    echo "ANDROID_HOME = $ANDROID_HOME; ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
 fi
 
 echo "Setting up sdkman"

--- a/setup/setup_ios_native.sh
+++ b/setup/setup_ios_native.sh
@@ -1,14 +1,11 @@
 # error out if any command fails
 set -e
 
-COCOAPODS_VERSION=1.9.1
-EXPECTED_PLUGIN_COUNT=15
-
 # Setup the development environment
 source setup/setup_shared.sh
 
 echo "Installing cocoapods"
-export PATH=~/.gem/ruby/2.6.0/bin:$PATH
+export PATH=$RUBY_PATH:$PATH
 gem install --no-document --user-install cocoapods -v $COCOAPODS_VERSION
 
 source setup/setup_shared_native.sh

--- a/setup/setup_shared.sh
+++ b/setup/setup_shared.sh
@@ -1,15 +1,9 @@
-export NVM_VERSION=0.35.3
-export NODE_VERSION=13.12.0
-export NPM_VERSION=6.14.4
-
-echo "Is this in a CI environment? $CI"
-export CI="true"
+source setup/export_shared_dep_versions.sh
 
 echo "Installing the correct version of nvm"
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh | bash
 
 echo "Setting up the variables to run nvm"
-export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 

--- a/setup/teardown_ios_native.sh
+++ b/setup/teardown_ios_native.sh
@@ -1,7 +1,6 @@
 echo "Ensure we exit on error"
 set -e
 
-export COCOAPODS_VERSION=1.9.1
 source setup/teardown_shared.sh
 
 echo "Uninstalling cocoapods"

--- a/setup/teardown_shared.sh
+++ b/setup/teardown_shared.sh
@@ -1,5 +1,4 @@
-export COCOAPODS_VERSION=1.7.5
-export NODE_VERSION=9.4.0
+source setup/export_shared_dep_versions.sh
 
 echo "Removing .nvm since we installed it"
 rm -rf ~/.nvm/$NODE_VERSION


### PR DESCRIPTION
Add a separate set of "activate" scripts

Which set up all the paths correctly but don't install anything
+ move out the version exports so we can reuse them across the setup scripts
+ change readme to specify how to use the activate
+ change the workflow scripts to setup with bash and activate with source
