### PR TITLE
Replace the help/walkthrough button with the resize icon

### DIFF
--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -2,7 +2,9 @@
     <ion-nav-bar class="bar-stable">
     </ion-nav-bar>
     <ion-nav-buttons side="left" id="toget" class="row buttons">
-        <button class="button button-icon ion-help walkthrough-button" ng-click="startWalkthrough()" style="padding-right: 0"></button>
+        <button class="button button-icon" ng-click="increaseHeight()">
+            <i class="icon ion-arrow-resize"></i>
+        </button>
         <div class="row buttons labelfilterlist">
             <button ng-repeat="selF in filterInputs" ng-click="select(selF)" class="{{selF.width}} button labelfilter" ng-class="{on:selF.state}" style="text-align: center;font-size: 14px;font-weight: 600;" translate>
                 {{selF.text}}
@@ -14,9 +16,6 @@
     </ion-nav-buttons>
     
     <ion-nav-buttons side="right">
-        <button class="button button-icon" ng-click="increaseHeight()">
-            <i class="icon ion-arrow-resize"></i>
-        </button>
         <button class="button button-icon" ng-click="refresh()">
             <i class="icon ion-refresh"></i>
         </button>


### PR DESCRIPTION
The top bar on the "infinite scroll" screen is already cluttered, and sometimes
there are overlaps. Adding one more button introduces overlaps even where we
didn't have them before.

We should really replace the button-based labels at the top with icons, or
convert to a drop-down.

https://github.com/e-mission/e-mission-docs/issues/679#issuecomment-946170746