### PR TITLE
Support a generic xpath selector for the HTML element

### DIFF
--- a/www/js/goals.js
+++ b/www/js/goals.js
@@ -894,8 +894,7 @@ angular.module('emission.main.goals',['emission.services', 'emission.plugin.logg
 
     $scope.startSurvey = function () {
       // (URL, elementID)
-      SurveyLaunch.startSurvey('https://berkeley.qualtrics.com/SE/?SID=SV_5pzFk7JnMkfWBw1', 'QR~QID2');
-      // startSurvey();
+      SurveyLaunch.startSurveyWithID('https://berkeley.qualtrics.com/SE/?SID=SV_5pzFk7JnMkfWBw1', 'QR~QID2');
     }
 
     // Tour steps

--- a/www/js/survey/uuid_insert_id.js
+++ b/www/js/survey/uuid_insert_id.js
@@ -1,0 +1,22 @@
+var populateId = function(userId) {
+  var curriedPI = function() {
+    populateId(userId);
+  };
+  if (document == null) {
+//     alert('document == '+document);
+     setTimeout(curriedPI, 1000);
+  } else {
+    var el = document.getElementById('SCRIPT_REPLACE_ELEMENT_SEL');
+//    alert('document = '+document+ ' element = '+ el);
+    if (el == null) {
+//      alert('element == null!');
+      setTimeout(curriedPI, 1000);
+    } else {
+      el.value = userId;
+    }
+  }
+};
+
+// alert("executing script");
+populateId('SCRIPT_REPLACE_VALUE');
+// alert("done executing script");

--- a/www/js/survey/uuid_insert_xpath.js
+++ b/www/js/survey/uuid_insert_xpath.js
@@ -6,13 +6,18 @@ var populateId = function(userId) {
 //     alert('document == '+document);
      setTimeout(curriedPI, 1000);
   } else {
-    var el = document.getElementById('SCRIPT_REPLACE_ELEMENT_ID');
+    var xpathres = document.evaluate('SCRIPT_REPLACE_ELEMENT_SEL', document, null, XPathResult.UNORDERED_NODE_ITERATOR_TYPE);
+    var el = xpathres.iterateNext();
+    var endElement = xpathres.iterateNext();
+    if (endElement != null) {
+      alert("Found multiple matches for xpath. Second match is "+endElement);
+    }
 //    alert('document = '+document+ ' element = '+ el);
     if (el == null) {
 //      alert('element == null!');
       setTimeout(curriedPI, 1000);
     } else {
-      el.value += userId;
+      el.value = userId;
     }
   }
 };


### PR DESCRIPTION
Before this, we supported specifying the UUID element by using an ID.
This works great for qualtrics, but other survey tools, such as google and
microsoft forms do not specify a unique ID for each element.

The tripaware group worked around this by hardcoding the class for their form
https://github.com/e-mission/e-mission-phone/blob/urap-2017-emotion/www/js/survey/uuid_insert.js#L9
but that is not a generalizable solution, and is likely to break if there are
multiple text elements in the first page.

While looking for an alternative, I found that most developer tools make it
easy to find the xpath of a form element. And since xpath is a standard, there
is a document level method to retrieve the element given an xpath.

So we also support xpaths as a specification mechanism.

Summary of changes:
- create a new javascript file for inserting from xpath
- rename the existing file to reflect that it was replacing by id
- refactor the launch script to support both id and xpath
  - including creating `startSurveyWithID` and `startSurveyWithXPath` methods
- changed the one instance of `startSurvey` in master to use
  `startSurveyWithID` instead.

Testing done:
- Added a new screen in the UI with two buttons to launch with ID and with path
    (see the docs for the sample code)
- Tested using a qualtrics form and a google form
- Both worked upto android 8
  - they did not work on android 9, where the IAB was not responding to any input
  - but that seems to be general issue with android 9 and will need to be investigated separately