### PR TITLE
wrap native calls in intro.js in a ready() statement

### DIFF
--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -20,41 +20,44 @@ angular.module('emission.intro', ['emission.splash.startprefs',
   });
 })
 
-.controller('IntroCtrl', function($scope, $state, $window, $ionicSlideBoxDelegate,
+.controller('IntroCtrl', function($scope, $state, $window,
+    $ionicPlatform, $ionicSlideBoxDelegate,
     $ionicPopup, $ionicHistory, ionicToast, $timeout, CommHelper, StartPrefs, UpdateCheck, $translate, i18nUtils) {
 
-  $scope.platform = $window.device.platform;
-  $scope.osver = $window.device.version.split(".")[0];
-  if($scope.platform.toLowerCase() == "android") {
-    if($scope.osver < 6) {
-        $scope.locationPermExplanation = $translate.instant('intro.permissions.locationPermExplanation-android-lt-6');
-    } else if ($scope.osver < 10) {
-        $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-6-9");
-    } else if ($scope.osver < 11) {
-        $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-10");
-    } else {
-        $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-gte-11");
-    }
+  $scope.setupPermissionText = function() {
+      $scope.platform = $window.device.platform;
+      $scope.osver = $window.device.version.split(".")[0];
+      if($scope.platform.toLowerCase() == "android") {
+        if($scope.osver < 6) {
+            $scope.locationPermExplanation = $translate.instant('intro.permissions.locationPermExplanation-android-lt-6');
+        } else if ($scope.osver < 10) {
+            $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-6-9");
+        } else if ($scope.osver < 11) {
+            $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-10");
+        } else {
+            $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-android-gte-11");
+        }
+      }
+
+      if($scope.platform.toLowerCase() == "ios") {
+        if($scope.osver < 13) {
+            $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-ios-lt-13");
+        } else {
+            $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-ios-gte-13");
+        }
+      }
+
+      $scope.backgroundRestricted = false;
+      if($window.device.manufacturer.toLowerCase() == "samsung") {
+        $scope.backgroundRestricted = true;
+        $scope.allowBackgroundInstructions = $translate.instant("intro.allow_background.samsung");
+      }
+
+      $scope.fitnessPermNeeded = ($scope.platform.toLowerCase() == "ios" ||
+        (($scope.platform.toLowerCase() == "android") && ($scope.osver >= 10)));
+
+      console.log("Explanation = "+$scope.locationPermExplanation);
   }
-
-  if($scope.platform.toLowerCase() == "ios") {
-    if($scope.osver < 13) {
-        $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-ios-lt-13");
-    } else {
-        $scope.locationPermExplanation = $translate.instant("intro.permissions.locationPermExplanation-ios-gte-13");
-    }
-  }
-
-  $scope.backgroundRestricted = false;
-  if($window.device.manufacturer.toLowerCase() == "samsung") {
-    $scope.backgroundRestricted = true;
-    $scope.allowBackgroundInstructions = $translate.instant("intro.allow_background.samsung");
-  }
-
-  $scope.fitnessPermNeeded = ($scope.platform.toLowerCase() == "ios" ||
-    (($scope.platform.toLowerCase() == "android") && ($scope.osver >= 10)));
-
-  console.log("Explanation = "+$scope.locationPermExplanation);
 
   var allIntroFiles = Promise.all([
     i18nUtils.geti18nFileName("templates/", "intro/summary", ".html"),
@@ -178,5 +181,9 @@ angular.module('emission.intro', ['emission.splash.startprefs',
     $scope.getIntroBox().slide(0);
     StartPrefs.loadPreferredScreen();
   }
+
+  $ionicPlatform.ready().then(function() {
+    $scope.setupPermissionText();
+  });
 });
 


### PR DESCRIPTION
Well, first wrap them into a function, and then call the function from ready()
Without this, live-reload on the intro wouldn't work
With this fix, live-reload on the intro works (see video in PR)