### PR TITLE
Support requiring the scan of a secret to start onboarding

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -68,6 +68,7 @@
     <script src="js/splash/referral.js"></script>
     <script src="js/splash/customURL.js"></script>
     <script src="js/splash/updatecheck.js"></script>
+    <script src="js/splash/secretcheck.js"></script>
     <script src="js/splash/startprefs.js"></script>
     <script src="js/splash/pushnotify.js"></script>
     <script src="js/splash/storedevicesettings.js"></script>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -10,12 +10,12 @@
 angular.module('emission', ['ionic',
     'emission.controllers','emission.services', 'emission.plugin.logger',
     'emission.splash.customURLScheme', 'emission.splash.referral',
-    'emission.splash.updatecheck', 'emission.services.email',
+    'emission.splash.secretcheck', 'emission.services.email',
   'emission.intro', 'emission.main',
   'pascalprecht.translate'])
 
 .run(function($ionicPlatform, $rootScope, $http, Logger,
-    CustomURLScheme, ReferralHandler, UpdateCheck) {
+    CustomURLScheme, ReferralHandler, SecretCheck) {
   console.log("Starting run");
   // alert("Starting run");
   // BEGIN: Global listeners, no need to wait for the platform
@@ -29,8 +29,8 @@ angular.module('emission', ['ionic',
     if (urlComponents.route == 'join') {
       ReferralHandler.setupGroupReferral(urlComponents);
       StartPrefs.loadWithPrefs();
-    } else if (urlComponents.route == 'change_client') {
-      UpdateCheck.handleClientChangeURL(urlComponents);
+    } else if (urlComponents.route == 'validate_secret') {
+      SecretCheck.handleValidateSecretURL(urlComponents);
     }
   });
   // END: Global listeners
@@ -86,7 +86,7 @@ angular.module('emission', ['ionic',
   // This cannot directly use plugins - has to check for them first.
   .state('splash', {
         url: '/splash',
-        templateUrl: 'templates/splash/splash.html',
+        templateUrl: 'templates/splash/study-text.html',
         controller: 'SplashCtrl'
   })
 

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -14,11 +14,60 @@ angular.module('emission.controllers', ['emission.splash.updatecheck',
 .controller('DashCtrl', function($scope) {})
 
 .controller('SplashCtrl', function($scope, $state, $interval, $rootScope, 
+    $ionicPlatform, $ionicPopup, $ionicPopover,
     UpdateCheck, StartPrefs, PushNotify, StoreDeviceSettings,
     LocalNotify, ClientStats, PostTripAutoPrompt, SurveyLaunch)  {
   console.log('SplashCtrl invoked');
   // alert("attach debugger!");
   // PushNotify.startupInit();
+
+  /*
+   * BEGIN: Copy from embase to handle the initial screen
+   */
+  $ionicPlatform.ready(function() {
+    $scope.scanEnabled = true;
+  });
+
+  $ionicPopover.fromTemplateUrl('templates/splash/about-app.html', {
+    backdropClickToClose: true,
+    hardwareBackButtonClose: true,
+    scope: $scope
+  }).then(function(popover) {
+    $scope.popover = popover;
+    $scope.isIOS = $ionicPlatform.is('ios');
+    $scope.isAndroid = $ionicPlatform.is('android');
+  });
+
+  $scope.showDetails = function($event) {
+    $scope.popover.show($event)
+  }
+
+  $scope.hideDetails = function($event) {
+    $scope.popover.hide($event)
+  }
+
+  $scope.scanCode = function() {
+    if (!$scope.scanEnabled) {
+        $ionicPopup.alert({template: "plugins not yet initialized, please retry later"});
+    } else {
+      cordova.plugins.barcodeScanner.scan(
+        function (result) {
+            if (result.format == "QR_CODE" &&
+                result.cancelled == false &&
+                result.text.substring(0,11) == "emission://") {
+                handleOpenURL(result.text);
+            } else {
+                $ionicPopup.alert({template: "invalid study reference "+result.text});
+            }
+        },
+        function (error) {
+            $ionicPopup.alert({template: "Scanning failed: " + error});
+        });
+    }
+  }; // scanCode
+  /*
+   * END: Copy from embase to handle the initial screen
+   */
 
   $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){
     console.log("Finished changing state from "+JSON.stringify(fromState)

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('emission.intro', ['emission.splash.startprefs',
-                                  'emission.splash.updatecheck',
+                                  'emission.splash.secretcheck',
                                   'emission.survey.launch',
                                   'emission.i18n.utils',
                                   'ionic-toast'])
@@ -22,7 +22,7 @@ angular.module('emission.intro', ['emission.splash.startprefs',
 })
 
 .controller('IntroCtrl', function($scope, $state, $window, $ionicSlideBoxDelegate,
-    $ionicPopup, $ionicHistory, ionicToast, $timeout, CommHelper, StartPrefs, SurveyLaunch, UpdateCheck, $translate, i18nUtils) {
+    $ionicPopup, $ionicHistory, ionicToast, $timeout, CommHelper, StartPrefs, SurveyLaunch, SecretCheck, $translate, i18nUtils) {
   $scope.platform = $window.device.platform;
   $scope.osver = $window.device.version.split(".")[0];
   if($scope.platform.toLowerCase() == "android") {
@@ -193,7 +193,8 @@ angular.module('emission.intro', ['emission.splash.startprefs',
   };
 
   $scope.login = function(token) {
-    window.cordova.plugins.BEMJWTAuth.setPromptedAuthToken(token).then(function(userEmail) {
+    const comboToken = SecretCheck.SECRET+token;
+    window.cordova.plugins.BEMJWTAuth.setPromptedAuthToken(comboToken).then(function(userEmail) {
       // ionicToast.show(message, position, stick, time);
       // $scope.next();
       ionicToast.show(userEmail, 'middle', false, 2500);
@@ -201,11 +202,6 @@ angular.module('emission.intro', ['emission.splash.startprefs',
         $scope.alertError("Invalid login "+userEmail);
       } else {
         CommHelper.registerUser(function(successResult) {
-          UpdateCheck.getChannel().then(function(retVal) {
-            CommHelper.updateUser({
-             client: retVal
-            });
-          });
           $scope.startSurvey();
           $scope.finish();
         }, function(errorResult) {

--- a/www/js/splash/secretcheck.js
+++ b/www/js/splash/secretcheck.js
@@ -1,0 +1,54 @@
+angular.module('emission.splash.secretcheck', ['emission.plugin.logger',
+                                              'emission.plugin.kvstore'])
+.factory('SecretCheck', function($window, $state, $ionicPlatform, $ionicPopup, KVStore, Logger) {
+
+    var sc = {};
+    sc.SECRET_STORE_KEY = "secret_key";
+    // hardcoded to highlight that this is a hack
+    // eventually, we want to remove this and use channels like we do for emTripLog
+    sc.SECRET = "REPLACEME"
+
+    sc.handleValidateSecretURL = function(urlComponents) {
+      Logger.log("handleValidateSecretURL = "+JSON.stringify(urlComponents));
+      const inputSecret = urlComponents['secret'];
+      Logger.log("input secret is = "+inputSecret);
+
+      const next_state = urlComponents['next_state'] || "root.intro";
+
+      if (sc.checkSecret(inputSecret)) {
+        sc.storeInputSecret(inputSecret).then(() => {
+            $state.go(next_state);
+        }).catch((e) =>
+            Logger.displayError("Could not store valid secret "+inputSecret, e)
+        );
+      } else {
+        Logger.displayError("Invalid input secret",
+            {message: "Input secret "+inputSecret+" does not match expected "+sc.SECRET,
+            stack: "In splash/secret.js"});
+      }
+    }
+
+    sc.checkSecret = function(secret) {
+        const retVal = secret != null && secret.length > 0 && secret === sc.SECRET;
+        if (!retVal) {
+            Logger.log("Secret "+secret+" does not match expected value");
+        };
+        return retVal;
+    }
+
+    sc.storeInputSecret = function(secret) {
+        return KVStore.set(sc.SECRET_STORE_KEY, secret);
+    }
+
+    sc.getInputSecret = function() {
+      return KVStore.get(sc.SECRET_STORE_KEY).then(function(read_secret) {
+        return read_secret;
+      });
+    }
+
+    sc.hasValidSecret = function() {
+        return sc.getInputSecret().then(sc.checkSecret);
+    }
+
+    return sc;
+});

--- a/www/templates/splash/about-app.html
+++ b/www/templates/splash/about-app.html
@@ -1,0 +1,41 @@
+<ion-popover-view>
+    <ion-content class="has-footer">
+        <div class="intro-text">
+            This app builds an automatic diary of all your trips, across all
+            transportation modes. It reads multiple sensors, including
+            location, in the background, and turns GPS tracking on and off
+            automatically for minimal power consumption. Information about your travel
+            patterns will be displayed to you according to the design of the study you
+            join.
+        </div>
+
+        <div class="intro-text">
+            <b>Tip(s) for correct operation:</b>
+            <div ng-show="isIOS">
+            <ion-list>
+            <ion-item class="item-text-wrap">
+                <i class="icon ion-checkmark-circled"></i>
+                "Always allow" access to location
+            </ion-item>
+            <ion-item class="item-text-wrap">
+                <i class="icon ion-checkmark-circled"></i>
+                Do not force kill the app
+            </ion-item>
+            </ion-list>
+            </div>
+            <div ng-show="isAndroid">
+            <ion-list>
+            <ion-item class="item-text-wrap"> <div>
+                <i class="icon ion-checkmark-circled"></i>
+                Keep location services turned on</div>
+            </ion-item>
+            </ion-list>
+            </div>
+        </div>
+    </ion-content>
+    <ion-footer-bar class="bar-positive">
+      <button class="button button-block button-clear" ng-click="hideDetails($event)">
+        Close
+      </button>
+    </ion-footer-bar>
+</ion-popover-view>

--- a/www/templates/splash/study-text.html
+++ b/www/templates/splash/study-text.html
@@ -1,0 +1,45 @@
+<ion-view>
+    <ion-content class="has-footer">
+        <!-- <div class="intro-space"></div> -->
+        <div class="intro-title">
+        <center><img alt="e-mission icon" src="img/icon.png"/ style="width: 25%; height: auto;"></center>
+        </div>
+        <div class="intro-text">
+        <div>
+        <center><button class="button button-clear button-dark" ng-click="showDetails($event)"><b>Welcome to emTripLog ℹ️ </b></button></center>
+        </div>
+        <!--  -->
+
+        To proceed further, you need a link 🔗 or QR code to join a study.
+        This should have been provided by the researcher who asked you to install this
+        app.
+
+        <div class="intro-space"></div>
+
+        <ion-list>
+            <ion-item class="item-text-wrap">
+            <div>
+            <i class="icon ion-iphone"></i>
+            On your phone 📱, switch back to the browser 🌐, scroll down and
+            click the link in step 2.
+            </div>
+            </ion-item>
+            <ion-item class="item-text-wrap">
+            <center> <b> - OR - </b> </center>
+            </ion-item>
+            <ion-item class="item-text-wrap">
+            <div>
+            <i class="icon ion-laptop"></i>
+            On your computer 💻, scroll down to step 2 and scan ⬇️  the QR code.
+            </div>
+            </ion-item>
+        </ion-list>
+        <div class="intro-space"></div>
+        </div>
+    </ion-content>
+    <ion-footer-bar class="bar-positive">
+      <button ng-enabled="scanEnabled" class="button button-block button-clear" ng-click="scanCode()">
+        Scan now
+      </button>
+    </ion-footer-bar>
+</ion-view>


### PR DESCRIPTION
This is the most challenging part of https://github.com/e-mission/e-mission-docs/issues/628
Concretely:
- Add a new secret check module
- have the external URL launch invoke the secret check module
- on success, start the built-in onboarding (no downloading the UI)

Since the UI is not replaced by download, we needed to add a new state to the onboarding flow to replace it.

High level changes:
- Add a secret check module
- Copy over the initial screen from em-base
- Add a new state to the onboarding process
- once the onboarding has started, include the secret as part of the token sent to the server

