### PR TITLE
Performance improvement for the diary loading

### DIFF
--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -992,10 +992,10 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
       var isProcessingCompletePromise = timeline.isProcessingComplete(day);
 
       // Also mode/purpose and survey answers
-      var tq = { key: 'write_ts', startTs: 0, endTs: moment().endOf('day').unix(), };
-      const modesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/mode_confirm', tq);
-      const purposesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/purpose_confirm', tq);
-      const surveyAnswersPromise = EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true });
+      var tq = $window.cordova.plugins.BEMUserCache.getAllTimeQuery();
+      var modesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/mode_confirm', tq);
+      var purposesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/purpose_confirm', tq);
+      var surveyAnswersPromise = EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true });
 
       // Deal with all the trip retrieval
       Promise.all([tripsFromServerPromise, isProcessingCompletePromise, modesPromise, purposesPromise, surveyAnswersPromise])

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -991,23 +991,22 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
       var tripsFromServerPromise = timeline.updateFromServer(day);
       var isProcessingCompletePromise = timeline.isProcessingComplete(day);
 
-      // Also mode/purpose and survey answers
+      // Also mode/purpose and (currently disabled) survey answers
       var tq = $window.cordova.plugins.BEMUserCache.getAllTimeQuery();
       var modesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/mode_confirm', tq);
       var purposesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/purpose_confirm', tq);
-      var surveyAnswersPromise = EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true });
+      // var surveyAnswersPromise = EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true });
 
       // Deal with all the trip retrieval
-      Promise.all([tripsFromServerPromise, isProcessingCompletePromise, modesPromise, purposesPromise, surveyAnswersPromise])
-        .then(function([processedTripList, completeStatus, modes, purposes, surveyAnswers]) {
+      Promise.all([tripsFromServerPromise, isProcessingCompletePromise, modesPromise, purposesPromise])
+        .then(function([processedTripList, completeStatus, modes, purposes]) {
         console.log("Promise.all() finished successfully with length "
           +processedTripList.length+" completeStatus = "+completeStatus);
-        console.log(` with ${modes.length} modes, ${purposes.length} purposes,  ${surveyAnswers.length} surveyAnswers`);
+        console.log(' with ${modes.length} modes, ${purposes.length} purposes');
         var tripList = processedTripList;
         timeline.data.unifiedConfirmsResults = {
           modes: modes,
-          purposes: purposes,
-          surveyAnswers: surveyAnswers,
+          purposes: purposes
         };
         if (!completeStatus) {
           return timeline.readUnprocessedTrips(day, processedTripList)

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -1002,6 +1002,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
         .then(function([processedTripList, completeStatus, modes, purposes, surveyAnswers]) {
         console.log("Promise.all() finished successfully with length "
           +processedTripList.length+" completeStatus = "+completeStatus);
+        console.log(` with ${modes.length} modes, ${purposes.length} purposes,  ${surveyAnswers.length} surveyAnswers`);
         var tripList = processedTripList;
         timeline.data.unifiedConfirmsResults = {
           modes: modes,

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -991,12 +991,23 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
       var tripsFromServerPromise = timeline.updateFromServer(day);
       var isProcessingCompletePromise = timeline.isProcessingComplete(day);
 
+      // Also mode/purpose and survey answers
+      var tq = { key: 'write_ts', startTs: 0, endTs: moment().endOf('day').unix(), };
+      const modesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/mode_confirm', tq);
+      const purposesPromise = UnifiedDataLoader.getUnifiedMessagesForInterval('manual/purpose_confirm', tq);
+      const surveyAnswersPromise = EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true });
+
       // Deal with all the trip retrieval
-      Promise.all([tripsFromServerPromise, isProcessingCompletePromise])
-        .then(function([processedTripList, completeStatus]) {
+      Promise.all([tripsFromServerPromise, isProcessingCompletePromise, modesPromise, purposesPromise, surveyAnswersPromise])
+        .then(function([processedTripList, completeStatus, modes, purposes, surveyAnswers]) {
         console.log("Promise.all() finished successfully with length "
           +processedTripList.length+" completeStatus = "+completeStatus);
         var tripList = processedTripList;
+        timeline.data.unifiedConfirmsResults = {
+          modes: modes,
+          purposes: purposes,
+          surveyAnswers: surveyAnswers,
+        };
         if (!completeStatus) {
           return timeline.readUnprocessedTrips(day, processedTripList)
             .then(function(unprocessedTripList) {
@@ -1009,16 +1020,6 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
         } else {
             return tripList;
         }
-      }).then(function([combinedTripList, modes, purposes]) {
-          return EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true }).then(function(surveyAnswers) {
-            timeline.data.unifiedConfirmsResults = {
-              modes: modes,
-              purposes: purposes,
-              surveyAnswers: surveyAnswers,
-            };
-            return combinedTripList;
-          });
-        return combinedTripList;
       }).then(function(combinedTripList) {
         processOrDisplayNone(day, combinedTripList);
       }).catch(function(error) {

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -1009,15 +1009,12 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
         } else {
             return tripList;
         }
-      }).then(function(combinedTripList) {
-          var tq = { key: 'write_ts', startTs: 0, endTs: moment().endOf('day').unix(), };
-          return Promise.all([
-            UnifiedDataLoader.getUnifiedMessagesForInterval('manual/mode_confirm', tq),
-            UnifiedDataLoader.getUnifiedMessagesForInterval('manual/purpose_confirm', tq)
-          ]).then(function(results) {
+      }).then(function([combinedTripList, modes, purposes]) {
+          return EnketoSurvey.getAllSurveyAnswers("manual/confirm_survey", { populateLabels: true }).then(function(surveyAnswers) {
             timeline.data.unifiedConfirmsResults = {
-              modes: results[0],
-              purposes: results[1],
+              modes: modes,
+              purposes: purposes,
+              surveyAnswers: surveyAnswers,
             };
             return combinedTripList;
           });


### PR DESCRIPTION
Improve performance for diary loading by making all remote calls in parallel. This is a restricted port of https://github.com/e-mission/e-mission-phone/pull/609 which removes the survey answers that are currently not used on master. The surveyanswers are removed in https://github.com/e-mission/e-mission-phone/commit/202624c61d69414eb120a84c981c3ecde751907d The others are original commits from @atton16 that he did not submit to master.
