### PR TITLE
Cherry-pick the walkthrough changes to master

### DIFF
--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -180,7 +180,6 @@ div.labelfilterlist {
 }
 
 .labelfilter:first-of-type {
-  margin-left:5%;
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
 }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -695,7 +695,7 @@ background-image: none !important; }
   background-color: #E0A1A1 !important;
 }
 
-#gray.control-icon-button{
+.gray-icon.control-icon-button{
   background-color: #CCCCCC !important;
 }
 

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -45,10 +45,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
 
   $scope.data = {};
 
-  // To aid in the walkthrough fix (see https://github.com/e-mission/e-mission-docs/issues/669)
-  var firstTripID = "";
-  $scope.getMoreTripsID = 'walkthrough'+'-'+'getmoretrips';
-
   $scope.getActiveFilters = function() {
     return $scope.filterInputs.filter(sf => sf.state).map(sf => sf.key);
   }
@@ -251,7 +247,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     if (!alreadyFiltered) {
         $scope.data.displayTrips = $scope.data.allTrips;
     };
-    firstTripID = "diary-card-"+$scope.data.displayTrips[0].dom_id;
   }
 
   angular.extend($scope, {
@@ -490,7 +485,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         // Pre-populate start and end names with &nbsp; so they take up the same amount of vertical space in the UI before they are populated with real data
         tripgj.start_display_name = "\xa0";
         tripgj.end_display_name = "\xa0";
-        tripgj.dom_id = Math.round(tripgj.start_ts).toString();
     }
 
     const fillPlacesForTripAsync = function(tripgj) {
@@ -607,97 +601,81 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     };
 
     // Tour steps
-    var tour = function() {
-      // We do some extra work here to avoid trying to target DOM elements that have been duplicated and moved off-screen. See https://github.com/e-mission/e-mission-docs/issues/669.
-      // filterOutTopLeft helps us ignore duplicated DOM elements that get translate3d'd to -9999, -9999, 0:
-      const filterOutTopLeft = ":not([style*='transform: translate3d(-'])";
-      // tripTag filters out duplicated DOM elements using the above, then gets the first trip by time. This is necessary because the trips are not necessarily in order in the DOM even though they appear in order on the screen.
-      const tripTag = ".collection-repeat-container>div"+filterOutTopLeft+" #"+firstTripID+" ";
-      // The "load more trips" button sometimes has the glitchy behavior as well. I haven't been able to reproduce enough to narrow down the issue; for now, we'll try the same tricks as we try with the trips.
-      const loadMoreTag = ".scroll"+filterOutTopLeft+" .control-icon-button#"+$scope.getMoreTripsID;
-      return {
-        config: {
-          mask: {
-            visibleOnNoTarget: true,
-            clickExit: true,
-          },
-          previousText: $translate.instant('tour-previous'),
-          nextText: $translate.instant('tour-next'),
-          finishText: $translate.instant('tour-finish')
+    var tour = {
+      config: {
+        mask: {
+          visibleOnNoTarget: true,
+          clickExit: true,
         },
-        steps: [{
-          target: '.ion-view-background',
-          content: $translate.instant('new_label_tour.0')
-        },
-        {
-          target: '.labelfilter',
-          content: $translate.instant('new_label_tour.1')
-        },
-        {
-          target: '.labelfilter.last',
-          content: $translate.instant('new_label_tour.2')
-        },
-        {
-          target: '.diary-entry',
-          content: $translate.instant('new_label_tour.3')
-        },
-        {
-          target: loadMoreTag,
-          content: $translate.instant('new_label_tour.4'),
-          before: function() {
-            return new Promise(function(resolve, reject) {
-              $ionicScrollDelegate.scrollTop(true);
-              resolve();
-            });
-          }
-        },
-        {
-          target: tripTag+'.input-confirm-row',
-          content: $translate.instant('new_label_tour.5'),
-          before: function() {
-            return new Promise(function(resolve, reject) {
-              console.log("HII");
-              console.log("#"+firstTripID+' .input-confirm-row');
-              resolve();
-            });
-          }
-        },
-        {
-          target: tripTag+'.input-confirm-row',
-          content: $translate.instant('new_label_tour.6')
-        },
-        {
-          target: tripTag+'.diary-checkmark-container i',
-          content: $translate.instant('new_label_tour.7')
-        },
-        {
-          target: tripTag+'.input-confirm-row',
-          content: $translate.instant('new_label_tour.8')
-        },
-        {
-          target: '.labelfilter',
-          content: $translate.instant('new_label_tour.9')
-        },
-        {
-          target: '.ion-view-background',
-          content: $translate.instant('new_label_tour.10')
-        },
-        {
-          target: '.walkthrough-button',
-          content: $translate.instant('new_label_tour.11'),
-          after: function() {
-            return new Promise(function(resolve, reject) {
-              $ionicScrollDelegate.scrollBottom(true);
-              resolve();
-            });
-          }
+        previousText: $translate.instant('tour-previous'),
+        nextText: $translate.instant('tour-next'),
+        finishText: $translate.instant('tour-finish')
+      },
+      steps: [{
+        target: '.ion-view-background',
+        content: $translate.instant('new_label_tour.0')
+      },
+      {
+        target: '.labelfilter',
+        content: $translate.instant('new_label_tour.1')
+      },
+      {
+        target: '.labelfilter.last',
+        content: $translate.instant('new_label_tour.2')
+      },
+      {
+        target: '.diary-entry',
+        content: $translate.instant('new_label_tour.3')
+      },
+      {
+        target: '.control-icon-button',
+        content: $translate.instant('new_label_tour.4'),
+        before: function() {
+          return new Promise(function(resolve, reject) {
+            $ionicScrollDelegate.scrollTop(true);
+            resolve();
+          });
         }
-        ]
-      };
+      },
+      {
+        target: '.diary-entry',
+        content: $translate.instant('new_label_tour.5')
+      },
+      {
+        target: '.diary-entry',
+        content: $translate.instant('new_label_tour.6')
+      },
+      {
+        target: '.diary-entry',
+        content: $translate.instant('new_label_tour.7')
+      },
+      {
+        target: '.diary-entry',
+        content: $translate.instant('new_label_tour.8'),
+        after: function() {
+          return new Promise(function(resolve, reject) {
+            $ionicScrollDelegate.scrollBottom(true);
+            resolve();
+          });
+        }
+      },
+      {
+        target: '.labelfilter',
+        content: $translate.instant('new_label_tour.9')
+      },
+      {
+        target: '.ion-view-background',
+        content: $translate.instant('new_label_tour.10')
+      },
+      {
+        target: '.walkthrough-button',
+        content: $translate.instant('new_label_tour.11')
+      }
+      ]
     };
 
     var startWalkthrough = function () {
-      nzTour.start(tour()).then(function(result) {
+      nzTour.start(tour).then(function(result) {
         // $ionicScrollDelegate.scrollBottom();
         Logger.log("list walkthrough start completed, no error");
       }).catch(function(err) {

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -45,6 +45,10 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
 
   $scope.data = {};
 
+  // To aid in the walkthrough fix (see https://github.com/e-mission/e-mission-docs/issues/669)
+  var firstTripID = "";
+  $scope.getMoreTripsID = 'walkthrough'+'-'+'getmoretrips';
+
   $scope.getActiveFilters = function() {
     return $scope.filterInputs.filter(sf => sf.state).map(sf => sf.key);
   }
@@ -247,6 +251,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     if (!alreadyFiltered) {
         $scope.data.displayTrips = $scope.data.allTrips;
     };
+    firstTripID = "diary-card-"+$scope.data.displayTrips[0].dom_id;
   }
 
   angular.extend($scope, {
@@ -485,6 +490,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         // Pre-populate start and end names with &nbsp; so they take up the same amount of vertical space in the UI before they are populated with real data
         tripgj.start_display_name = "\xa0";
         tripgj.end_display_name = "\xa0";
+        tripgj.dom_id = Math.round(tripgj.start_ts).toString();
     }
 
     const fillPlacesForTripAsync = function(tripgj) {
@@ -601,81 +607,97 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     };
 
     // Tour steps
-    var tour = {
-      config: {
-        mask: {
-          visibleOnNoTarget: true,
-          clickExit: true,
+    var tour = function() {
+      // We do some extra work here to avoid trying to target DOM elements that have been duplicated and moved off-screen. See https://github.com/e-mission/e-mission-docs/issues/669.
+      // filterOutTopLeft helps us ignore duplicated DOM elements that get translate3d'd to -9999, -9999, 0:
+      const filterOutTopLeft = ":not([style*='transform: translate3d(-'])";
+      // tripTag filters out duplicated DOM elements using the above, then gets the first trip by time. This is necessary because the trips are not necessarily in order in the DOM even though they appear in order on the screen.
+      const tripTag = ".collection-repeat-container>div"+filterOutTopLeft+" #"+firstTripID+" ";
+      // The "load more trips" button sometimes has the glitchy behavior as well. I haven't been able to reproduce enough to narrow down the issue; for now, we'll try the same tricks as we try with the trips.
+      const loadMoreTag = ".scroll"+filterOutTopLeft+" .control-icon-button#"+$scope.getMoreTripsID;
+      return {
+        config: {
+          mask: {
+            visibleOnNoTarget: true,
+            clickExit: true,
+          },
+          previousText: $translate.instant('tour-previous'),
+          nextText: $translate.instant('tour-next'),
+          finishText: $translate.instant('tour-finish')
         },
-        previousText: $translate.instant('tour-previous'),
-        nextText: $translate.instant('tour-next'),
-        finishText: $translate.instant('tour-finish')
-      },
-      steps: [{
-        target: '.ion-view-background',
-        content: $translate.instant('new_label_tour.0')
-      },
-      {
-        target: '.labelfilter',
-        content: $translate.instant('new_label_tour.1')
-      },
-      {
-        target: '.labelfilter.last',
-        content: $translate.instant('new_label_tour.2')
-      },
-      {
-        target: '.diary-entry',
-        content: $translate.instant('new_label_tour.3')
-      },
-      {
-        target: '.control-icon-button',
-        content: $translate.instant('new_label_tour.4'),
-        before: function() {
-          return new Promise(function(resolve, reject) {
-            $ionicScrollDelegate.scrollTop(true);
-            resolve();
-          });
+        steps: [{
+          target: '.ion-view-background',
+          content: $translate.instant('new_label_tour.0')
+        },
+        {
+          target: '.labelfilter',
+          content: $translate.instant('new_label_tour.1')
+        },
+        {
+          target: '.labelfilter.last',
+          content: $translate.instant('new_label_tour.2')
+        },
+        {
+          target: '.diary-entry',
+          content: $translate.instant('new_label_tour.3')
+        },
+        {
+          target: loadMoreTag,
+          content: $translate.instant('new_label_tour.4'),
+          before: function() {
+            return new Promise(function(resolve, reject) {
+              $ionicScrollDelegate.scrollTop(true);
+              resolve();
+            });
+          }
+        },
+        {
+          target: tripTag+'.input-confirm-row',
+          content: $translate.instant('new_label_tour.5'),
+          before: function() {
+            return new Promise(function(resolve, reject) {
+              console.log("HII");
+              console.log("#"+firstTripID+' .input-confirm-row');
+              resolve();
+            });
+          }
+        },
+        {
+          target: tripTag+'.input-confirm-row',
+          content: $translate.instant('new_label_tour.6')
+        },
+        {
+          target: tripTag+'.diary-checkmark-container i',
+          content: $translate.instant('new_label_tour.7')
+        },
+        {
+          target: tripTag+'.input-confirm-row',
+          content: $translate.instant('new_label_tour.8')
+        },
+        {
+          target: '.labelfilter',
+          content: $translate.instant('new_label_tour.9')
+        },
+        {
+          target: '.ion-view-background',
+          content: $translate.instant('new_label_tour.10')
+        },
+        {
+          target: '.walkthrough-button',
+          content: $translate.instant('new_label_tour.11'),
+          after: function() {
+            return new Promise(function(resolve, reject) {
+              $ionicScrollDelegate.scrollBottom(true);
+              resolve();
+            });
+          }
         }
-      },
-      {
-        target: '.input-confirm-row',
-        content: $translate.instant('new_label_tour.5')
-      },
-      {
-        target: '.input-confirm-row',
-        content: $translate.instant('new_label_tour.6')
-      },
-      {
-        target: '.diary-checkmark-container i',
-        content: $translate.instant('new_label_tour.7')
-      },
-      {
-        target: '.input-confirm-row',
-        content: $translate.instant('new_label_tour.8'),
-        after: function() {
-          return new Promise(function(resolve, reject) {
-            $ionicScrollDelegate.scrollBottom(true);
-            resolve();
-          });
-        }
-      },
-      {
-        target: '.labelfilter',
-        content: $translate.instant('new_label_tour.9')
-      },
-      {
-        target: '.ion-view-background',
-        content: $translate.instant('new_label_tour.10')
-      },
-      {
-        target: '.walkthrough-button',
-        content: $translate.instant('new_label_tour.11')
-      }
-      ]
+        ]
+      };
     };
 
     var startWalkthrough = function () {
-      nzTour.start(tour).then(function(result) {
+      nzTour.start(tour()).then(function(result) {
         // $ionicScrollDelegate.scrollBottom();
         Logger.log("list walkthrough start completed, no error");
       }).catch(function(err) {

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -78,7 +78,7 @@
     <div class="" ng-show="userDataExpanded()">
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.erase-data'}}</div>
-        <div ng-click="eraseUserData()" id="gray" class=" control-icon-button"><i class="ion-trash-b"></i></div>
+        <div ng-click="eraseUserData()" class="gray-icon control-icon-button"><i class="ion-trash-b"></i></div>
       </div>
       <ion-list>
 
@@ -129,23 +129,23 @@
       </div>
       <div class="control-list-item">
         <div class="control-list-text">{{parseState(settings.collect.state)}}</div>
-        <div ng-click="forceState()" id="gray" class="control-icon-button"><i class="ion-edit"></i></div>
+        <div ng-click="forceState()" class="gray-icon control-icon-button"><i class="ion-edit"></i></div>
       </div>
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.check-log'}}</div>
-        <div ng-click="showLog()" id="gray" class="control-icon-button"><i class="ion-ios-arrow-right"></i></div>
+        <div ng-click="showLog()" class="gray-icon control-icon-button"><i class="ion-ios-arrow-right"></i></div>
       </div>
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.check-sensed-data'}}</div>
-        <div ng-click="showSensed()" id="gray" class="control-icon-button"><i class="ion-ios-arrow-right"></i></div>
+        <div ng-click="showSensed()" class="gray-icon control-icon-button"><i class="ion-ios-arrow-right"></i></div>
       </div>
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.check-map'}}</div>
-        <div ng-click="showMap()" id="gray" class="control-icon-button"><i class="ion-ios-arrow-right"></i></div>
+        <div ng-click="showMap()" class="gray-icon control-icon-button"><i class="ion-ios-arrow-right"></i></div>
       </div>
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.collection'}}</div>
-        <div ng-click="editCollectionConfig($event)" id="gray" class="control-icon-button"><i class="ion-edit"></i></div>
+        <div ng-click="editCollectionConfig($event)" class="gray-icon control-icon-button"><i class="ion-edit"></i></div>
       </div>
       <ion-list>
 
@@ -157,7 +157,7 @@
 
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.sync'}}</div>
-        <div ng-click="editSyncConfig($event)" id="gray" class="control-icon-button"><i class="ion-edit"></i></div>
+        <div ng-click="editSyncConfig($event)" class="gray-icon control-icon-button"><i class="ion-edit"></i></div>
       </div>
       <ion-list>
         <ion-item class="row" ng-repeat="entry in settings.sync.show_config">
@@ -172,7 +172,7 @@
 
       <div class="control-list-item">
         <div class="control-list-text" translate>{{'.transition-notify'}}</div>
-        <div ng-click="editTNotifyConfig($event)" id="gray" class="control-icon-button"><i class="ion-edit"></i></div>
+        <div ng-click="editTNotifyConfig($event)" class="gray-icon control-icon-button"><i class="ion-edit"></i></div>
       </div>
       <ion-list>
         <ion-item ng-repeat="entry in settings.tnotify.show_config">

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -2,7 +2,7 @@
     <ion-nav-bar class="bar-stable">
     </ion-nav-bar>
     <ion-nav-buttons side="left" id="toget" class="row buttons">
-        <button class="button button-icon ion-help walkthrough-button" ng-click="startWalkthrough()"></button>
+        <button class="button button-icon ion-help walkthrough-button" ng-click="startWalkthrough()" style="padding-right: 0"></button>
         <div class="row buttons labelfilterlist">
             <button ng-repeat="selF in filterInputs" ng-click="select(selF)" class="{{selF.width}} button labelfilter" ng-class="{on:selF.state}" style="text-align: center;font-size: 14px;font-weight: 600;" translate>
                 {{selF.text}}
@@ -34,9 +34,8 @@
                 <div class="row" translate="diary.filter-display-status" translate-values="{displayTripsLength: data.displayTrips.length, allTripsLength: data.allTrips.length}"></div>
                 <div ng-if="data.allTrips.length > 0" class="row" translate="diary.filter-display-range" translate-values="{currentStart: data.allTrips.slice(-1)[0].start_ts * 1000, currentEnd: infScrollControl.currentEnd * 1000}"></div>
             </div>
-            <!-- The hope with the ng-attr-id stuff here is that between looking up the property and populating the actual id field, something will only happen for DOM elements that actually appear on screen and not for the duplicated ones. I don't have a good way to test this as the problem happens so rarely and irreproducibly. See https://github.com/e-mission/e-mission-docs/issues/669. -->
-            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" ng-attr-id="{{getMoreTripsID}}" class="gray-icon control-icon-button"><i class="ion-ios-download"></i></div>
-            <div ng-if="infScrollControl.reachedEnd" ng-attr-id="{{getMoreTripsID}}" class="control-icon-button"><i class="ion-checkmark"></i></div>
+            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" id="gray" class="control-icon-button"><i class="ion-ios-download"></i></div>
+            <div ng-if="infScrollControl.reachedEnd" id="green" class="control-icon-button"><i class="ion-checkmark"></i></div>
         </div>
 
 		<ion-list>
@@ -55,7 +54,7 @@
             <div  style="padding-left: 19%;">
 
 			 <ion-item id="diary-item" style="background-color: transparent;" class="list-item">
-                <div ng-attr-id="diary-card-{{trip.dom_id}}" ng-class="trip.listCardClass" ng-style="{height: '150px'}">
+                <div id="diary-card" ng-class="trip.listCardClass" ng-style="{height: '150px'}">
                     <div class="row">
                         <div ng-click="showDetail($event, trip)" class="col-90 center-vert" ng-class="listTextClass" style="font-size: 14px; padding-left: 30px; margin-bottom: 0; justify-self: flex-start;" translate=".date-distance-in-time" translate-value-date="{{ trip.display_date }}" translate-value-distance="{{ trip.display_distance }}" translate-value-time="{{ trip.display_time }}"></div>
                         <div ng-click="showDetail($event, trip)" class="col-10 diary-more-container center-vert center-horiz">

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -2,7 +2,7 @@
     <ion-nav-bar class="bar-stable">
     </ion-nav-bar>
     <ion-nav-buttons side="left" id="toget" class="row buttons">
-        <button class="button button-icon ion-help walkthrough-button" ng-click="startWalkthrough()" style="padding-right: 0"></button>
+        <button class="button button-icon ion-help walkthrough-button" ng-click="startWalkthrough()"></button>
         <div class="row buttons labelfilterlist">
             <button ng-repeat="selF in filterInputs" ng-click="select(selF)" class="{{selF.width}} button labelfilter" ng-class="{on:selF.state}" style="text-align: center;font-size: 14px;font-weight: 600;" translate>
                 {{selF.text}}
@@ -34,8 +34,9 @@
                 <div class="row" translate="diary.filter-display-status" translate-values="{displayTripsLength: data.displayTrips.length, allTripsLength: data.allTrips.length}"></div>
                 <div ng-if="data.allTrips.length > 0" class="row" translate="diary.filter-display-range" translate-values="{currentStart: data.allTrips.slice(-1)[0].start_ts * 1000, currentEnd: infScrollControl.currentEnd * 1000}"></div>
             </div>
-            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" id="gray" class="control-icon-button"><i class="ion-ios-download"></i></div>
-            <div ng-if="infScrollControl.reachedEnd" id="green" class="control-icon-button"><i class="ion-checkmark"></i></div>
+            <!-- The hope with the ng-attr-id stuff here is that between looking up the property and populating the actual id field, something will only happen for DOM elements that actually appear on screen and not for the duplicated ones. I don't have a good way to test this as the problem happens so rarely and irreproducibly. See https://github.com/e-mission/e-mission-docs/issues/669. -->
+            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" ng-attr-id="{{getMoreTripsID}}" class="gray-icon control-icon-button"><i class="ion-ios-download"></i></div>
+            <div ng-if="infScrollControl.reachedEnd" ng-attr-id="{{getMoreTripsID}}" class="control-icon-button"><i class="ion-checkmark"></i></div>
         </div>
 
 		<ion-list>
@@ -54,7 +55,7 @@
             <div  style="padding-left: 19%;">
 
 			 <ion-item id="diary-item" style="background-color: transparent;" class="list-item">
-                <div id="diary-card" ng-class="trip.listCardClass" ng-style="{height: '150px'}">
+                <div ng-attr-id="diary-card-{{trip.dom_id}}" ng-class="trip.listCardClass" ng-style="{height: '150px'}">
                     <div class="row">
                         <div ng-click="showDetail($event, trip)" class="col-90 center-vert" ng-class="listTextClass" style="font-size: 14px; padding-left: 30px; margin-bottom: 0; justify-self: flex-start;" translate=".date-distance-in-time" translate-value-date="{{ trip.display_date }}" translate-value-distance="{{ trip.display_distance }}" translate-value-time="{{ trip.display_time }}"></div>
                         <div ng-click="showDetail($event, trip)" class="col-10 diary-more-container center-vert center-horiz">

--- a/www/templates/diary/list.html
+++ b/www/templates/diary/list.html
@@ -20,7 +20,7 @@
         <!--
         <div  ng-if="inTrip()" class="control-list-item">
             <div class="control-list-text">Current Trip</div>
-            <div ng-click="redirect()" id="gray" class="control-icon-button"><i class="ion-ios-arrow-right"></i></div>
+            <div ng-click="redirect()" class="gray-icon control-icon-button"><i class="ion-ios-arrow-right"></i></div>
         </div>
         -->
 		<ion-list>


### PR DESCRIPTION
This is a replacement for https://github.com/e-mission/e-mission-phone/pull/795
which got messed up with a bunch of unrelated commits.

The walkthrough now works on both physical android and physical iOS, even after hitting the refresh button.
It highlights the entire list instead of individual list items since our current walkthrough doesn't work when there are multiple items with the same class or id.

nzTour is deprecated, so we should move to a new walkthrough mechanism anyway. We can take a look at what that mechanism supports and tighten up the walkthrough.

The build seems to be failing, but that should not be related to our changes since they are UI only.