### PR TITLE
Handle "other" modes without mappings in the JSON

### DIFF
--- a/www/js/metrics-mappings.js
+++ b/www/js/metrics-mappings.js
@@ -363,8 +363,12 @@ angular.module('emission.main.metrics.mappings', ['emission.plugin.logger',
                 this.range_limited_motorized = opt;
                 console.log("Found range limited motorized mode", this.range_limited_motorized);
             }
-            return [opt.value, opt.co2PerMeter];
-        });
+            if (angular.isDefined(opt.co2PerMeter)) {
+                return [opt.value, opt.co2PerMeter];
+            } else {
+                return undefined;
+            }
+        }).filter((modeCO2) => angular.isDefined(modeCO2));;
         this.customPerMeterFootprint = Object.fromEntries(modeCO2PerMeter);
         console.log("After populating, custom perMeterFootprint", this.customPerMeterFootprint);
     }


### PR DESCRIPTION
The custom footprint creation currently assumes that all modes have an CO2 entry in the JSON.
This is true, except in the case where the user selects "other" and puts in a custom mode.
In that case, we have no mapping, so the footprint map has an entry for {mode: undefined}
which causes the footprint calculations to return NaN.

We instead check whether we have a mapping and return `undefined` in that case.
We also filter out the undefined entries.

After this change, the custom other modes will be excluded, and we will use the
standard 0 - max footprint range to handle them.

The calorie/MET calculation already worked like this; so this just ensures that
both sets of values are consistent.

This fixes https://github.com/e-mission/e-mission-docs/issues/697