### PR TITLE
Upgrade to API 29

### DIFF
--- a/bin/sign_and_align_keys.sh
+++ b/bin/sign_and_align_keys.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+PROJECT=$1
+VERSION=$2
+
 if [[ $# -eq 0 ]]; then
     echo "No arguments supplied"
     exit 1
@@ -7,7 +10,7 @@ fi
 
 # Sign and release the L+ version
 # Make sure the highest supported version has the biggest version code
-npx cordova build android --release -- --minSdkVersion=21
-cp platforms/android/app/build/outputs/apk/release/app-release-unsigned.apk platforms/android/app/build/outputs/apk/app-L+-release-signed-unaligned.apk
-jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Safety_Infrastructure/MovesConnect/production.keystore ./platforms/android/app/build/outputs/apk/app-L+-release-signed-unaligned.apk androidproductionkey
-~/Library/Android/sdk/build-tools/27.0.3/zipalign -v 4 platforms/android/app/build/outputs/apk/app-L+-release-signed-unaligned.apk cv-19-track-L+-build-$1.apk
+npx cordova build android --release -- --minSdkVersion=22
+cp platforms/android/app/build/outputs/apk/release/app-release-unsigned.apk platforms/android/app/build/outputs/apk/app-release-signed-unaligned.apk
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ../config_files/production.keystore ./platforms/android/app/build/outputs/apk/app-release-signed-unaligned.apk androidproductionkey
+~/Library/Android/sdk/build-tools/30.0.1/zipalign -v 4 platforms/android/app/build/outputs/apk/app-release-signed-unaligned.apk $1-build-$2.apk

--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -78,7 +78,7 @@
     <platform name="android">
         <hook src="hooks/before_build/android/android_copy_locales.js" type="before_build" />
         <preference name="android-minSdkVersion" value="22" />
-        <preference name="android-targetSdkVersion" value="28" />
+        <preference name="android-targetSdkVersion" value="29" />
         <preference name="AndroidXEnabled" value="true" />
         <resource-file src="google-services.json" target="app/google-services.json" />
         <hook src="hooks/before_build/android/android_set_provider.js" type="before_build" />

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -72,7 +72,7 @@
     "cordova-plugin-app-version": "0.1.9",
     "cordova-plugin-customurlscheme": "5.0.1",
     "cordova-plugin-device": "2.0.1",
-    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.4.4",
+    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.4.5",
     "cordova-plugin-em-jwt-auth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.6.2",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.3",
     "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.4",

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -250,6 +250,7 @@
         "permissions": {
             "locationPermExplanation-android-lt-6": "you accepted the permission during installation. You don't need to do anything now.",
             "locationPermExplanation-android-gte-6": "please select 'allow'",
+            "locationPermExplanation-android-gte-10": "please select 'Allow all the time'",
             "locationPermExplanation-ios-lt-13": "please select 'Always allow'. This allows us to understand your travel even when you are not actively using the app",
             "locationPermExplanation-ios-gte-13": "please select 'when in use' now. After a few days, you will be asked whether you want to give the app background permission. Please say 'Always Allow' at that time. This allows us to understand your travel even when you are not actively using the app"
         }

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -26,8 +26,10 @@ angular.module('emission.intro', ['emission.splash.startprefs',
   if($scope.platform.toLowerCase() == "android") {
     if($scope.osver < 6) {
         $scope.locationPermExplanation = $translate.instant('intro.permissions.locationPermExplanation-android-lt-6');
-    } else {
+    } else if ($scope.osver < 10) {
         $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-gte-6");
+    } else {
+        $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-gte-10");
     }
   }
 


### PR DESCRIPTION
Most of the changes were in the plugin, which we upgraded from version `1.4.4` to `1.4.5`.
The main change in here was to change the intro to specify the choice for android 10+ ("Always allow")

Other minor fixes:
- Fix the release script
  - Bump up the minSDK number
  - Fix the location of the production keystore
  - Fix the version of the buildtools used in the build
  - Change apk file names a bit since we build only one apk right now