### PR TITLE
Reverse Label screen scrolling direction

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -926,7 +926,7 @@ button.button.back-button.buttons.button-clear.header-item {
         font-size: 12px;
         position: absolute;
         left: 1%;
-        bottom: 15px;
+        top: 15px;
         line-height: 16px;
 }
 .stop-time-tag-inf-scroll {
@@ -940,7 +940,7 @@ button.button.back-button.buttons.button-clear.header-item {
         font-size: 12px;
         position: absolute;
         left: 1%;
-        top: 15px;
+        bottom: 15px;
         line-height: 16px;
 }
 .stop-time-tag-lower {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -857,7 +857,9 @@ button.button.back-button.buttons.button-clear.header-item {
   top: 16px;
 }
 .list-card {
-  margin: 16px 0; box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  margin: 16px 0;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  border: 1px solid #ccc;
 }
 .bg-light {
   background-color: #ffffff; 

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -82,7 +82,8 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
             $scope.inferFinalLabels(trip);
             $scope.updateVerifiability(trip);
         });
-        ctList.forEach(function(trip, index) {
+        // Fill places on a reversed copy of the list so we fill from the bottom up
+        ctList.slice().reverse().forEach(function(trip, index) {
             fillPlacesForTripAsync(trip);
         });
         $scope.data.allTrips = ctList.concat($scope.data.allTrips);

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -55,9 +55,11 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   $scope.allTrips = false;
   const ONE_WEEK = 7 * 24 * 60 * 60; // seconds
 
-  $scope.infScrollControl = {};
+  $scope.infScrollControl = {threshold: 75, scrollLock: true, fromBottom: -1, callback: undefined};
 
   $scope.readDataFromServer = function() {
+    $scope.infScrollControl.scrollLock = true;
+    $scope.infScrollControl.fromBottom = $ionicScrollDelegate.getScrollView().__contentHeight-$ionicScrollDelegate.getScrollPosition().top;
     console.log("calling readDataFromServer with "+
         JSON.stringify($scope.infScrollControl));
     const currEnd = $scope.infScrollControl.currentEnd;
@@ -67,12 +69,10 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         return;
     }
     Timeline.readAllConfirmedTrips(currEnd, ONE_WEEK).then((ctList) => {
-        // let's reverse the incoming list so we go most recent to oldest
         Logger.log("Received batch of size "+ctList.length);
-        ctList.reverse();
         ctList.forEach($scope.populateBasicClasses);
         ctList.forEach((trip, tIndex) => {
-          console.log("Expectation: "+JSON.stringify(trip.expectation));
+            // console.log("Expectation: "+JSON.stringify(trip.expectation));
             // console.log("Inferred labels from server: "+JSON.stringify(trip.inferred_labels));
             trip.userInput = {};
             ConfirmHelper.INPUTS.forEach(function(item, index) {
@@ -85,9 +85,9 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         ctList.forEach(function(trip, index) {
             fillPlacesForTripAsync(trip);
         });
-        $scope.data.allTrips = $scope.data.allTrips.concat(ctList);
+        $scope.data.allTrips = ctList.concat($scope.data.allTrips);
         Logger.log("After adding batch of size "+ctList.length+" cumulative size = "+$scope.data.allTrips.length);
-        const oldestTrip = ctList[ctList.length -1];
+        const oldestTrip = ctList[0];
         if (oldestTrip) {
             if (oldestTrip.start_ts <= $scope.infScrollControl.pipelineRange.start_ts) {
                 Logger.log("Oldest trip in batch starts at "+ moment(oldestTrip.start_ts)
@@ -106,13 +106,14 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         }
         $scope.recomputeDisplayTrips();
         Logger.log("Broadcasting infinite scroll complete");
-        $scope.$broadcast('scroll.infiniteScrollComplete')
+        $scope.$broadcast('scroll.infiniteScrollComplete');
+
     }).catch((err) => {
         Logger.displayError("while reading confirmed trips", err);
         Logger.log("Reached the end of the scrolling");
         $scope.infScrollControl.reachedEnd = true;
         Logger.log("Broadcasting infinite scroll complete");
-        $scope.$broadcast('scroll.infiniteScrollComplete')
+        $scope.$broadcast('scroll.infiniteScrollComplete');
     });
   };
 
@@ -126,8 +127,10 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
             $scope.data.manualResultMap = manualResultMap;
             $scope.infScrollControl.pipelineRange = pipelineRange;
             $scope.infScrollControl.currentEnd = pipelineRange.end_ts;
-            // Don't need to do this, the infinite scroll code calls it automatically
-            // $scope.readDataFromServer();
+            $scope.infScrollControl.callback = function() {
+              $ionicScrollDelegate.scrollBottom();
+            };
+            $scope.readDataFromServer();
         } else {
             $scope.$apply(() => {
                 $scope.infScrollControl.reachedEnd = true;
@@ -135,6 +138,31 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
             $scope.$broadcast('scroll.infiniteScrollComplete')
         }
     });
+  }
+
+  $scope.$on("scroll.infiniteScrollComplete", function() {
+    if ($scope.infScrollControl.callback != undefined) {
+      $scope.infScrollControl.callback();
+      $scope.infScrollControl.callback = undefined;
+    }
+    $scope.infScrollControl.scrollLock = false;
+  });
+
+  $scope.handleScroll = function() {
+    if ($scope.infScrollControl.scrollLock) return;
+    if ($scope.infScrollControl.reachedEnd) {
+      console.log("reached end");
+      return;
+    }
+    if ($ionicScrollDelegate.getScrollPosition().top < $scope.infScrollControl.threshold) {
+      $scope.infScrollControl.callback = function() {
+        // This whole "infinite scroll upwards" implementation is quite hacky, but after hours of work on it, it's the only way I could approximate the desired behavior.
+        $ionicScrollDelegate.scrollBottom();
+        const clientHeight = $ionicScrollDelegate.getScrollView().__clientHeight;
+        $ionicScrollDelegate.scrollBy(0, -$scope.infScrollControl.fromBottom+clientHeight);
+      };
+      $scope.readDataFromServer();
+    }
   }
 
   $ionicModal.fromTemplateUrl("templates/diary/trip-detail-popover.html", {

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -1,7 +1,7 @@
 <ion-view ng-class="ion-view-background" translate-namespace="diary">
     <ion-nav-bar class="bar-stable">
     </ion-nav-bar>
-    <ion-nav-buttons side="primary" id="toget" class="row buttons">
+    <ion-nav-buttons side="left" id="toget" class="row buttons">
         <button ng-repeat="selF in filterInputs" ng-click="select(selF)" class="col col-50 button labelfilter" ng-class="{on:selF.state}" style="text-align: center;font-size: 14px;font-weight: 600;" translate>
             {{selF.text}}
         </button>
@@ -9,13 +9,13 @@
             {{'.show-all'}}
         </button>
     </ion-nav-buttons>
-    <ion-nav-buttons side="secondary">
+    <ion-nav-buttons side="right">
         <button class="button button-icon" ng-click="refresh()">
             <i class="icon ion-refresh"></i>
         </button>
     </ion-nav-buttons>
     <div style="background-color: transparent; border-left-style: solid; border-left-width: 0.5px; border-left-color: #212121; margin-left: 10%; position: absolute; float: left; height: 100%;"></div>
-	<ion-content class="diary-entry">
+	<ion-content class="diary-entry" on-scroll="handleScroll()">
         <!--
         <div  ng-if="inTrip()" class="control-list-item">
             <div class="control-list-text">Current Trip</div>
@@ -98,10 +98,10 @@
             </div>
            <div class="start-time-tag-inf-scroll">{{trip.display_start_time}}</div>
         </div>
-        <ion-infinite-scroll
+        <!-- <ion-infinite-scroll
             ng-if="!infScrollControl.reachedEnd"
             on-infinite="readDataFromServer()"></ion-infinite-scroll>
-        </ion-list>
+        </ion-list> -->
 	</ion-content>
     <!--
     <ion-footer-bar>

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -43,7 +43,7 @@
         MUST test on android first to make sure that the scrolling works.
         -->
 		<div collection-repeat="trip in data.displayTrips" item-height="'160px'">
-            <div class="stop-time-tag-inf-scroll">{{trip.display_end_time}}</div>
+            <div class="start-time-tag-inf-scroll">{{trip.display_start_time}}</div>
             <div  style="padding-left: 19%;">
 
 			 <ion-item id="diary-item" style="background-color: transparent;" class="list-item">
@@ -96,7 +96,7 @@
                 </div>
             </ion-item>
             </div>
-           <div class="start-time-tag-inf-scroll">{{trip.display_start_time}}</div>
+           <div class="stop-time-tag-inf-scroll">{{trip.display_end_time}}</div>
         </div>
         <!-- <ion-infinite-scroll
             ng-if="!infScrollControl.reachedEnd"


### PR DESCRIPTION
The Label screen now loads with the most recent trip at the bottom of the screen and loads older trips as the user scrolls upwards. The start and end time labels have also been reversed to correspond to this layout, place names load from the most recent trip back in time, and a border was added to the trip cards per a user request.

Demo GIF:
![output](https://user-images.githubusercontent.com/23368820/128263918-ca60647f-5d25-4f75-8798-c5076a61f50e.gif)
Note that not all the place names have loaded. The GIF was recorded at this stage on purpose to show how they load bottom to top. This GIF was made using a real human's data with their informed consent.