### PR TITLE
Switch the infinite scroll from auto-load on scroll to a button

### DIFF
--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -160,6 +160,7 @@
         "no-trips-found": "No trips found",
         "for-current-filter": "for current filter. Show All to remove filters",
         "scroll-to-load-more": "Scroll to load more",
+        "filter-display-status": "Displaying {{displayTripsLength}} of {{allTripsLength}} trips upto {{currentEnd | date}}",
         "choose-mode": "Mode 📝 ",
         "choose-replaced-mode": "Replaces 📝",
         "choose-purpose": "Purpose 📝",

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -160,7 +160,7 @@
         "no-trips-found": "No trips found",
         "for-current-filter": "for current filter. Show All to remove filters",
         "scroll-to-load-more": "Scroll to load more",
-        "filter-display-status": "Displaying {{displayTripsLength}} of {{allTripsLength}} trips upto {{currentEnd | date}}",
+        "filter-display-status": "Displaying {{displayTripsLength}} of {{allTripsLength}} trips up to {{currentEnd | date}}",
         "choose-mode": "Mode 📝 ",
         "choose-replaced-mode": "Replaces 📝",
         "choose-purpose": "Purpose 📝",

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -210,6 +210,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     });
     $scope.allTrips = false;
     $scope.recomputeDisplayTrips();
+    $ionicScrollDelegate.scrollBottom();
     ClientStats.addReading(ClientStats.getStatKeys().LABEL_TAB_SWITCH, {"source": prev, "dest": $scope.getActiveFilters()});
   }
 
@@ -220,6 +221,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     });
     $scope.allTrips = true;
     $scope.recomputeDisplayTrips();
+    $ionicScrollDelegate.scrollBottom();
     ClientStats.addReading(ClientStats.getStatKeys().LABEL_TAB_SWITCH, {"source": prev, "dest": $scope.getActiveFilters()});
   }
 

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -210,6 +210,9 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     });
     $scope.allTrips = false;
     $scope.recomputeDisplayTrips();
+    // scroll to the bottom while changing filters so users don't have to
+    // fixes the first of the fit-and-finish issues from
+    // https://github.com/e-mission/e-mission-docs/issues/662
     $ionicScrollDelegate.scrollBottom();
     ClientStats.addReading(ClientStats.getStatKeys().LABEL_TAB_SWITCH, {"source": prev, "dest": $scope.getActiveFilters()});
   }

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -60,11 +60,38 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   $scope.allTrips = false;
   const ONE_WEEK = 7 * 24 * 60 * 60; // seconds
 
-  $scope.infScrollControl = {threshold: 75, scrollLock: true, fromBottom: -1, callback: undefined};
+  /*
+   * These values are used to ensure that when the user scrolls upwards, they
+   * end up at the same location as they were. Since we now add entries to the
+   * top of the list, without these changes, as we load more entries, we will
+   * see the top of the new entries and will potentially have to scroll down to
+   * find where we originally were.
+   * That is not terrible, but it is also not super intuitive. This keeps track
+   * of where we were from the bottom and scrolls back to that location after
+   * the data is loaded and the infiniteScrollCallback is broadcast.
+   *
+   * We need to define and store the callback since we want to scroll *after*
+   * the new items have been fully added (i.e. in the `$scope.$on`). If the
+   * focus group is ok with seeing the newly loaded trips first, we can
+   * simplify this.
+   */
+  $scope.infScrollControl = {fromBottom: -1, callback: undefined};
+
+  var adjustScrollAfterDownload = function() {
+    // This whole "infinite scroll upwards" implementation is quite hacky, but after hours of work on it, it's the only way I could approximate the desired behavior.
+    $ionicScrollDelegate.scrollBottom();
+    const clientHeight = $ionicScrollDelegate.getScrollView().__clientHeight;
+    $ionicScrollDelegate.scrollBy(0, -$scope.infScrollControl.fromBottom+clientHeight);
+  };
+
+  var getFromBottom = function() {
+    return $ionicScrollDelegate.getScrollView().__contentHeight
+        - $ionicScrollDelegate.getScrollPosition().top;
+  }
 
   $scope.readDataFromServer = function() {
-    $scope.infScrollControl.scrollLock = true;
-    $scope.infScrollControl.fromBottom = $ionicScrollDelegate.getScrollView().__contentHeight-$ionicScrollDelegate.getScrollPosition().top;
+    $scope.infScrollControl.fromBottom = getFromBottom()
+    $scope.infScrollControl.callback = adjustScrollAfterDownload;
     console.log("calling readDataFromServer with "+
         JSON.stringify($scope.infScrollControl));
     const currEnd = $scope.infScrollControl.currentEnd;
@@ -147,29 +174,12 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   }
 
   $scope.$on("scroll.infiniteScrollComplete", function() {
+    Logger.log("infiniteScrollComplete broadcast")
     if ($scope.infScrollControl.callback != undefined) {
       $scope.infScrollControl.callback();
       $scope.infScrollControl.callback = undefined;
     }
-    $scope.infScrollControl.scrollLock = false;
   });
