### PR TITLE
Track when the verify button is pressed + robustness fixes

### DIFF
--- a/www/js/diary/infinite_scroll_filters.js
+++ b/www/js/diary/infinite_scroll_filters.js
@@ -10,9 +10,10 @@
 
 angular.module('emission.main.diary.infscrollfilters',[
     'emission.tripconfirm.services',
+    'emission.stats.clientstats',
     'emission.plugin.logger'
   ])
-.factory('InfScrollFilters', function(Logger, ConfirmHelper, $translate){
+.factory('InfScrollFilters', function(Logger, ConfirmHelper, ClientStats, $translate){
     var sf = {};
     var unlabeledCheck = function(t) {
        return ConfirmHelper.INPUTS
@@ -30,8 +31,12 @@ angular.module('emission.main.diary.infscrollfilters',[
     }
 
     var toLabelCheck = function(trip) {
-        console.log(trip.expectation.to_label)
-        return trip.expectation.to_label && unlabeledCheck(trip);
+        if (angular.isDefined(trip.expectation)) {
+            console.log(trip.expectation.to_label)
+            return trip.expectation.to_label && unlabeledCheck(trip);
+        } else {
+            return true;
+        }
     }
 
     sf.UNLABELED = {

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -323,7 +323,10 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
       const confidenceThreshold = 0.5;
 
       // Deep copy the possibility tuples
-      let labelsList = JSON.parse(JSON.stringify(trip.inferred_labels));
+      let labelsList = [];
+      if (angular.isDefined(trip.inferred_labels)) {
+          labelsList = JSON.parse(JSON.stringify(trip.inferred_labels));
+      }
 
       // Capture the level of certainty so we can reconstruct it later
       const totalCertainty = labelsList.map(item => item.p).reduce(((item, rest) => item + rest), 0);
@@ -644,6 +647,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
      * verifyTrip turns all of a given trip's yellow labels green
      */
     $scope.verifyTrip = function($event, trip) {
+      ClientStats.addEvent(ClientStats.getStatKeys().VERIFY_TRIP);
       if (trip.verifiability != "can-verify") return;
       
       $scope.draftInput = {

--- a/www/js/stats/clientstats.js
+++ b/www/js/stats/clientstats.js
@@ -21,7 +21,8 @@ angular.module('emission.stats.clientstats', [])
       BEAR_TIME: "bear_time",
       DIARY_TIME: "diary_time",
       CHECKED_INF_SCROLL: "checked_inf_scroll",
-      INF_SCROLL_TIME: "inf_scroll_time"
+      INF_SCROLL_TIME: "inf_scroll_time",
+      VERIFY_TRIP: "verify_trip"
     };
   }
 


### PR DESCRIPTION
- Add the ClientStats module to infinite scroll
- Add a new kind of client stat
- Mark the stat when the button is pressed

Testing done:
- Hacked the code to ensure that verifiability is always set to "can-verify"
- Verified the trip
- "End trip and force sync"
- Confirmed that the value was pushed
```
2021-08-04 15:37:25,004:DEBUG:123145498861568:Updated result for user = 113aef67-400e-4e21-a29f-d04e50fc42ea, key = stats/client_nav_event, write_ts = 1628116460.869 = {'n': 1, 'nModified': 0, 'upserted': ObjectId('610b16a53906cf6a2964f11b'), 'ok': 1.0, 'updatedExisting': False}
2021-08-04 15:37:25,005:DEBUG:123145498861568:Updated result for user = 113aef67-400e-4e21-a29f-d04e50fc42ea, key = stats/client_nav_event, write_ts = 1628116560.485 = {'n': 1, 'nModified': 0, 'upserted': ObjectId('610b16a53906cf6a2964f11d'), 'ok': 1.0, 'updatedExisting': False}
2021-08-04 15:37:25,007:DEBUG:123145498861568:Updated result for user = 113aef67-400e-4e21-a29f-d04e50fc42ea, key = stats/client_time, write_ts = 1628116588.745 = {'n': 1, 'nModified': 0, 'upserted': ObjectId('610b16a53906cf6a2964f11f'), 'ok': 1.0, 'updatedExisting': False}
```
- Confirmed that the value was in the usercache at the end

```
edb.get_usercache_db().find({"metadata.key": "stats/client_nav_event"}).distinct("data.name")
['app_launched',
 'checked_diary',
 'checked_inf_scroll',
 'expanded_trip',
 'notification_open',
 'opened_app',
 'sync_launched',
 'verify_trip']
```

+ two robustness fixes where we check for the inferred labels and the
expectation before using them. These should not occur but it is good to avoid
crashing if they do!