### PR TITLE
Heavy lifting for supporting the option to upload the phone log

### DIFF
--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -60,6 +60,7 @@
         "check-ui-updates": "Check for UI updates",
         "download-json-dump": "Download json dump",
         "email-log": "Email log",
+        "upload-log": "Upload log",
         "user-data": "User data",
         "erase-data": "Erase data",
         "dev-zone": "Developer zone",
@@ -244,6 +245,12 @@
             "subject-data-dump-from-to": "Data dump from {{start}} to {{end}}",
             "body-data-consists-of-list-of-entries": "Data consists of a list of entries.\nEntry formats are at https://github.com/e-mission/e-mission-server/tree/master/emission/core/wrapper \nData can be loaded locally using instructions at https://github.com/e-mission/e-mission-server#loading-test-data \n and can be manipulated using the example at https://github.com/e-mission/e-mission-server/blob/master/Timeseries_Sample.ipynb"
         }
+    },
+
+    "upload-service":{
+        "upload-from-dir": "Uploading from directory {{parentDir}}",
+        "going-to-email": "Going to email database from {{parentDir}}",
+        "please-fill-in-what-is-wrong": "please fill in what is wrong",
     },
 
     "intro": {

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -254,6 +254,7 @@
         "going-to-email": "Going to email database from {{parentDir}}",
         "please-fill-in-what-is-wrong": "please fill in what is wrong",
         "upload-success": "Upload successful",
+        "upload-progress": "Sending {{filesizemb | number}} MB to {{serverURL}}",
         "upload-details": "Sent {{filesizemb | number}} MB to {{serverURL}}"
     },
 

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -248,9 +248,11 @@
     },
 
     "upload-service":{
-        "upload-from-dir": "Uploading from directory {{parentDir}}",
+        "upload-database": "Uploading database {{db}}",
+        "upload-from-dir": "from directory {{parentDir}}",
+        "upload-to-server": "to servers {{serverURL}}",
         "going-to-email": "Going to email database from {{parentDir}}",
-        "please-fill-in-what-is-wrong": "please fill in what is wrong",
+        "please-fill-in-what-is-wrong": "please fill in what is wrong"
     },
 
     "intro": {

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -252,7 +252,9 @@
         "upload-from-dir": "from directory {{parentDir}}",
         "upload-to-server": "to servers {{serverURL}}",
         "going-to-email": "Going to email database from {{parentDir}}",
-        "please-fill-in-what-is-wrong": "please fill in what is wrong"
+        "please-fill-in-what-is-wrong": "please fill in what is wrong",
+        "upload-success": "Upload successful",
+        "upload-details": "Sent {{filesizemb | number}} MB to {{serverURL}}"
     },
 
     "intro": {

--- a/www/index.html
+++ b/www/index.html
@@ -99,6 +99,7 @@
     <script src="js/goals.js"></script>
     <script src="js/control/general-settings.js"></script>
     <script src="js/control/emailService.js"></script>
+    <script src="js/control/uploadService.js"></script>
     <script src="js/control/collect-settings.js"></script>
     <script src="js/control/sync-settings.js"></script>
     <script src="js/control/transition-notify-settings.js"></script>

--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -17,7 +17,7 @@ angular.module('emission.main.control',['emission.services',
                $ionicPlatform,
                $state, $ionicPopup, $ionicActionSheet, $ionicPopover,
                $rootScope, KVStore, ionicDatePicker,
-               StartPrefs, ControlHelper, UploadHelper,
+               StartPrefs, ControlHelper, EmailHelper, UploadHelper,
                ControlCollectionHelper, ControlSyncHelper,
                ControlTransitionNotifyHelper,
                CarbonDatasetHelper,
@@ -54,9 +54,14 @@ angular.module('emission.main.control',['emission.services',
 
     $scope.carbonDatasetString = $translate.instant('general-settings.carbon-dataset') + ": " + CarbonDatasetHelper.getCurrentCarbonDatasetCode();
 
-    $scope.emailLog = function () {
+    $scope.uploadLog = function () {
         // Passing true, we want to send logs
         UploadHelper.uploadFile("loggerDB")
+    };
+
+    $scope.emailLog = function () {
+        // Passing true, we want to send logs
+        EmailHelper.sendEmail("loggerDB")
     };
 
     $scope.userData = []

--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -17,7 +17,7 @@ angular.module('emission.main.control',['emission.services',
                $ionicPlatform,
                $state, $ionicPopup, $ionicActionSheet, $ionicPopover,
                $rootScope, KVStore, ionicDatePicker,
-               StartPrefs, ControlHelper, EmailHelper,
+               StartPrefs, ControlHelper, UploadHelper,
                ControlCollectionHelper, ControlSyncHelper,
                ControlTransitionNotifyHelper,
                CarbonDatasetHelper,
@@ -56,7 +56,7 @@ angular.module('emission.main.control',['emission.services',
 
     $scope.emailLog = function () {
         // Passing true, we want to send logs
-        EmailHelper.sendEmail("loggerDB")
+        UploadHelper.uploadFile("loggerDB")
     };
 
     $scope.userData = []

--- a/www/js/control/uploadService.js
+++ b/www/js/control/uploadService.js
@@ -5,19 +5,19 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
     .service('UploadHelper', function ($window, $translate, $http, $rootScope, $ionicPopup, Logger) {
         const getUploadConfig = function () {
             return new Promise(function (resolve, reject) {
-                window.Logger.log(window.Logger.LEVEL_INFO, "About to get email config");
+                Logger.log(Logger.LEVEL_INFO, "About to get email config");
                 var url = [];
                 $http.get("json/uploadConfig.json").then(function (uploadConfig) {
-                    window.Logger.log(window.Logger.LEVEL_DEBUG, "uploadConfigString = " + JSON.stringify(uploadConfig.data));
+                    Logger.log(Logger.LEVEL_DEBUG, "uploadConfigString = " + JSON.stringify(uploadConfig.data));
                     url.push(uploadConfig.data.url)
                     resolve(url);
                 }).catch(function (err) {
                     $http.get("json/uploadConfig.json.sample").then(function (uploadConfig) {
-                        window.Logger.log(window.Logger.LEVEL_DEBUG, "default uploadConfigString = " + JSON.stringify(uploadConfig.data));
+                        Logger.log(Logger.LEVEL_DEBUG, "default uploadConfigString = " + JSON.stringify(uploadConfig.data));
                         url.push(uploadConfig.data.url)
                         resolve(url);
                     }).catch(function (err) {
-                        window.Logger.log(window.Logger.LEVEL_ERROR, "Error while reading default upload config" + err);
+                        Logger.log(Logger.LEVEL_ERROR, "Error while reading default upload config" + err);
                         reject(err);
                     });
                 });
@@ -92,10 +92,13 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
 
             const newScope = $rootScope.$new();
             newScope.data = {};
+            newScope.fromDirText = $translate.instant('upload-service.upload-from-dir',  {parentDir: parentDir});
+            newScope.toServerText = $translate.instant('upload-service.upload-to-server',  {serverURL: uploadConfig});
 
             const detailsPopup = $ionicPopup.show({
-                title: $translate.instant("upload-service.upload-from-dir", { parentDir: parentDir }),
-                template: '<input type="text" ng-model="data.reason"'
+                title: $translate.instant("upload-service.upload-database", { db: database }),
+                template: newScope.toServerText
+                    + '<input type="text" ng-model="data.reason"'
                     +' placeholder="{{ \'upload-service.please-fill-in-what-is-wrong \' | translate}}">',
                 scope: newScope,
                 buttons: [
@@ -115,7 +118,7 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                 ]
             });
 
-            window.Logger.log(window.Logger.LEVEL_INFO, "Going to upload " + database);
+            Logger.log(Logger.LEVEL_INFO, "Going to upload " + database);
             const readFileAndInfo = [readDBFile(database), detailsPopup];
             Promise.all(readFileAndInfo).then((binString, reason) => {
                 const fd = new FormData();

--- a/www/js/control/uploadService.js
+++ b/www/js/control/uploadService.js
@@ -1,0 +1,132 @@
+'use strict';
+
+angular.module('emission.services.upload', ['emission.plugin.logger'])
+
+    .service('UploadHelper', function ($window, $translate, $http, $rootScope, $ionicPopup, Logger) {
+        const getUploadConfig = function () {
+            return new Promise(function (resolve, reject) {
+                window.Logger.log(window.Logger.LEVEL_INFO, "About to get email config");
+                var url = [];
+                $http.get("json/uploadConfig.json").then(function (uploadConfig) {
+                    window.Logger.log(window.Logger.LEVEL_DEBUG, "uploadConfigString = " + JSON.stringify(uploadConfig.data));
+                    url.push(uploadConfig.data.url)
+                    resolve(url);
+                }).catch(function (err) {
+                    $http.get("json/uploadConfig.json.sample").then(function (uploadConfig) {
+                        window.Logger.log(window.Logger.LEVEL_DEBUG, "default uploadConfigString = " + JSON.stringify(uploadConfig.data));
+                        url.push(uploadConfig.data.url)
+                        resolve(url);
+                    }).catch(function (err) {
+                        window.Logger.log(window.Logger.LEVEL_ERROR, "Error while reading default upload config" + err);
+                        reject(err);
+                    });
+                });
+            });
+        }
+
+        const onReadError = function(err) {
+            Logger.displayError("Error while reading log", err);
+        }
+
+        const onUploadError = function(err) {
+            Logger.displayError("Error while uploading log", err);
+        }
+
+        const readDBFile = function(database, callbackFn) {
+            return new Promise(function(resolve, reject) {
+                const storageRoot = cordova.file.applicationStorageDirectory;
+                window.resolveLocalFileSystemURL(storageRoot, function(fs) {
+                    fs.filesystem.root.getFile(fs.fullPath+"databases/"+database, null, (fileEntry) => {
+                        console.log(fileEntry);
+                        fileEntry.file(function(file) {
+                          console.log(file);
+                          var reader = new FileReader();
+
+                          reader.onprogress = function(report) {
+                            console.log("Current progress is "+JSON.stringify(report));
+                            if (callbackFn != undefined) {
+                                callbackFn(report.loaded * 100 / report.total);
+                            }
+                          }
+
+                          reader.onerror = function(error) {
+                            console.log(this.error);
+                            reject({"error": {"message": this.error}});
+                          }
+
+                          reader.onload = function() {
+                            console.log("Successful file read with " + this.result.length +" characters");
+                            resolve(this.result);
+                          }
+
+                          reader.readAsBinaryString(file);
+                        }, reject);
+                    }, reject);
+                });
+            });
+        }
+
+        const sendToServer = function upload(url, formData) {
+            var config = {
+                headers: {'Content-Type': "undefined"},
+                transformRequest: []
+            };
+            return $http.post(url, formData, config);
+        }
+
+        this.uploadFile = function (database) {
+          getUploadConfig().then((uploadConfig) => {
+            var parentDir = "unknown";
+
+            if (ionic.Platform.isAndroid()) {
+                parentDir = cordova.file.applicationStorageDirectory+"/databases";
+            }
+            if (ionic.Platform.isIOS()) {
+                alert($translate.instant('email-service.email-account-mail-app'));
+                parentDir = cordova.file.dataDirectory + "../LocalDatabase";
+            }
+
+            if (parentDir === "unknown") {
+                alert("parentDir unexpectedly = " + parentDir + "!")
+            }
+
+            const newScope = $rootScope.$new();
+            newScope.data = {};
+
+            const detailsPopup = $ionicPopup.show({
+                title: $translate.instant("upload-service.upload-from-dir", { parentDir: parentDir }),
+                template: '<input type="text" ng-model="data.reason"'
+                    +' placeholder="{{ \'upload-service.please-fill-in-what-is-wrong \' | translate}}">',
+                scope: newScope,
+                buttons: [
+                  { text: 'Cancel' },
+                  {
+                    text: '<b>Upload</b>',
+                    type: 'button-positive',
+                    onTap: function(e) {
+                      if (!newScope.data.reason) {
+                        //don't allow the user to close unless he enters wifi password
+                        e.preventDefault();
+                      } else {
+                        return newScope.data.reason;
+                      }
+                    }
+                  }
+                ]
+            });
+
+            window.Logger.log(window.Logger.LEVEL_INFO, "Going to upload " + database);
+            const readFileAndInfo = [readDBFile(database), detailsPopup];
+            Promise.all(readFileAndInfo).then((binString, reason) => {
+                const fd = new FormData();
+                fd.append("reason", reason);
+                fd.append("rawFile", binString);
+                uploadConfig.forEach((url) => {
+                    sendToServer(url, fd).then((response) => {
+                        console.log(response);
+                    }).catch(onUploadError);
+                });
+            }).catch(onReadError);
+          }).catch(onReadError);
+        };
+});

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -9,7 +9,7 @@ angular.module('emission.main', ['emission.main.recent',
                                  'emission.main.metrics',
                                  'emission.tripconfirm.posttrip.map',
                                  'emission.services',
-                                 'emission.services.email'])
+                                 'emission.services.upload'])
 
 .config(function($stateProvider, $ionicConfigProvider, $urlRouterProvider) {
   $stateProvider

--- a/www/json/uploadConfig.json.sample
+++ b/www/json/uploadConfig.json.sample
@@ -1,0 +1,3 @@
+{
+    "url": "http://fill.me.in <replace with httpbin.org for testing, note that this uploads unencrypted data. replace with your final upload server for production>"
+}

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -58,7 +58,12 @@
 
     <div class="control-list-item">
       <div class="control-list-text" translate>{{'.upload-log'}}</div>
-      <div ng-click="emailLog()" class="control-icon-button"><i class="ion-android-upload"></i></div>
+      <div ng-click="uploadLog()" class="control-icon-button"><i class="ion-android-upload"></i></div>
+    </div>
+
+    <div class="control-list-item">
+      <div class="control-list-text" translate>{{'.email-log'}}</div>
+      <div ng-click="emailLog()" class="control-icon-button"><i class="ion-android-mail"></i></div>
     </div>
 
     <div class="control-list-item" ng-show="userDataSaved()">

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -57,8 +57,8 @@
     </div>
 
     <div class="control-list-item">
-      <div class="control-list-text" translate>{{'.email-log'}}</div>
-      <div ng-click="emailLog()" class="control-icon-button"><i class="ion-android-mail"></i></div>
+      <div class="control-list-text" translate>{{'.upload-log'}}</div>
+      <div ng-click="emailLog()" class="control-icon-button"><i class="ion-android-upload"></i></div>
     </div>
 
     <div class="control-list-item" ng-show="userDataSaved()">


### PR DESCRIPTION
Instead of emailing it.
This is a partial fix for https://github.com/e-mission/e-mission-docs/issues/609

Has only been tested on android, needs to be tested on iOS as well

Main changes:
- add a new upload service
- figure out how to read the phone logs into memory from the app ecosystem
- figure out how to format them as phone data
- include a popup to gather additional information
- combine info from popup along with phone logs and upload to a test site

Change the control screen to upload instead of emailing logs

There are other improvements we can make, but let's get this checked in first