### PR TITLE
Update Cordova-Android to 10.0.1 to prevent build issues with Android build-tools 31

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -8,19 +8,18 @@
     "url": "git+https://github.com/e-mission/e-mission-phone.git"
   },
   "devDependencies": {
-    "cordova": "10.0.0",
+    "@havesource/cordova-plugin-push": "^2.0.0",
     "@ionic/cli": "6.12.0",
-    "bower": "1.8.8"
+    "bower": "1.8.8",
+    "cordova": "10.0.0",
+    "cordova-android": "^10.0.1"
   },
   "cordova": {
     "platforms": [
-      "android",
-      "ios"
+      "ios",
+      "android"
     ],
     "plugins": {
-      "phonegap-plugin-push": {
-        "FCM_VERSION": "17.0.0"
-      },
       "cordova-plugin-ionic-keyboard": {},
       "cordova-plugin-app-version": {},
       "cordova-plugin-file": {},
@@ -61,11 +60,15 @@
       "cordova-plugin-em-transition-notify": {},
       "cordova-plugin-em-unifiedlogger": {},
       "cordova-plugin-em-usercache": {},
-      "cordova-plugin-androidx-adapter": {}
+      "cordova-plugin-androidx-adapter": {},
+      "@havesource/cordova-plugin-push": {
+        "ANDROID_SUPPORT_V13_VERSION": "28.0.0",
+        "FCM_VERSION": "18.+",
+        "IOS_FIREBASE_MESSAGING_VERSION": "~> 6.32.2"
+      }
     }
   },
   "dependencies": {
-    "cordova-android": "9.0.0",
     "cordova-ios": "6.1.0",
     "cordova-plugin-advanced-http": "3.0.0",
     "cordova-plugin-androidx-adapter": "git+https://github.com/dpa99c/cordova-plugin-androidx-adapter.git",
@@ -90,7 +93,6 @@
     "cordova-plugin-whitelist": "~1.3.3",
     "cordova-plugin-x-socialsharing": "6.0.0",
     "fs-extra": "^9.0.1",
-    "klaw-sync": "^6.0.0",
-    "phonegap-plugin-push": "=2.3.0"
+    "klaw-sync": "^6.0.0"
   }
 }


### PR DESCRIPTION
Update Cordova-Android to 10.0.1 to prevent build issues with Android build-tools 31

Replace phonegap-plugin-push with cordova-plugin-push to remove dependency on cordova-support-google-services causing build error with GradlePluginGoogleServicesEnabled. 

https://github.com/phonegap/phonegap-plugin-push/pull/2873
https://github.com/havesource/cordova-plugin-push/pull/8/files