### PR TITLE
Real fix to automatically connect to the staging server depending on the token

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -14,7 +14,7 @@ angular.module('emission', ['ionic',
   'emission.intro', 'emission.main',
   'pascalprecht.translate'])
 
-.run(function($ionicPlatform, $rootScope, $http, Logger,
+.run(function($ionicPlatform, $rootScope, $http, Logger, StartPrefs,
     CustomURLScheme, ReferralHandler, UpdateCheck) {
   console.log("Starting run");
   // alert("Starting run");
@@ -45,29 +45,33 @@ angular.module('emission', ['ionic',
     }
 
     // Configure the connection settings
-    Logger.log("about to get connection config");
-    $http.get("json/connectionConfig.json").then(function(connectionConfig) {
-        if(connectionConfig.data.length == 0) {
-            throw "blank string instead of missing file on dynamically served app";
+    StartPrefs.readStartupState().then(function([is_intro_done, is_consented]) {
+        if (!is_intro_done) {
+            Logger.log("intro not done, about to set connection config");
+            $http.get("json/connectionConfig.json").then(function(connectionConfig) {
+                if(connectionConfig.data.length == 0) {
+                    throw "blank string instead of missing file on dynamically served app";
+                }
+                Logger.log("connectionConfigString = "+JSON.stringify(connectionConfig.data));
+                $rootScope.connectionConfig = connectionConfig.data;
+                $rootScope.connectUrl = connectionConfig.data.connectUrl;
+                $rootScope.aggregateAuth = connectionConfig.data.aggregate_call_auth;
+                window.cordova.plugins.BEMConnectionSettings.setSettings(connectionConfig.data);
+            }).catch(function(err) {
+                // not displaying the error here since we have a backup
+                Logger.log("error "+JSON.stringify(err)+" while reading connection config, reverting to defaults");
+                window.cordova.plugins.BEMConnectionSettings.getDefaultSettings().then(function(defaultConfig) {
+                    Logger.log("defaultConfig = "+JSON.stringify(defaultConfig));
+                    $rootScope.connectionConfig = defaultConfig;
+                    $rootScope.connectUrl = defaultConfig.connectUrl;
+                    $rootScope.aggregateAuth = "no_auth";
+                    window.cordova.plugins.BEMConnectionSettings.setSettings(defaultConfig);
+                }).catch(function(err) {
+                    // displaying the error here since we don't have a backup
+                    Logger.displayError("Error reading or setting connection defaults", err);
+                });
+            });
         }
-        Logger.log("connectionConfigString = "+JSON.stringify(connectionConfig.data));
-        $rootScope.connectionConfig = connectionConfig.data;
-        $rootScope.connectUrl = connectionConfig.data.connectUrl;
-        $rootScope.aggregateAuth = connectionConfig.data.aggregate_call_auth;
-        window.cordova.plugins.BEMConnectionSettings.setSettings(connectionConfig.data);
-    }).catch(function(err) {
-        // not displaying the error here since we have a backup
-        Logger.log("error "+JSON.stringify(err)+" while reading connection config, reverting to defaults");
-        window.cordova.plugins.BEMConnectionSettings.getDefaultSettings().then(function(defaultConfig) {
-            Logger.log("defaultConfig = "+JSON.stringify(defaultConfig));
-            $rootScope.connectionConfig = defaultConfig;
-            $rootScope.connectUrl = defaultConfig.connectUrl;
-            $rootScope.aggregateAuth = "no_auth";
-            window.cordova.plugins.BEMConnectionSettings.setSettings(defaultConfig);
-        }).catch(function(err) {
-            // displaying the error here since we don't have a backup
-            Logger.displayError("Error reading or setting connection defaults", err);
-        });
     });
     cordova.plugin.http.setDataSerializer('json');
   });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -51,6 +51,7 @@ angular.module('emission', ['ionic',
             throw "blank string instead of missing file on dynamically served app";
         }
         Logger.log("connectionConfigString = "+JSON.stringify(connectionConfig.data));
+        $rootScope.connectionConfig = connectionConfig.data;
         $rootScope.connectUrl = connectionConfig.data.connectUrl;
         $rootScope.aggregateAuth = connectionConfig.data.aggregate_call_auth;
         window.cordova.plugins.BEMConnectionSettings.setSettings(connectionConfig.data);
@@ -59,6 +60,7 @@ angular.module('emission', ['ionic',
         Logger.log("error "+JSON.stringify(err)+" while reading connection config, reverting to defaults");
         window.cordova.plugins.BEMConnectionSettings.getDefaultSettings().then(function(defaultConfig) {
             Logger.log("defaultConfig = "+JSON.stringify(defaultConfig));
+            $rootScope.connectionConfig = defaultConfig;
             $rootScope.connectUrl = defaultConfig.connectUrl;
             $rootScope.aggregateAuth = "no_auth";
             window.cordova.plugins.BEMConnectionSettings.setSettings(defaultConfig);

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -21,7 +21,7 @@ angular.module('emission.intro', ['emission.splash.startprefs',
   });
 })
 
-.controller('IntroCtrl', function($scope, $state, $window, $ionicSlideBoxDelegate,
+.controller('IntroCtrl', function($scope, $rootScope, $state, $window, $ionicSlideBoxDelegate,
     $ionicPopup, $ionicHistory, ionicToast, $timeout, CommHelper, StartPrefs, SurveyLaunch, UpdateCheck, $translate, i18nUtils) {
 
   $scope.platform = $window.device.platform;
@@ -135,6 +135,16 @@ angular.module('emission.intro', ['emission.splash.startprefs',
       });
   }
 
+  var changeURLIfNeeded = function(userEmail) {
+    if (userEmail.startsWith("STAGE_")) {
+        $rootScope.connectionConfig.connectUrl = "https://stage.canbikeco.org";
+        $rootScope.connectUrl = "https://stage.canbikeco.org";
+        return window.cordova.plugins.BEMConnectionSettings.setSettings($rootScope.connectionConfig);
+    } else {
+        return Promise.resolve();
+    }
+  }
+
   $scope.login = function() {
     window.cordova.plugins.BEMJWTAuth.signIn().then(function(userEmail) {
       // ionicToast.show(message, position, stick, time);
@@ -143,19 +153,23 @@ angular.module('emission.intro', ['emission.splash.startprefs',
       if (userEmail == "null" || userEmail == "") {
         $scope.alertError("Invalid login "+userEmail);
       } else {
-        CommHelper.registerUser(function(successResult) {
-          UpdateCheck.getChannel().then(function(retVal) {
-            CommHelper.updateUser({
-             client: retVal
+        changeURLIfNeeded(userEmail).then(function() {
+            CommHelper.registerUser(function(successResult) {
+              UpdateCheck.getChannel().then(function(retVal) {
+                CommHelper.updateUser({
+                 client: retVal
+                });
+              });
+              if (localStorage.getItem('username') != null) {
+                $scope.finish();
+              } else {
+                $scope.showUsernamePopup();
+              }
+            }, function(errorResult) {
+              $scope.alertError('User registration error', errorResult);
             });
-          });
-          if (localStorage.getItem('username') != null) {
-            $scope.finish();
-          } else {
-            $scope.showUsernamePopup();
-          }
-        }, function(errorResult) {
-          $scope.alertError('User registration error', errorResult);
+        }).catch(function(error) {
+            $scope.alertError('connection settings error', error);
         });
       }
     }, function(error) {

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -136,7 +136,7 @@ angular.module('emission.intro', ['emission.splash.startprefs',
   }
 
   var changeURLIfNeeded = function(userEmail) {
-    if (userEmail.startsWith("STAGE_")) {
+    if (userEmail.startsWith("stage_")) {
         $rootScope.connectionConfig.connectUrl = "https://stage.canbikeco.org";
         $rootScope.connectUrl = "https://stage.canbikeco.org";
         return window.cordova.plugins.BEMConnectionSettings.setSettings($rootScope.connectionConfig);


### PR DESCRIPTION
In the onboarding, if the token starts with `stage_`, set the connection spec to `stage.canbikeco.org`
Skip connection settings init on app start if the intro_done is complete
Note that this means that we can't change the server to connect to after the initial onboarding is done unless we want to hardcode that as well