### PR TITLE
Workaround the android tools upgrade to get CI to work again

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: osx-ubuntu-build-android
+name: osx-build-android
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Pre-requisites
 - git
 - the most recent version of android studio
     - **NOTE**: although Catalina has a `/usr/bin/java`, trying to run it gives the error `No Java runtime present, requesting install.`. Installed [OpenJDK 1.8 using AdoptOpenJDK](https://adoptopenjdk.net/releases.html) to be consistent with the CI.
+    - NOTE: The setup script below will modify this install to workaround
+        https://github.com/actions/virtual-environments/issues/3757
 
 Important
 ---

--- a/setup/setup_android_native.sh
+++ b/setup/setup_android_native.sh
@@ -17,6 +17,11 @@ ANDROID_BUILD_TOOLS_VERSION=27.0.3
 MIN_SDK_VERSION=21
 TARGET_SDK_VERSION=28
 
+echo "Uninstalling build tools > 30"
+echo "As a temporary workaround until we upgrade to cordova 10"
+SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+echo y | $SDKMANAGER --uninstall "build-tools;31.0.0"
+
 # Setup the development environment
 source setup/setup_shared.sh
 


### PR DESCRIPTION
Workaround from
https://github.com/actions/virtual-environments/issues/3757#issuecomment-883646793
until we upgrade to the most recent version of cordova

Other fixes:
- rename the android CI workflow to clarify that we only build on OSX
- highlight the tools uninstallation in the README