### PR TITLE
Handle the case where no trips have been labeled for two weeks

### DIFF
--- a/www/js/metrics.js
+++ b/www/js/metrics.js
@@ -1390,6 +1390,11 @@ angular.module('emission.main.metrics',['nvd3',
         scope: {
             change: "="
         },
+        link: function(scope) {
+            if (isNaN(scope.change.low)) scope.change.low = 0;
+            if (isNaN(scope.change.high)) scope.change.high = 0;
+            console.log("In diffdisplay, after changes, scope = ", scope);
+        },
         templateUrl: "templates/metrics/arrow-greater-lesser.html"
     }
 })

--- a/www/templates/metrics/arrow-greater-lesser.html
+++ b/www/templates/metrics/arrow-greater-lesser.html
@@ -4,7 +4,7 @@ https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-1000692615
 -->
 <div ng-if="change.low == change.high">
   <!-- Branch one: both values are the same, so only one arrow and one message -->
-    <div ng-if="change.low > 0">
+    <div ng-if="change.low >= 0">
       <div id="arrow-color" class="icon ion-arrow-up-a"></div>
       <div class="percentage-change"> {{ change.low | number:0 }}% {{'metrics.greater-than' | translate }} {{ 'metrics.last-week' | translate }}</div>
     </div>
@@ -19,18 +19,20 @@ https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-1000692615
     <div class="col col-45">
         <div id="arrow-color" class="icon ion-arrow-down-a" ng-if="change.low < 0"></div>
         <div id="arrow-color" class="icon ion-arrow-up-a" ng-if="change.low > 0"></div>
+        <div id="arrow-color" ng-if="change.low == 0"> = </div>
         <div class="percentage-change" ng-if="change.low < 0"> {{ (-1) * change.low | number:0 }}% {{'metrics.less' | translate }} </div>
-        <div class="percentage-change" ng-if="change.low > 0"> {{ change.low | number:0 }}% {{'metrics.greater' | translate }} </div>
+        <div class="percentage-change" ng-if="change.low >= 0"> {{ change.low | number:0 }}% {{'metrics.greater' | translate }} </div>
     </div>
     <div class="col-15">
-        <div id="arrow-color" ng-if="change.low != 0 && change.high != 0"> {{'metrics.or' | translate }} </div>
+        <div id="arrow-color"> {{'metrics.or' | translate }} </div>
         <div class="percentage-change"> {{'metrics.week-before' | translate }} </div>
     </div>
     <div class="col col-45">
         <div id="arrow-color" class="icon ion-arrow-down-a" ng-if="change.high < 0"></div>
         <div id="arrow-color" class="icon ion-arrow-up-a" ng-if="change.high > 0"></div>
+        <div id="arrow-color" ng-if="change.high == 0"> = </div>
         <div class="percentage-change" ng-if="change.high < 0"> {{ (-1) * change.high | number:0 }}% {{'metrics.less' | translate }} </div>
-        <div class="percentage-change" ng-if="change.high > 0"> {{ change.high | number:0 }}% {{'metrics.greater' | translate }} </div>
+        <div class="percentage-change" ng-if="change.high >= 0"> {{ change.high | number:0 }}% {{'metrics.greater' | translate }} </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This is likely fairly common for those people who have given up on labeling, so
it is worth addressing. The problem is that in that case,

```
lastWeek.footprint.low = 0
thisWeek.footprint.low = 0

thisWeek.footprint.low/lastWeek.footprint.low = NaN
```

So we end up with a blank "low" on the diff display, which looks weird.

To fix, we add a pre-processing step to the directive, which converts NaN -> 0
and display the % if it is >= 0

This then leads to the marginally less weird case in which we don't show the
arrow and we don't show the OR

To fix that as well, we remove the `ng-if` for the OR (not sure why it was ever added)
and add an = for the case in which the metric is 0