### PR TITLE
Get confidenceThreshold from config file

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -318,10 +318,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
      *   - Never show user yellow labels that have a lower probability of being correct than confidenceThreshold
      */
     $scope.inferFinalLabels = function(trip) {
-      // Display a label as red if its most probable inferred value has a probability of less than or equal to confidenceThreshold
-      // TODO: make this configurable
-      const confidenceThreshold = 0.5;
-
       // Deep copy the possibility tuples
       let labelsList = JSON.parse(JSON.stringify(trip.inferred_labels));
 
@@ -361,8 +357,9 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
             if (thisP > max.p) max = {p: thisP, labelValue: thisLabelValue};
           }
 
-          // Apply threshold
-          if (max.p <= confidenceThreshold) max.labelValue = undefined;
+          // Display a label as red if its most probable inferred value has a probability less than or equal to the trip's confidence_threshold
+          // Fails safe if confidence_threshold doesn't exist
+          if (max.p <= trip.confidence_threshold) max.labelValue = undefined;
 
           $scope.populateInput(trip.finalInference, inputType, max.labelValue);
         }


### PR DESCRIPTION
Use the confidenceThreshold from the server
+ Get `confidenceThreshold` from the trip object instead of using a hardcoded placeholder

End-to-end testing:
 1. Use server and client branches with only mode and purpose
 2. Enable placeholder predictor 3
 3. Use an expectations config that has a relaxed mode with a `confidenceThreshold` < 0.80 and an intensive mode with a `confidenceThreshold` >= 0.80 with a schedule beginning at `2015-07-22T16:00:00` local time
 2. Reset pipeline; load and intake the `shankari_2015-07-22` `test_july_22` test dataset
 4. Ensure on the client that the second most recent trip has all yellow labels and that the most recent trip has all red labels