### PR TITLE
Allow bower to be run as root

### DIFF
--- a/setup/setup_serve.sh
+++ b/setup/setup_serve.sh
@@ -11,7 +11,7 @@ echo "Setting up all npm packages"
 npm install
 
 echo "Updating bower"
-npx bower update
+npx bower update --allow-root
 
 echo "Pulling the plugin-specific UIs"
 npm run setup-serve


### PR DESCRIPTION
Without this change, we get the following error while running in a docker container

```
Updating bower

bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

You can however run a command with sudo using "--allow-root" option
```

Since the default user in the container is `root`, this is actually an expected
use case for us.

I tried to avoid this by calling `bower update --allow-root` in the docker
setup script https://github.com/e-mission/e-mission-docker/pull/18

But that ran into multiple inconsistencies (
https://github.com/e-mission/e-mission-docs/issues/657#issuecomment-894981839
https://github.com/e-mission/e-mission-docs/issues/657#issuecomment-894994308
)

In order to avoid more bitrotted containers, just changing the code in the
setup script so it works in the container as well

This fixes https://github.com/e-mission/e-mission-docs/issues/657