### PR TITLE
Store a bunch of device settings that can help debug any tracking iss…

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -70,6 +70,7 @@
     <script src="js/splash/updatecheck.js"></script>
     <script src="js/splash/startprefs.js"></script>
     <script src="js/splash/pushnotify.js"></script>
+    <script src="js/splash/storedevicesettings.js"></script>
     <script src="js/splash/localnotify.js"></script>
     <script src="js/controllers.js"></script>
     <script src="js/services.js"></script>

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -3,6 +3,7 @@
 angular.module('emission.controllers', ['emission.splash.updatecheck',
                                         'emission.splash.startprefs',
                                         'emission.splash.pushnotify',
+                                        'emission.splash.storedevicesettings',
                                         'emission.splash.localnotify',
                                         'emission.survey.launch',
                                         'emission.stats.clientstats',
@@ -13,7 +14,7 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('DashCtrl', function($scope) {})
 
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope, 
-    UpdateCheck, StartPrefs, PushNotify,
+    UpdateCheck, StartPrefs, PushNotify, StoreDeviceSettings,
     LocalNotify, ClientStats, PostTripAutoPrompt, SurveyLaunch)  {
   console.log('SplashCtrl invoked');
   // alert("attach debugger!");

--- a/www/js/splash/storedevicesettings.js
+++ b/www/js/splash/storedevicesettings.js
@@ -1,0 +1,59 @@
+angular.module('emission.splash.storedevicesettings', ['emission.plugin.logger',
+                                             'emission.services',
+                                             'emission.splash.startprefs'])
+.factory('StoreDeviceSettings', function($window, $state, $rootScope, $ionicPlatform,
+    $ionicPopup, $translate, Logger, CommHelper, StartPrefs) {
+
+    var storedevicesettings = {};
+
+    storedevicesettings.storeDeviceSettings = function() {
+      var lang = $translate.use();
+      var manufacturer = $window.device.manufacturer;
+      var osver = $window.device.version;
+      return $window.cordova.getAppVersion.getVersionNumber().then(function(appver) {
+        var updateJSON = {
+          phone_lang: lang,
+          curr_platform: ionic.Platform.platform(),
+          manufacturer: manufacturer,
+          client_os_version: osver,
+          client_app_version: appver
+        };
+        Logger.log("About to update profile with settings = "+JSON.stringify(updateJSON));
+        return CommHelper.updateUser(updateJSON);
+      }).then(function(updateJSON) {
+         // alert("Finished saving token = "+JSON.stringify(t.token));
+      }).catch(function(error) {
+        Logger.displayError("Error in updating profile to store device settings", error);
+      });
+    }
+
+    $ionicPlatform.ready().then(function() {
+      storedevicesettings.datacollect = $window.cordova.plugins.BEMDataCollection;
+      StartPrefs.readConsentState()
+        .then(StartPrefs.isConsented)
+        .then(function(consentState) {
+          if (consentState == true) {
+              storedevicesettings.storeDeviceSettings();
+          } else {
+            Logger.log("no consent yet, waiting to store device settings in profile");
+          }
+        });
+      Logger.log("storedevicesettings startup done");
+    });
+
+    $rootScope.$on(StartPrefs.CONSENTED_EVENT, function(event, data) {
+      console.log("got consented event "+JSON.stringify(event.name)
+                      +" with data "+ JSON.stringify(data));
+      if (StartPrefs.isIntroDone()) {
+          console.log("intro is done -> reconsent situation, we already have a token -> register");
+          storedevicesettings.storeDeviceSettings();
+      }
+    });
+
+    $rootScope.$on(StartPrefs.INTRO_DONE_EVENT, function(event, data) {
+          console.log("intro is done -> original consent situation, we should have a token by now -> register");
+       storedevicesettings.storeDeviceSettings();
+    });
+
+    return storedevicesettings;
+});


### PR DESCRIPTION
…ues on the phone

I was going to store the language in the profile as part of the CEO ebike
project, so that we can serve separate English and Spanish surveys. And since I
was adding a background updater to the startup anyway, I though that I might as
well add other device settings that may help debug tracking issues, such as the
app version, the OS version, and the manufacturer (for https://dontkillmyapp.com/).

This fixes an issue requested by @asiripanich as part of the UNSW study, but I
am not able to find it to auto-close :(

Testing done:
- Integrated it into the CanBikeCo branch
- Ensured that the values were saved into the profile database
- Thanks to the magic of autogenerated tables, the new fields even show up in
  the participant view

- Dropped the connection
- Launched the app again
- Ensured that an error message was generated