### PR TITLE
Use pre-filled survey URLs to autopopulate values for google forms

### DIFF
--- a/www/js/survey/launch.js
+++ b/www/js/survey/launch.js
@@ -161,6 +161,23 @@ angular.module('emission.survey.launch', ['emission.services',
         startSurveyCommon(url, elementXPath, "js/survey/uuid_insert_xpath.js");
     }
 
+    surveylaunch.startSurveyPrefilled = function (url, uuidSearchParam) {
+      CommHelper.getUser().then(function(userProfile) {
+        // alert("finished loading script");
+        let uuid = userProfile.user_id['$uuid']
+        Logger.log("inserting user id into survey. userId = "+ uuid
+                      +" base url = "+url);
+        let urlObj = new URL(url);
+        urlObj.searchParams.append(uuidSearchParam, uuid);
+        let modifiedURL = urlObj.href;
+        Logger.log("modified URL = "+modifiedURL);
+        let iab = $window.cordova.InAppBrowser.open(modifiedURL, '_blank', surveylaunch.options);
+        iab.addEventListener('loaderror', function(event) {
+          Logger.displayError("Unable to launch survey", event);
+        });
+      });
+    }
+
     surveylaunch.init = function() {
       $rootScope.$on('cloud:push:notification', function(event, data) {
         Logger.log("data = "+JSON.stringify(data));
@@ -175,6 +192,8 @@ angular.module('emission.survey.launch', ['emission.services',
                   surveylaunch.startSurveyWithID(survey_spec.url, survey_spec.uuidElementId);
                 } else if (angular.isDefined(survey_spec.uuidXPath)) {
                   surveylaunch.startSurveyWithXPath(survey_spec.url, survey_spec.uuidXPath);
+                } else if (angular.isDefined(survey_spec.uuidSearchParam)) {
+                  surveylaunch.startSurveyPrefilled(survey_spec.url, survey_spec.uuidSearchParam);
                 } else {
                     $ionicPopup.alert("survey was not specified correctly. spec is "+JSON.stringify(survey_spec));
                 }


### PR DESCRIPTION
The previous method of setting the element value directly does not work,
possibly as a workaround to prevent bots filling out forms.

Testing done:
- Deployed as part of the CanBikeCO project

This fixes
https://github.com/e-mission/e-mission-docs/issues/582