-
-  $scope.handleScroll = function() {
-    if ($scope.infScrollControl.scrollLock) return;
-    if ($scope.infScrollControl.reachedEnd) {
-      console.log("reached end");
-      return;
-    }
-    if ($ionicScrollDelegate.getScrollPosition().top < $scope.infScrollControl.threshold) {
-      $scope.infScrollControl.callback = function() {
-        // This whole "infinite scroll upwards" implementation is quite hacky, but after hours of work on it, it's the only way I could approximate the desired behavior.
-        $ionicScrollDelegate.scrollBottom();
-        const clientHeight = $ionicScrollDelegate.getScrollView().__clientHeight;
-        $ionicScrollDelegate.scrollBy(0, -$scope.infScrollControl.fromBottom+clientHeight);
-      };
-      $scope.readDataFromServer();
-    }
-  }
 
   $ionicModal.fromTemplateUrl("templates/diary/trip-detail-popover.html", {
     scope: $scope,

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -15,13 +15,8 @@
         </button>
     </ion-nav-buttons>
     <div style="background-color: transparent; border-left-style: solid; border-left-width: 0.5px; border-left-color: #212121; margin-left: 10%; position: absolute; float: left; height: 100%;"></div>
-	<ion-content class="diary-entry" on-scroll="handleScroll()">
+	<ion-content class="diary-entry">
         <!--
-        <div  ng-if="inTrip()" class="control-list-item">
-            <div class="control-list-text">Current Trip</div>
-            <div ng-click="redirect()" id="gray" class="control-icon-button"><i class="ion-ios-arrow-right"></i></div>
-        </div>
-        -->
         <div ng-if="data.displayTrips.length == 0" style="background-color: transparent;" id="no-border" class="list-item" item-height="'400px'">
                <div ng-if="data.displayTrips.length == 0" style="position: absolute; top: 50%; left: 50%; transform: translateX(-50%);" height="'400px'">
                  <h3>{{'diary.no-trips-found' | translate}}</h3>
@@ -29,9 +24,14 @@
                  <h3 ng-if="!infScrollControl.reachedEnd">{{'diary.scroll-to-load-more' | translate }}</h3>
                </div>
          </div>
+        -->
+        <div class="control-list-item">
+            <div class="control-list-text" translate="diary.filter-display-status" translate-values="{displayTripsLength: data.displayTrips.length, allTripsLength: data.allTrips.length, currentEnd: infScrollControl.currentEnd * 1000}"></div>
+            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" id="gray" class="control-icon-button"><i class="ion-ios-download"></i></div>
+            <div ng-if="infScrollControl.reachedEnd" id="green" class="control-icon-button"><i class="ion-checkmark"></i></div>
+        </div>
 
 		<ion-list>
-        <ion-nav-view ></ion-nav-view>
         <!--
         This needs to be collection-repeat instead of ng-repeat on android.
         Otherwise, you can only scroll using the sidebar, scrolling on the map side does not work.


### PR DESCRIPTION
The auto-load on scroll feature, so common to messaging and chat apps is actually fairly complicated to implement correctly in the case in which we display a filtered list. In particular:
- the additional scrolling required to maintain "place" in the list triggers multiple "scroll" calls even when the user is not doing anything, which leads to multiple calls to the server.
- if new entries are not added to the list after the server call, then the condition that triggered the server call (top < threshold) persists, leading to multiple calls again.

See https://github.com/e-mission/e-mission-docs/issues/662

This is an inherent limitation of using auto-load on scroll for a filtered list and also happens with the standard ionic component, https://github.com/e-mission/e-mission-docs/issues/662#issuecomment-899312254

So instead of butting my head against the wall getting auto-load to work, I switched to manual load, similar to the diary screen. https://github.com/e-mission/e-mission-phone/pull/769

As a bonus, this also helps with https://github.com/e-mission/e-mission-docs/issues/659
It indicates how many of the trips are displayed in **this filter**, should help to clarify questions around "missing trips" and allow users to explore other tabs as necessary.

Testing done:
    - loaded data for a user with a single trip
    - labeled that trip so the user had no trips
    - loaded data for a user with multiple trips

In all cases, used the button to scroll all the way to the oldest trip.
Did not encounter any issues.

+ bonus fix to scroll to the bottom of the screen when switching filters, which is one of the fit-and-finish issues in https://github.com/e-mission/e-mission-docs/issues/662