### PR TITLE
Delay the deletion of entries from the To Label screen

### DIFF
--- a/www/js/diary/infinite_scroll_filters.js
+++ b/www/js/diary/infinite_scroll_filters.js
@@ -39,6 +39,10 @@ angular.module('emission.main.diary.infscrollfilters',[
         }
     }
 
+    sf.waitingForMod = function(t) {
+        return t.waitingForMod == true;
+    }
+
     sf.UNLABELED = {
         key: "unlabeled",
         text: $translate.instant(".unlabeled"),


### PR DESCRIPTION
to give users a chance to correct the trip.

The implementation is fairly straightforward.
- as a trip is modified, set its `waiting for modification` flag to true
- ensure that trips that are waiting for modification are not filtered out
- create a timeout to set the flag to false and recompute
- cancel any existing timeouts to avoid recomputations

Testing done:
#### Set all three labels for a trip
- Saw the logs:

Open first popover, create new timeout promise, nothing to cancel

```
DEBUG:in openPopover, setting draftInput = {"start_ts":1628366684.0019567,"end_ts":1628367280.652}
DEBUG:in storeInput, after setting input.value = walk, draftInput = {"start_ts":1628366684.0019567,"end_ts":1628367280.652,"label":"walk"}
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: creating new timeout
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: cancelling existing timeout undefined
```

Open second popover, create new timeout promise, cancel previous

```
DEBUG:in openPopover, setting draftInput = {"start_ts":1628366684.0019567,"end_ts":1628367280.652}
DEBUG:in storeInput, after setting input.value = home, draftInput = {"start_ts":1628366684.0019567,"end_ts":1628367280.652,"label":"home"}
ionic.bundle.js:3063 [Violation] 'touchend' handler took 150ms
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: creating new timeout
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: cancelling existing timeout [object Object]
ionic.bundle.js:5301 [Intervention] Ignored attempt to cancel a touchstart event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
self.touchStart @ ionic.bundle.js:5301
```

Open third popover, create new timeout promise, cancel previous

```
DEBUG:in openPopover, setting draftInput = {"start_ts":1628366684.0019567,"end_ts":1628367280.652}
DEBUG:in storeInput, after setting input.value = bike, draftInput = {"start_ts":1628366684.0019567,"end_ts":1628367280.652,"label":"bike"}
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: creating new timeout
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: cancelling existing timeout [object Object]
```

After a significant time, recompute

```
DevTools failed to load SourceMap: Could not load content for http://10.0.2.2:3000/socket.io/socket.io.js.map: Connection error: net::ERR_CONNECTION_TIMED_OUT
DEBUG:trip starting at 2021-08-07T13:04:44.001957-07:00: executing recompute
```

#### Set two labels for a trip and then the third

Set first two labels

```
DEBUG:in openPopover, setting draftInput = {"start_ts":1628294651.152,"end_ts":1628297929.551}
DEBUG:in storeInput, after setting input.value = walk, draftInput = {"start_ts":1628294651.152,"end_ts":1628297929.551,"label":"walk"}
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: creating new timeout
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: cancelling existing timeout undefined
DEBUG:in openPopover, setting draftInput = {"start_ts":1628294651.152,"end_ts":1628297929.551}
DEBUG:in storeInput, after setting input.value = work, draftInput = {"start_ts":1628294651.152,"end_ts":1628297929.551,"label":"work"}
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: creating new timeout
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: cancelling existing timeout [object Object]
```

Recompute is run, but the trip is not filtered because only two labels are filled out

```
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: executing recompute
```

Third label is filled out

```
DEBUG:in openPopover, setting draftInput = {"start_ts":1628294651.152,"end_ts":1628297929.551}
DEBUG:in storeInput, after setting input.value = no_travel, draftInput = {"start_ts":1628294651.152,"end_ts":1628297929.551,"label":"no_travel"}
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: creating new timeout
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: cancelling existing timeout undefined
```

Final recompute is called and trip is filtered

```
DEBUG:trip starting at 2021-08-06T17:04:11.152000-07:00: executing recompute
```