### PR TITLE
Call ForceSync on app resume

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -11,11 +11,12 @@ angular.module('emission', ['ionic',
     'emission.controllers','emission.services', 'emission.plugin.logger',
     'emission.splash.customURLScheme', 'emission.splash.referral',
     'emission.splash.updatecheck', 'emission.services.email',
+    'emission.main.control.sync',
   'emission.intro', 'emission.main',
   'pascalprecht.translate'])
 
 .run(function($ionicPlatform, $rootScope, $http, Logger,
-    CustomURLScheme, ReferralHandler, UpdateCheck) {
+    CustomURLScheme, ReferralHandler, UpdateCheck, ControlSyncHelper) {
   console.log("Starting run");
   // alert("Starting run");
   // BEGIN: Global listeners, no need to wait for the platform
@@ -34,6 +35,15 @@ angular.module('emission', ['ionic',
     }
   });
   // END: Global listeners
+  let autoForceSync = function() {
+    if ($ionicPlatform.is("android")) {
+      console.log("app has started/resumed, forcing sync on android");
+      ControlSyncHelper.forceSync().then(function() {
+        ClientStats.addEvent(ClientStats.getStatKeys().RESUME_FORCE_SYNC);
+      });
+    }
+  };
+
   $ionicPlatform.ready(function() {
     // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
     // for form inputs)
@@ -68,7 +78,13 @@ angular.module('emission', ['ionic',
         });
     });
     cordova.plugin.http.setDataSerializer('json');
+    autoForceSync();
   });
+
+  $ionicPlatform.on("resume", function() {
+    autoForceSync();
+  });
+
   console.log("Ending run");
 })
 

--- a/www/js/stats/clientstats.js
+++ b/www/js/stats/clientstats.js
@@ -17,7 +17,8 @@ angular.module('emission.stats.clientstats', [])
       INF_SCROLL_TIME: "inf_scroll_time",
       VERIFY_TRIP: "verify_trip",
       LABEL_TAB_SWITCH: "label_tab_switch",
-      SELECT_LABEL: "select_label"
+      SELECT_LABEL: "select_label",
+      RESUME_FORCE_SYNC: "resume_force_sync"
     };
   }
 


### PR DESCRIPTION
This is a UI-only hack to experiment with syncing on every app start/resume.
In general, our assumption was that people will open the app only sporadically,
and we want to push data more frequently than that. So we do so in a background
process.

However, due to the various restrictions on background operations in android,
sometimes the background process is not launched. We can ask the user to "force
sync" but that is not a viable solution as well.

We push a UI-only update that force-syncs on every app launch to see the extent
of this problem and confirm that this fixes it.

Once we know that this works, we should move this to native code, potentially
by pushing data at the end of a trip as we do on iOS. We may also want to
introduce silent push notifications on android as well.

Testing done:
- Started app
- Paused and resumed app

Saw message "app has started/resumed, forcing sync on android" in the console
in both cases.