### PR TITLE
Fix "second level of end checks" for the user label matching

### DIFF
--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -439,9 +439,9 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
             var endChecks = (userInput.data.end_ts <= trip.end_ts ||
                     (userInput.data.end_ts - trip.end_ts) <= 15 * 60);
             if (startChecks && !endChecks) {
-                if (angular.isDefined(nextTripgj)) {
-                    endChecks = userInput.data.end_ts <= nextTripgj.data.properties.start_ts;
-                    Logger.log("Second level of end checks when the next trip is defined("+userInput.data.end_ts+" <= "+ nextTripgj.data.properties.start_ts+") = "+endChecks);
+                if (angular.isDefined(nextTrip)) {
+                    endChecks = userInput.data.end_ts <= nextTrip.start_ts;
+                    Logger.log("Second level of end checks when the next trip is defined("+userInput.data.end_ts+" <= "+ nextTrip.start_ts+") = "+endChecks);
                 } else {
                     // next trip is not defined, last trip
                     endChecks = (userInput.data.end_local_dt.day == userInput.data.start_local_dt.day)


### PR DESCRIPTION
As part of https://github.com/e-mission/e-mission-phone/commit/3ec573446b2e56f865750d3da03744c2aafed158
we changed the input from a trip geojson to a trip object. But we forgot to
change one of the code paths, which caused a regression.

Fixed by changing the variable and the format of the variable.

Testing done:
- loaded fake manual entries for a test user
- before the change, got the error
- after the change, did not get the error

This fixes https://github.com/e-mission/e-mission-docs/issues/713