### PR TITLE
Unify mode and purpose code

### DIFF
--- a/www/js/diary/detail.js
+++ b/www/js/diary/detail.js
@@ -5,7 +5,7 @@ angular.module('emission.main.diary.detail',['ui-leaflet', 'ng-walkthrough',
                                       'emission.stats.clientstats',
                                       'emission.incident.posttrip.manual'])
 
-.controller("DiaryDetailCtrl", function($scope, $rootScope, $window, $stateParams, $ionicActionSheet,
+.controller("DiaryDetailCtrl", function($scope, $rootScope, $window, $state, $stateParams, $ionicActionSheet,
                                         $ionicPlatform, ClientStats,
                                         leafletData, leafletMapEvents, nzTour, KVStore,
                                         Logger, Timeline, DiaryHelper, Config,

--- a/www/js/diary/detail.js
+++ b/www/js/diary/detail.js
@@ -5,7 +5,7 @@ angular.module('emission.main.diary.detail',['ui-leaflet', 'ng-walkthrough',
                                       'emission.stats.clientstats',
                                       'emission.incident.posttrip.manual'])
 
-.controller("DiaryDetailCtrl", function($scope, $rootScope, $window, $state, $stateParams, $ionicActionSheet,
+.controller("DiaryDetailCtrl", function($scope, $rootScope, $window, $stateParams, $ionicActionSheet,
                                         $ionicPlatform, ClientStats,
                                         leafletData, leafletMapEvents, nzTour, KVStore,
                                         Logger, Timeline, DiaryHelper, Config,

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -26,9 +26,6 @@ angular.module('emission.main.diary.list',['ui-leaflet',
                                     leafletData, Timeline, CommonGraph, DiaryHelper,
     Config, PostTripManualMarker, ConfirmHelper, nzTour, KVStore, Logger, UnifiedDataLoader, $ionicPopover, $translate) {
   console.log("controller DiaryListCtrl called");
-    var MODE_CONFIRM_KEY = "manual/mode_confirm";
-    var PURPOSE_CONFIRM_KEY = "manual/purpose_confirm";
-
   // Add option
 
   $scope.$on('leafletDirectiveMap.resize', function(event, data) {
@@ -159,45 +156,24 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     }
 
     /**
-     * Embed 'mode' to the trip
+     * Embed 'inputType' to the trip
      */
-    $scope.populateModeFromTimeline = function (tripgj, modeList) {
-        var userMode = DiaryHelper.getUserInputForTrip(tripgj, modeList);
-        if (angular.isDefined(userMode)) {
-            // userMode is a mode object with data + metadata
+    $scope.populateInputFromTimeline = function (tripgj, inputType, inputList) {
+        var userInput = DiaryHelper.getUserInputForTrip(tripgj, inputList);
+        if (angular.isDefined(userInput)) {
+            // userInput is an object with data + metadata
             // the label is the "value" from the options
-            var userModeEntry = $scope.value2entryMode[userMode.data.label];
-            if (!angular.isDefined(userModeEntry)) {
-              userModeEntry = ConfirmHelper.getFakeEntry(userMode.data.label);
-              $scope.modeOptions.push(userModeEntry);
-              $scope.value2entryMode[userMode.data.label] = userModeEntry;
+            var userInputEntry = $scope.inputParams[inputType].value2entry[userInput.data.label];
+            if (!angular.isDefined(userInputEntry)) {
+              userInputEntry = ConfirmHelper.getFakeEntry(userInput.data.label);
+              $scope.inputParams[inputType].options.push(userInputEntry);
+              $scope.inputParams[inputType].value2entry[userInput.data.label] = userInputEntry;
             }
-            console.log("Mapped label "+userMode.data.label+" to entry "+JSON.stringify(userModeEntry));
-            tripgj.usermode = userModeEntry;
+            console.log("Mapped label "+userInput.data.label+" to entry "+JSON.stringify(userInputEntry));
+            tripgj.userInput[inputType] = userInputEntry;
         }
-        Logger.log("Set mode" + JSON.stringify(userModeEntry) + " for trip id " + JSON.stringify(tripgj.data.id));
-        $scope.modeTripgj = angular.undefined;
-    }
-
-    /**
-     * Embed 'purpose' to the trip
-     */
-    $scope.populatePurposeFromTimeline = function (tripgj, purposeList) {
-        var userPurpose = DiaryHelper.getUserInputForTrip(tripgj, purposeList);
-        if (angular.isDefined(userPurpose)) {
-            // userPurpose is a purpose object with data + metadata
-            // the label is the "value" from the options
-            var userPurposeEntry = $scope.value2entryPurpose[userPurpose.data.label];
-            if (!angular.isDefined(userPurposeEntry)) {
-              userPurposeEntry = ConfirmHelper.getFakeEntry(userPurpose.data.label);
-              $scope.purposeOptions.push(userPurposeEntry);
-              $scope.value2entryPurpose[userPurpose.data.label] = userPurposeEntry;
-            }
-            console.log("Mapped label "+userPurpose.data.label+" to entry "+JSON.stringify(userPurposeEntry));
-            tripgj.userpurpose = userPurposeEntry;
-        }
-        Logger.log("Set purpose " + JSON.stringify(userPurposeEntry) + " for trip id " + JSON.stringify(tripgj.data.id));
-        $scope.purposeTripgj = angular.undefined;
+        Logger.log("Set "+ inputType + " " + JSON.stringify(userInputEntry) + " for trip id " + JSON.stringify(tripgj.data.id));
+        $scope.editingTrip = angular.undefined;
     }
 
     $scope.getFormattedDistanceInMiles = function(input) {
@@ -259,8 +235,10 @@ angular.module('emission.main.diary.list',['ui-leaflet',
           Timeline.setTripWrappers(currDayTripWrappers);
 
           $scope.data.currDayTripWrappers.forEach(function(tripgj, index, array) {
-            $scope.populateModeFromTimeline(tripgj, $scope.data.unifiedConfirmsResults.modes);
-            $scope.populatePurposeFromTimeline(tripgj, $scope.data.unifiedConfirmsResults.purposes);
+            tripgj.userInput = {};
+            ConfirmHelper.INPUTS.forEach(function(item, index) {
+                $scope.populateInputFromTimeline(tripgj, item, $scope.data.unifiedConfirmsResults[item]);
+            });
             $scope.populateBasicClasses(tripgj);
             $scope.populateCommonInfo(tripgj);
           });
@@ -389,9 +367,6 @@ angular.module('emission.main.diary.list',['ui-leaflet',
       });
     }
 
-    $scope.userModes = [
-        "walk", "bicycle", "car", "bus", "light_rail", "train", "tram", "subway", "unicorn"
-    ];
     $scope.parseEarlierOrLater = DiaryHelper.parseEarlierOrLater;
 
     $scope.getTimeSplit = function(tripList) {
@@ -506,202 +481,108 @@ angular.module('emission.main.diary.list',['ui-leaflet',
 
     $scope.showModes = DiaryHelper.showModes;
 
-    $ionicPopover.fromTemplateUrl('templates/diary/mode-popover.html', {
-      scope: $scope
-    }).then(function (popover) {
-      $scope.modePopover = popover;
+    $scope.popovers = {};
+    ConfirmHelper.INPUTS.forEach(function(item, index) {
+        let popoverPath = 'templates/diary/'+item.toLowerCase()+'-popover.html';
+        return $ionicPopover.fromTemplateUrl(popoverPath, {
+          scope: $scope
+        }).then(function (popover) {
+          $scope.popovers[item] = popover;
+        });
     });
 
-    $scope.openModePopover = function ($event, tripgj) {
-      var userMode = tripgj.usermode;
-      if (angular.isDefined(userMode)) {
-        $scope.selected.mode.value = userMode.value;
+    $scope.openPopover = function ($event, tripgj, inputType) {
+      var userInput = tripgj.userInput[inputType];
+      if (angular.isDefined(userInput)) {
+        $scope.selected[inputType].value = userInput.value;
       } else {
-        $scope.selected.mode.value = '';
+        $scope.selected[inputType].value = '';
       }
-      $scope.draftMode = {
+      $scope.draftInput = {
         "start_ts": tripgj.data.properties.start_ts,
         "end_ts": tripgj.data.properties.end_ts
       };
-      $scope.modeTripgj = tripgj;
-      Logger.log("in openModePopover, setting draftMode = " + JSON.stringify($scope.draftMode));
-      $scope.modePopover.show($event);
+      $scope.editingTrip = tripgj;
+      Logger.log("in openPopover, setting draftInput = " + JSON.stringify($scope.draftInput));
+      $scope.popovers[inputType].show($event);
     };
 
-    var closeModePopover = function () {
-      $scope.selected.mode = {
+    var closePopover = function (inputType) {
+      $scope.selected[inputType] = {
         value: ''
       };
-      $scope.modePopover.hide();
-    };
-
-    $ionicPopover.fromTemplateUrl('templates/diary/purpose-popover.html', {
-      scope: $scope
-    }).then(function (popover) {
-      $scope.purposePopover = popover;
-    });
-
-    $scope.openPurposePopover = function ($event, tripgj) {
-      var userPurpose = tripgj.userpurpose;
-      if (angular.isDefined(userPurpose)) {
-        $scope.selected.purpose.value = userPurpose.value;
-      } else {
-        $scope.selected.purpose.value = '';
-      }
-
-      $scope.draftPurpose = {
-        "start_ts": tripgj.data.properties.start_ts,
-        "end_ts": tripgj.data.properties.end_ts
-      };
-      $scope.purposeTripgj = tripgj;
-      Logger.log("in openPurposePopover, setting draftPurpose = " + JSON.stringify($scope.draftPurpose));
-      $scope.purposePopover.show($event);
-    };
-
-    var closePurposePopover = function () {
-      $scope.selected.purpose = {
-        value: ''
-      };
-      $scope.purposePopover.hide();
+      $scope.popovers[inputType].hide();
     };
 
     /**
      * Store selected value for options
-     * $scope.selected is for display purpose only
+     * $scope.selected is for display only
      * the value is displayed on popover selected option
      */
-    $scope.selected = {
-      mode: {
-        value: ''
-      },
-      other: {
-        text: '',
-        value: ''
-      },
-      purpose: {
-        value: ''
-      },
-    };
+    $scope.selected = Object.fromEntries(ConfirmHelper.INPUTS.map(function(item, index) {
+        return [item, {value: ''}];
+    }));
+    $scope.selected.other = {text: '', value: ''};
 
     /*
      * This is a curried function that curries the `$scope` variable
      * while returing a function that takes `e` as the input
      */
-    var checkOtherOptionOnTap = function ($scope, choice) {
+    var checkOtherOptionOnTap = function ($scope, inputType) {
         return function (e) {
           if (!$scope.selected.other.text) {
             e.preventDefault();
           } else {
             Logger.log("in choose other, other = " + JSON.stringify($scope.selected));
-            if (choice.value == 'other_mode') {
-              $scope.storeMode($scope.selected.other, true /* isOther */);
-              $scope.selected.other = '';
-            } else if (choice.value == 'other_purpose') {
-              $scope.storePurpose($scope.selected.other, true /* isOther */);
-              $scope.selected.other = '';
-            }
+            $scope.store(inputType, $scope.selected.other, true /* isOther */);
+            $scope.selected.other = '';
             return $scope.selected.other;
           }
         }
     };
 
-    $scope.choosePurpose = function () {
-      var isOther = false;
-      if ($scope.selected.purpose.value != "other_purpose") {
-        $scope.storePurpose($scope.selected.purpose, isOther);
-      } else {
-        isOther = true
-        ConfirmHelper.checkOtherOption($scope.selected.purpose, checkOtherOptionOnTap, $scope);
-      }
-      closePurposePopover();
-    };
-
-    $scope.chooseMode = function () {
+    $scope.choose = function (inputType) {
       var isOther = false
-      if ($scope.selected.mode.value != "other_mode") {
-        $scope.storeMode($scope.selected.mode, isOther);
+      if ($scope.selected[inputType].value != "other") {
+        $scope.store(inputType, $scope.selected[inputType], isOther);
       } else {
         isOther = true
-        ConfirmHelper.checkOtherOption($scope.selected.mode, checkOtherOptionOnTap, $scope);
+        ConfirmHelper.checkOtherOption(inputType, checkOtherOptionOnTap, $scope);
       }
-      closeModePopover();
+      closePopover(inputType);
     };
-
-    /*
-     * Convert the array of {text, value} objects to a {value: text} map so that 
-     * we can look up quickly without iterating over the list for each trip
-     */
-
-    var arrayToMap = function(optionsArray) {
-        var text2entryMap = {};
-        var value2entryMap = {};
-
-        optionsArray.forEach(function(text2val) {
-            text2entryMap[text2val.text] = text2val;
-            value2entryMap[text2val.value] = text2val;
-        });
-        return [text2entryMap, value2entryMap];
-    }
 
     $scope.$on('$ionicView.loaded', function() {
-        ConfirmHelper.getModeOptions().then(function(modeOptions) {
-            $scope.modeOptions = modeOptions;
-            var modeMaps = arrayToMap($scope.modeOptions);
-            $scope.text2entryMode = modeMaps[0];
-            $scope.value2entryMode = modeMaps[1];
-        });
-        ConfirmHelper.getPurposeOptions().then(function(purposeOptions) {
-            $scope.purposeOptions = purposeOptions;
-            var purposeMaps = arrayToMap($scope.purposeOptions);
-            $scope.text2entryPurpose = purposeMaps[0];
-            $scope.value2entryPurpose = purposeMaps[1];
+        $scope.inputParams = {}
+        ConfirmHelper.INPUTS.forEach(function(item) {
+            ConfirmHelper.getOptionsAndMaps(item).then(function(omObj) {
+                $scope.inputParams[item] = omObj;
+            });
         });
     });
 
-    $scope.storeMode = function (mode, isOther) {
+    $scope.store = function (inputType, input, isOther) {
       if(isOther) {
-        // Let's make the value for user entered modes look consistent with our
+        // Let's make the value for user entered inputs look consistent with our
         // other values
-        mode.value = ConfirmHelper.otherTextToValue(mode.text);
+        input.value = ConfirmHelper.otherTextToValue(input.text);
       }
-      $scope.draftMode.label = mode.value;
-      Logger.log("in storeMode, after setting mode.value = " + mode.value + ", draftMode = " + JSON.stringify($scope.draftMode));
-      var tripToUpdate = $scope.modeTripgj;
-      $window.cordova.plugins.BEMUserCache.putMessage(MODE_CONFIRM_KEY, $scope.draftMode).then(function () {
+      $scope.draftInput.label = input.value;
+      Logger.log("in storeInput, after setting input.value = " + input.value + ", draftInput = " + JSON.stringify($scope.draftInput));
+      var tripToUpdate = $scope.editingTrip;
+      $window.cordova.plugins.BEMUserCache.putMessage(ConfirmHelper.inputDetails[inputType].key, $scope.draftInput).then(function () {
         $scope.$apply(function() {
           if (isOther) {
-            tripToUpdate.usermode = ConfirmHelper.getFakeEntry(mode.value);
-            $scope.modeOptions.push(tripToUpdate.usermode);
-            $scope.value2entryMode[mode.value] = tripToUpdate.usermode;
+            tripToUpdate.userInput[inputType] = ConfirmHelper.getFakeEntry(input.value);
+            $scope.inputParams[inputType].options.push(tripToUpdate.userInput[inputType]);
+            $scope.inputParams[inputType].value2entry[input.value] = tripToUpdate.userInput[inputType];
           } else {
-            tripToUpdate.usermode = $scope.value2entryMode[mode.value];
+            tripToUpdate.userInput[inputType] = $scope.inputParams[inputType].value2entry[input.value];
           }
         });
       });
       if (isOther == true)
-        $scope.draftMode = angular.undefined;
-    }
-
-    $scope.storePurpose = function (purpose, isOther) {
-      if (isOther) {
-        purpose.value = ConfirmHelper.otherTextToValue(purpose.text);
-      }
-      $scope.draftPurpose.label = purpose.value;
-      Logger.log("in storePurpose, after setting purpose.value = " + purpose.value + ", draftPurpose = " + JSON.stringify($scope.draftPurpose));
-      var tripToUpdate = $scope.purposeTripgj;
-      $window.cordova.plugins.BEMUserCache.putMessage(PURPOSE_CONFIRM_KEY, $scope.draftPurpose).then(function () {
-        $scope.$apply(function() {
-          if (isOther) {
-            tripToUpdate.userpurpose = ConfirmHelper.getFakeEntry(purpose.value);
-            $scope.purposeOptions.push(tripToUpdate.userpurpose);
-            $scope.value2entryPurpose[purpose.value] = tripToUpdate.userpurpose;
-          } else {
-            tripToUpdate.userpurpose = $scope.value2entryPurpose[purpose.value];
-          }
-        });
-      });
-      if (isOther == true)
-        $scope.draftPurpose = angular.undefined;
+        $scope.draftInput = angular.undefined;
     }
 
     $scope.redirect = function(){

--- a/www/js/tripconfirm/trip-confirm-services.js
+++ b/www/js/tripconfirm/trip-confirm-services.js
@@ -1,15 +1,41 @@
 angular.module('emission.tripconfirm.services', ['ionic', "emission.plugin.logger"])
 .factory("ConfirmHelper", function($http, $ionicPopup, $translate, Logger) {
     var ch = {};
-    ch.otherModes = [];
-    ch.otherPurposes = [];
+    ch.INPUTS = ["MODE", "PURPOSE"]
+    ch.inputDetails = {
+        "MODE": {
+            key: "manual/mode_confirm",
+            otherVals: {}
+        },
+        "PURPOSE": {
+            key: "manual/purpose_confirm",
+            otherVals: {}
+        }
+    }
 
     var fillInOptions = function(confirmConfig) {
         if(confirmConfig.data.length == 0) {
             throw "blank string instead of missing file on dynamically served app";
         }
-        ch.modeOptions = confirmConfig.data.modeOptions;
-        ch.purposeOptions = confirmConfig.data.purposeOptions;
+        ch.INPUTS.forEach(function(i) {
+            ch.inputDetails[i].options = confirmConfig.data[i]
+        });
+    }
+
+    /*
+     * Convert the array of {text, value} objects to a {value: text} map so that 
+     * we can look up quickly without iterating over the list for each trip
+     */
+
+    var arrayToMap = function(optionsArray) {
+        var text2entryMap = {};
+        var value2entryMap = {};
+
+        optionsArray.forEach(function(text2val) {
+            text2entryMap[text2val.text] = text2val;
+            value2entryMap[text2val.value] = text2val;
+        });
+        return [text2entryMap, value2entryMap];
     }
 
     var loadAndPopulateOptions = function (lang) {
@@ -35,52 +61,52 @@ angular.module('emission.tripconfirm.services', ['ionic', "emission.plugin.logge
             });
         });
     }
+
+    ch.getOptionsAndMaps = function(inputType) {
+        return ch.getOptions(inputType).then(function(inputOptions) {
+            var inputMaps = arrayToMap(inputOptions);
+            return {
+                options: inputOptions,
+                text2entry: inputMaps[0],
+                value2entry: inputMaps[1]
+            };
+        });
+    };
     
     /*
      * Lazily loads the options and returns the chosen one. Using this option
      * instead of an in-memory data structure so that we can return a promise
      * and not have to worry about when the data is available.
      */
-    ch.getModeOptions = function() {
-        if (!angular.isDefined(ch.modeOptions)) {
+    ch.getOptions = function(inputType) {
+        if (!angular.isDefined(ch.inputDetails[inputType].options)) {
             var lang = $translate.use();
             return loadAndPopulateOptions(lang)
-                .then(function () { return ch.modeOptions; });
+                .then(function () { return ch.inputDetails[inputType].options; });
         } else {
-            return Promise.resolve(ch.modeOptions);
+            return Promise.resolve(ch.inputDetails[inputType].options);
         }
     }
 
-    ch.getPurposeOptions = function() {
-        if (!angular.isDefined(ch.purposeOptions)) {
-            var lang = $translate.use();
-            return loadAndPopulateOptions(lang)
-                .then(function () { return ch.purposeOptions; });
-        } else {
-            return Promise.resolve(ch.purposeOptions);
-        }
-    }
-
-    ch.checkOtherOption = function(choice, onTapFn, $scope) {
-        if(choice.value == 'other_mode' || choice.value == 'other_purpose') {
-          var text = choice.value == 'other_mode' ? "mode" : "purpose";
-          $ionicPopup.show({title: $translate.instant("trip-confirm.services-please-fill-in",{text: text}),
+    ch.checkOtherOption = function(inputType, onTapFn, $scope) {
+          $ionicPopup.show({title: $translate.instant("trip-confirm.services-please-fill-in",{text: inputType.toLowerCase()}),
             scope: $scope,
             template: '<input type = "text" ng-model = "selected.other.text">',
             buttons: [
                 { text: $translate.instant('trip-confirm.services-cancel'),
                   onTap: function(e) {
-                    $scope.selected.mode = {value: ''};
-                    $scope.selected.purpose = {value: ''};
+                    ch.INPUTS.forEach(function(item) {
+                        $scope.selected[item] = {value: ''};
+                        $scope.selected[item] = {value: ''};
+                    });
                   }
                 }, {
                    text: '<b>' + $translate.instant('trip-confirm.services-save') + '</b>',
                    type: 'button-positive',
-                   onTap: onTapFn($scope, choice)
+                   onTap: onTapFn($scope, inputType)
                 }
             ]
           });
-        }
     }
 
     ch.otherTextToValue = function(otherText) {
@@ -103,4 +129,4 @@ angular.module('emission.tripconfirm.services', ['ionic', "emission.plugin.logge
     }
 
     return ch;
-})
+});

--- a/www/js/tripconfirm/trip-confirm-services.js
+++ b/www/js/tripconfirm/trip-confirm-services.js
@@ -97,7 +97,6 @@ angular.module('emission.tripconfirm.services', ['ionic', "emission.plugin.logge
                   onTap: function(e) {
                     ch.INPUTS.forEach(function(item) {
                         $scope.selected[item] = {value: ''};
-                        $scope.selected[item] = {value: ''};
                     });
                   }
                 }, {

--- a/www/json/trip_confirm_options.json.sample
+++ b/www/json/trip_confirm_options.json.sample
@@ -1,5 +1,5 @@
 {
-  "modeOptions" : [
+  "MODE" : [
        {"text":"Walk", "value":"walk"},
        {"text":"Bike","value":"bike"},
        {"text":"Drove Alone","value":"drove_alone"},
@@ -8,8 +8,8 @@
        {"text":"Bus","value":"bus"},
        {"text":"Train","value":"train"},
        {"text":"Free Shuttle","value":"free_shuttle"},
-       {"text":"Other","value":"other_mode"}],
-    "purposeOptions" : [
+       {"text":"Other","value":"other"}],
+    "PURPOSE" : [
        {"text":"Home", "value":"home"},
        {"text":"Work","value":"work"},
        {"text":"School","value":"school"},
@@ -21,5 +21,5 @@
        {"text":"Recreation/Exercise","value":"exercise"},
        {"text":"Entertainment/Social","value":"entertainment"},
        {"text":"Religious", "value":"religious"},
-       {"text":"Other","value":"other_purpose"}]
+       {"text":"Other","value":"other"}]
 }

--- a/www/templates/diary/list.html
+++ b/www/templates/diary/list.html
@@ -104,25 +104,25 @@
              </div>
              <div class="row" style="padding-left: 5px;padding-right: 5px;">
                 <div class="col-50" style="text-align: center;">
-                    <div ng-if="tripgj.usermode" class="mode-confirm-container">
-                        <button ng-click ="openModePopover($event, tripgj)" class="button btn-mode-confirm btn-mode-confirm-green">
-                            {{tripgj.usermode.text}}
+                    <div ng-if="tripgj.userInput.MODE" class="mode-confirm-container">
+                        <button ng-click ="openPopover($event, tripgj, 'MODE')" class="button btn-mode-confirm btn-mode-confirm-green">
+                            {{tripgj.userInput.MODE.text}}
                         </button>
                     </div>
-                    <div  ng-if="!tripgj.usermode" class="mode-confirm-container">
-                        <button ng-click ="openModePopover($event, tripgj)" class="button btn-mode-confirm btn-mode-confirm-white" translate>
+                    <div  ng-if="!tripgj.userInput.MODE" class="mode-confirm-container">
+                        <button ng-click ="openPopover($event, tripgj, 'MODE')" class="button btn-mode-confirm btn-mode-confirm-white" translate>
                         {{'.choose-mode'}}
                         </button>
                     </div>
                 </div>
                 <div class="col-50" style="text-align: center;">
-                    <div ng-if="tripgj.userpurpose" class="purpose-confirm-container">
-                        <button ng-click="openPurposePopover($event, tripgj)" class="button btn-purpose-confirm btn-purpose-confirm-green">
-                            {{tripgj.userpurpose.text}}
+                    <div ng-if="tripgj.userInput.PURPOSE" class="purpose-confirm-container">
+                        <button ng-click="openPopover($event, tripgj, 'PURPOSE')" class="button btn-purpose-confirm btn-purpose-confirm-green">
+                            {{tripgj.userInput.PURPOSE.text}}
                         </button>
                     </div>
-                    <div ng-if="!tripgj.userpurpose" class="purpose-confirm-container">
-                        <button ng-click="openPurposePopover($event, tripgj)" class="button btn-purpose-confirm btn-purpose-confirm-white" translate>
+                    <div ng-if="!tripgj.userInput.PURPOSE" class="purpose-confirm-container">
+                        <button ng-click="openPopover($event, tripgj, 'PURPOSE')" class="button btn-purpose-confirm btn-purpose-confirm-white" translate>
                         {{'.choose-purpose'}}
                         </button>
                     </div>

--- a/www/templates/diary/mode-popover.html
+++ b/www/templates/diary/mode-popover.html
@@ -3,8 +3,8 @@
       <h2 class = "title" translate>{{'diary.select-mode-scroll'}}</h2>
    </ion-header-bar>
    <ion-content>
-      	<ion-list ng-repeat="mode in modeOptions">
-		    <ion-radio ng-click="chooseMode()" ng-model="selected.mode.value" ng-value="mode.value">{{mode.text}}</ion-radio>
+        <ion-list ng-repeat="mode in inputParams.MODE.options">
+		    <ion-radio ng-click="choose('MODE')" ng-model="selected.MODE.value" ng-value="mode.value">{{mode.text}}</ion-radio>
 		</ion-list>
    </ion-content>
 </ion-popover-view>

--- a/www/templates/diary/purpose-popover.html
+++ b/www/templates/diary/purpose-popover.html
@@ -3,8 +3,8 @@
       <h2 class = "title" translate>{{'diary.select-purpose-scroll'}}</h2>
    </ion-header-bar>
    <ion-content>
-      	<ion-list ng-repeat="purpose in purposeOptions">
-		    <ion-radio ng-click="choosePurpose()" ng-model="selected.purpose.value" ng-value="purpose.value">{{purpose.text}}</ion-radio>
+        <ion-list ng-repeat="purpose in inputParams.PURPOSE.options">
+		    <ion-radio ng-click="choose('PURPOSE')" ng-model="selected.PURPOSE.value" ng-value="purpose.value">{{purpose.text}}</ion-radio>
 		</ion-list>
    </ion-content>
 </ion-popover-view>


### PR DESCRIPTION
The mode and purpose code had a lot of copy-pasted components that were
different only in variable names. Copy-pasting is bad and does not follow the
DRY principle.

And this is only going to get worse as we want to add counter-factual mode
selection as a third dropdown.

Prior to that, we refactor the confirmation code to be DRY.
The list of confirmation keys is defined in `www/js/tripconfirm/trip-confirm-services.js`
and the corresponding options are in `www/json/trip_confirm_options.json.sample`

At this point, we also have separate popover templates in `www/templates/diary`
(in case we want the text to be different) and separate buttons in
`www/templates/diary/list.html`

Everything else takes the `inputType` as a parameter or iterates over all input
types and is completely generic.

Testing done:
- on both android and iOS:
    - created trips to show in the diary
    - selected various pre-defined mode and purpose and "other" options
    - pre-defined modes were selected
    - other options were selected and added to the list
    - cancelling the other popup also worked :)