### PR TITLE
Fix tiles not loading at closer zoom levels on Android

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com http://nominatim.openstreetmap.org https://e-mission.eecs.berkeley.edu https://api.ionic.io/push/tokens https://ee.kobotoolbox.org emission: 'unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data: http://*.tile.openstreetmap.org https://*.tile.openstreetmap.org http://tile.stamen.com https://*.tile.stamen.com http://*.tile.stamen.com https://ee.kobotoolbox.org 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com https://nominatim.openstreetmap.org https://e-mission.eecs.berkeley.edu https://api.ionic.io/push/tokens https://ee.kobotoolbox.org emission: 'unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data: http://*.tile.openstreetmap.org https://*.tile.openstreetmap.org http://tile.stamen.com https://stamen-tiles.a.ssl.fastly.net https://stamen-tiles-*.a.ssl.fastly.net https://ee.kobotoolbox.org 'unsafe-inline'">
     <title></title>
 
     <link href="lib/ionic/css/ionic.css" rel="stylesheet">

--- a/www/js/common/services.js
+++ b/www/js/common/services.js
@@ -199,7 +199,7 @@ angular.module('emission.main.common.services', ['emission.plugin.logger'])
       };
       switch (mode) {
         case 'place':
-          var url = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.geometry.coordinates[1]
+          var url = "https://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.geometry.coordinates[1]
           + "&lon=" + obj.geometry.coordinates[0];
           $http.get(url).then(function(response) {
             console.log("while reading data from nominatim, status = "+response.status
@@ -210,7 +210,7 @@ angular.module('emission.main.common.services', ['emission.plugin.logger'])
           });
           break;
         case 'cplace':
-        var url = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.location.coordinates[1]
+        var url = "https://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.location.coordinates[1]
         + "&lon=" + obj.location.coordinates[0];
 
           $http.get(url).then(function(response) {
@@ -222,7 +222,7 @@ angular.module('emission.main.common.services', ['emission.plugin.logger'])
           });
           break;
         case 'ctrip':
-          var url0 = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.start_loc.coordinates[1]
+          var url0 = "https://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.start_loc.coordinates[1]
           + "&lon=" + obj.start_loc.coordinates[0];
           console.log("About to make call "+url0);
           $http.get(url0).then(function(response) {
@@ -232,7 +232,7 @@ angular.module('emission.main.common.services', ['emission.plugin.logger'])
           }, function(error) {
             console.log("while reading data from nominatim, error = "+error);
           });
-          var url1 = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.end_loc.coordinates[1]
+          var url1 = "https://nominatim.openstreetmap.org/reverse?format=json&lat=" + obj.end_loc.coordinates[1]
           + "&lon=" + obj.end_loc.coordinates[0];
           console.log("About to make call "+url1);
           $http.get(url1).then(function(response) {

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -564,7 +564,7 @@ angular.module('emission.services', ['emission.plugin.logger',
 
     config.getMapTiles = function() {
       return {
-          tileLayer: 'http://tile.stamen.com/terrain/{z}/{x}/{y}.png',
+          tileLayer: 'https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
           tileLayerOptions: {
               attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
               opacity: 0.9,

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -564,9 +564,9 @@ angular.module('emission.services', ['emission.plugin.logger',
 
     config.getMapTiles = function() {
       return {
-          tileLayer: 'https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+          tileLayer: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
           tileLayerOptions: {
-              attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+              attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
               opacity: 0.9,
               detectRetina: true,
               reuseTiles: true,


### PR DESCRIPTION
This pull request cherry picks some patches applied to Master to change 
* http://nominatim.openstreetmap.com to https://nominatim.openstreetmap.com (HTTPS) to prevent a CORS issue causing 404 Not Founds. 
* The street map tile provider to Open Street Map from Stamin since the latter has missing tiles at closer zoom levels leading to blank maps at some zoom levels (not applicable for all regions but visible on the outskirts of Sydney)