### PR TITLE
Add support for aggregate auth on this phone as well

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -52,6 +52,7 @@ angular.module('emission', ['ionic',
         }
         Logger.log("connectionConfigString = "+JSON.stringify(connectionConfig.data));
         $rootScope.connectUrl = connectionConfig.data.connectUrl;
+        $rootScope.aggregateAuth = connectionConfig.data.aggregate_call_auth;
         window.cordova.plugins.BEMConnectionSettings.setSettings(connectionConfig.data);
     }).catch(function(err) {
         // not displaying the error here since we have a backup
@@ -59,6 +60,7 @@ angular.module('emission', ['ionic',
         window.cordova.plugins.BEMConnectionSettings.getDefaultSettings().then(function(defaultConfig) {
             Logger.log("defaultConfig = "+JSON.stringify(defaultConfig));
             $rootScope.connectUrl = defaultConfig.connectUrl;
+            $rootScope.aggregateAuth = "no_auth";
             window.cordova.plugins.BEMConnectionSettings.setSettings(defaultConfig);
         }).catch(function(err) {
             // displaying the error here since we don't have a backup

--- a/www/js/diary/current.js
+++ b/www/js/diary/current.js
@@ -240,7 +240,7 @@
           removeExistingIncidentMarkers(_map, _serverIncidentMarkers);
           _serverIncidentMarkers = [];
           if(res.data.incidents.length > 0) {
-            addIncidents(res.data.incidents, _map, _serverIncidentMarkers);
+            addIncidents(res.incidents, _map, _serverIncidentMarkers);
           }
           });
       }, function(error){

--- a/www/js/heatmap.js
+++ b/www/js/heatmap.js
@@ -46,10 +46,11 @@ angular.module('emission.main.heatmap',['ui-leaflet', 'emission.services',
     Logger.log("Sending data "+JSON.stringify(data));
     return CommHelper.getAggregateData("result/heatmap/pop.route/local_date", data)
     .then(function(response) {
-      if (angular.isDefined(response.data.lnglat)) {
-        Logger.log("Got points in heatmap "+response.data.lnglat.length);
+      console.log("Pop route query response = "+response);
+      if (angular.isDefined(response.lnglat)) {
+        Logger.log("Got points in heatmap "+response.lnglat.length);
         $scope.$apply(function() {
-            $scope.showHeatmap(response.data.lnglat);
+            $scope.showHeatmap(response.lnglat);
         });
       } else {
         Logger.log("did not find latlng in response data "+JSON.stringify(response.data));
@@ -270,8 +271,8 @@ angular.module('emission.main.heatmap',['ui-leaflet', 'emission.services',
   };
 
   $scope.getHeatmaps = function() {
-    $scope.getPopRoute().finally($scope.switchSelData);
-    $scope.getIncidents().finally($scope.switchSelData);
+    $scope.getPopRoute().then($scope.switchSelData).catch($scope.switchSelData);
+    $scope.getIncidents().then($scope.switchSelData).catch($scope.switchSelData);
   }
 
   /*
@@ -293,13 +294,14 @@ angular.module('emission.main.heatmap',['ui-leaflet', 'emission.services',
     Logger.log("Sending data "+JSON.stringify(data));
     return CommHelper.getAggregateData("result/heatmap/incidents/local_date", data)
     .then(function(response) {
-      if (angular.isDefined(response.data.incidents)) {
+      console.log("Incident query response = "+response);
+      if (angular.isDefined(response.incidents)) {
         $scope.$apply(function() {
-            Logger.log("Got incidents"+response.data.incidents.length);
-            $scope.showIncidents(response.data.incidents);
+            Logger.log("Got incidents"+response.incidents.length);
+            $scope.showIncidents(response.incidents);
         });
       } else {
-        Logger.log("did not find incidents in response data "+JSON.stringify(response.data));
+        Logger.log("did not find incidents in response data "+JSON.stringify(response));
       }
       $scope.stressData.isLoading = false;
     }, function(error) {

--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -503,7 +503,7 @@ angular.module('emission.main.metrics',['nvd3',
       })
 
       getAggMetricsFromServer().then(function(results) {
-          $scope.fillAggregateValues(results.data.aggregate_metrics);
+          $scope.fillAggregateValues(results.aggregate_metrics);
           $scope.uictrl.hasAggr = true;
           if (angular.isDefined($scope.chartDataAggr)) { //Only have to check one because
             // Restore the $apply if/when we go away from $http

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -185,19 +185,30 @@ angular.module('emission.services', ['emission.plugin.logger',
     this.getAggregateData = function(path, data) {
         return new Promise(function(resolve, reject) {
           const full_url = $rootScope.connectUrl+"/"+path;
-          console.log("getting aggregate data without user authentication from "
-            + full_url +" with arguments "+JSON.stringify(data));
-          const options = {
-              method: 'post',
-              data: data,
-              responseType: 'json'
+          data["aggregate"] = true
+
+          if ($rootScope.aggregateAuth === "no_auth") {
+              console.log("getting aggregate data without user authentication from "
+                + full_url +" with arguments "+JSON.stringify(data));
+              const options = {
+                  method: 'post',
+                  data: data,
+                  responseType: 'json'
+              }
+              cordova.plugin.http.sendRequest(full_url, options,
+              function(response) {
+                resolve(response.data);
+              }, function(error) {
+                reject(error);
+              });
+          } else {
+              console.log("getting aggregate data with user authentication from "
+                + full_url +" with arguments "+JSON.stringify(data));
+              var msgFiller = function(message) {
+                return Object.assign(message, data);
+              };
+              window.cordova.plugins.BEMServerComm.pushGetJSON("/"+path, msgFiller, resolve, reject);
           }
-          cordova.plugin.http.sendRequest(full_url, options,
-          function(response) {
-            resolve(response);
-          }, function(error) {
-            reject(error);
-          });
         });
     };
 })

--- a/www/json/connectionConfig.googleauth.json.sample
+++ b/www/json/connectionConfig.googleauth.json.sample
@@ -1,5 +1,6 @@
 {
     "connectUrl": "https://<your-production-host>:8080",
+    "aggregate_call_auth": "no_auth",
     "android": {
         "auth": {
             "method": "google-authutil",

--- a/www/json/connectionConfig.openid.json.sample
+++ b/www/json/connectionConfig.openid.json.sample
@@ -1,5 +1,6 @@
 {
   "connectUrl": "<e-mission server url, including host and port>",
+  "aggregate_call_auth": "no_auth",
   "android": {
     "auth": {
       "method": "openid-authutil",

--- a/www/json/connectionConfig.physical_device2localhost.json.sample
+++ b/www/json/connectionConfig.physical_device2localhost.json.sample
@@ -1,5 +1,6 @@
 {
     "connectUrl": "http://<your laptop ip>:8080",
+    "aggregate_call_auth": "no_auth",
     "android": {
         "auth": {
             "method": "prompted-auth",

--- a/www/json/connectionConfig.token_list.json.sample
+++ b/www/json/connectionConfig.token_list.json.sample
@@ -1,5 +1,6 @@
 {
     "connectUrl": "<e-mission server url, including host and port>",
+    "aggregate_call_auth": "no_auth",
     "android": {
         "auth": {
             "method": "prompted-auth",


### PR DESCRIPTION
This fixes https://github.com/e-mission/e-mission-docs/issues/408
and is a partial fix for
https://github.com/e-mission/e-mission-docs/issues/628

Fix is fairly straightforward:
- introduce a `aggregate_call_auth` config option, similar to the server
- if is it set to `no_auth`, use the `cordova.plugin.http.sendRequest` as before
- if it is set to `user_only`, call
  `window.cordova.plugins.BEMServerComm.pushGetJSON` similar to the existing
  user calls

`window.cordova.plugins.BEMServerComm.pushGetJSON` returns the data from the
response instead of the response directly. So change the `no_auth` option to
also return the response data, and change all calling functions to access
`response.foo` instead of `response.data.foo`

Bonus fix: `finally` breaks on android 27 emulator, use `then().catch()`
instead.

Testing done:
- with a server configured for `no_auth`
    - client = `no_auth` works
- with a server configured for `user_only`
    - client = `no_auth` fails
    ```
    2021-03-16 16:58:42.465 23394-23394/edu.berkeley.eecs.emission.devapp I/chromium: [INFO:CONSOLE(145)] "ERROR:Error loading aggregate data, averages not available{"status":403,"url":"http://10.0.2.2:8080/result/metrics/timestamp","headers":{"date":"Tue, 16 Mar 2021 23:59:25 GMT","content-length":"761","server":"Cheroot/8.4.2","x-android-selected-protocol":"http/1.1","x-android-response-source":"NETWORK 403","x-android-received-millis":"1615939122220","x-android-sent-millis":"1615939122206","content-type":"text/html; charset=UTF-8"},"error":"\n    <!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n    <html>\n        <head>\n            <title>Error: 403 Forbidden</title>\n            <style type=\"text/css\">\n              html {background-color: #eee; font-family: sans-serif;}\n              body {background-color: #fff; border: 1px solid #ddd;\n                    padding: 15px; margin: 15px;}\n              pre {background-color: #eee; border: 1px solid #ddd; padding: 5px;}\n            </style>\n        </head>\n        <body>\n            <h1>Error: 403 Forbidden</h1>\n            <p>Sorry, the requested URL <tt>&#039;http://10.0.2.2:8080/result/metrics/timestamp&#039;</tt>\n               caused an error:</p>\n            <pre>aggregations only available to users</pre>\n        </body>\n    </html>\n"}", source: http://localhost/_app_file_/data/user/0/edu.berkeley.eecs.emission.devapp/files/phonegapdevapp/www/index.html (145)
    ```
    - client = `user_only` succeeds
    ```
    2021-03-16 18:52:47,214:DEBUG:123145648730112:START POST /result/metrics/timestamp
    2021-03-16 18:52:47,214:DEBUG:123145648730112:Aggregate call, checking user_only policy
    2021-03-16 18:52:47,214:DEBUG:123145648730112:methodName = skip, returning <class 'emission.net.auth.skip.SkipMethod'>
    2021-03-16 18:52:47,215:DEBUG:123145648730112:Using the skip method to verify id token REPLACEMEkVVdF9rT of length 17
    2021-03-16 18:52:47,216:DEBUG:123145648730112:retUUID = cf8ccb7b-84d7-40e4-a726-7691e614b042
    2021-03-16 18:52:47,223:DEBUG:123145648730112:END POST /result/metrics/timestamp cf8ccb7b-84d7-40e4-a726-7691e614b042 0.009236335754394531
    ```