### PR TITLE
Switch to es5-compatible version of bottleneck

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -116,7 +116,7 @@
     <script src="lib/nvd3/build/nv.d3.min.js"></script>
     <script src="lib/angular-nvd3/dist/angular-nvd3.min.js"></script>
     <script src="lib/nz-tour/dist/nz-tour.min.js"></script>
-    <script src="lib/bottleneck/light.js"></script>
+    <script src="lib/bottleneck/es5.js"></script>
     <link rel="stylesheet" href="lib/nvd3/build/nv.d3.css">
   </head>
 


### PR DESCRIPTION
So it works on older versions of android and iOS
Not sure how necessary this backward-compat is, but the test phones are set up
to not upgrade, so I ran into this with them.
We should decide when to move beyond es5 to es2017 at least :)
es5 = 2009
es2017 = 2017

without this fix, we get a syntax error and white screen on older android
(force no update for webview) or iOS 12