### PR TITLE
Add further Label screen instrumentation

### DIFF
--- a/www/js/diary/infinite_scroll_filters.js
+++ b/www/js/diary/infinite_scroll_filters.js
@@ -40,16 +40,19 @@ angular.module('emission.main.diary.infscrollfilters',[
     }
 
     sf.UNLABELED = {
+        key: "unlabeled",
         text: $translate.instant(".unlabeled"),
         filter: unlabeledCheck
     }
 
     sf.INVALID_EBIKE = {
+        key: "invalid_ebike",
         text: $translate.instant(".invalid-ebike"),
         filter: invalidCheck
     }
 
     sf.TO_LABEL = {
+        key: "to_label",
         text: $translate.instant(".to-label"),
         filter: toLabelCheck
     }

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -660,6 +660,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         ClientStats.addReading(ClientStats.getStatKeys().VERIFY_TRIP, {"verifiable": false});
         return;
       }
+      ClientStats.addReading(ClientStats.getStatKeys().VERIFY_TRIP, {"verifiable": true, "userInput": angular.toJson(trip.userInput), "finalInference": angular.toJson(trip.finalInference)});
       
       $scope.draftInput = {
         "start_ts": trip.start_ts,
@@ -672,7 +673,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         // TODO: figure out what to do with "other". For now, do not verify.
         if (inferred && !trip.userInput[inputType] && inferred != "other") $scope.store(inputType, inferred, false);
       }
-      ClientStats.addReading(ClientStats.getStatKeys().VERIFY_TRIP, {"verifiable": true, "userInput": angular.toJson(trip.userInput), "finalInference": angular.toJson(trip.finalInference)});
     }
 
     /**

--- a/www/js/stats/clientstats.js
+++ b/www/js/stats/clientstats.js
@@ -22,7 +22,9 @@ angular.module('emission.stats.clientstats', [])
       DIARY_TIME: "diary_time",
       CHECKED_INF_SCROLL: "checked_inf_scroll",
       INF_SCROLL_TIME: "inf_scroll_time",
-      VERIFY_TRIP: "verify_trip"
+      VERIFY_TRIP: "verify_trip",
+      LABEL_TAB_SWITCH: "label_tab_switch",
+      SELECT_LABEL: "select_label"
     };
   }
 


### PR DESCRIPTION
 + Track when the user switches between filter tabs
 + Track what green and yellow labels are present when trips are verified
   * Note that doing this changed `verify_trip` from a `stats/client_nav_event` entry to a `stats/client_time` entry
 + Track whether the verify button was grayed out when it was pressed
 + Track what green and yellow labels are present when labels are selected

Tested by verifying that the desired messages appear in the backend database: ran

```
import emission.core.get_database as edb
uc_db = edb.get_usercache_db()
c = uc_db.find({"metadata.key": "stats/client_time"})
for d in c: print(d)
```
, searched in the output for `verify_trip`, `label_tab_switch`, and `select_label`, and inspected the corresponding `reading`s.
