### PR TITLE
Fix the paths for the file where the provider needs to be customized

### DIFF
--- a/hooks/before_build/android/android_set_provider.js
+++ b/hooks/before_build/android/android_set_provider.js
@@ -71,6 +71,8 @@ var changeAccountTypeAndProvider = function (file, accountType, providerName, ne
                 console.log(LOG_NAME + "" + file + " updated...")
             });
         });
+    } else {
+        console.error(LOG_NAME + "File "+file+" does not exist");
     }
 }
 
@@ -87,7 +89,7 @@ module.exports = function (context) {
         var applicationName = etree._root.attrib.id;
         console.log(LOG_NAME + "Your application is " + applicationName);
 
-        var platformRoot = path.join(context.opts.projectRoot, 'platforms/android/')
+        var platformRoot = path.join(context.opts.projectRoot, 'platforms/android/app/src/main')
 
         console.log(LOG_NAME + "Updating AndroidManifest.xml...");
         var androidManifest = path.join(platformRoot, 'AndroidManifest.xml');
@@ -102,12 +104,8 @@ module.exports = function (context) {
         changeAccountType(authenticator, ACCOUNT_TYPE, applicationName);
 
         console.log(LOG_NAME + "Updating ServerSyncPlugin.java");
-        var serverSyncPlugin = path.join(platformRoot, 'src/edu/berkeley/eecs/emission/cordova/serversync/ServerSyncPlugin.java');
+        var serverSyncPlugin = path.join(platformRoot, 'java/edu/berkeley/eecs/emission/cordova/serversync/ServerSyncPlugin.java');
         changeAccountTypeAndProvider(serverSyncPlugin, ACCOUNT_TYPE, PROVIDER, applicationName);
-
-        console.log(LOG_NAME + "Updating android.json");
-        var androidJson = path.join(platformRoot, 'android.json');
-        changeProvider(androidJson, PROVIDER, applicationName);
     } else {
         throw new Error(LOG_NAME + "Could not retrieve application name.");
     }


### PR DESCRIPTION
This is a cleanup of a1c7ff19e703ef0be816c86afde69b22190a1197
to adapt it to the structure in the latest version of cordova.

This fixes https://github.com/e-mission/e-mission-docs/issues/568

The provider name in `android.json` is already fixed in 
https://github.com/e-mission/cordova-server-sync/commit/6e8f0df5fc23fd95f9360253d491005a753470d6

So we don't need it any more