### PR TITLE
Bump up the versions of the plugins that communicate with the server

### DIFF
--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="46" id="edu.berkeley.eecs.emission" ios-CFBundleVersion="44" version="3.2.3" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="47" id="edu.berkeley.eecs.emission" ios-CFBundleVersion="45" version="3.2.4" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>emission</name>
     <description>
         A commute pattern tracker and carbon footprint estimator.

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -1,6 +1,6 @@
 {
   "name": "edu.berkeley.eecs.emission",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "displayName": "emission",
   "license": "BSD-3-Clause",
   "repository": {
@@ -80,9 +80,9 @@
     "cordova-plugin-device": "2.0.3",
     "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.7.2",
     "cordova-plugin-em-jwt-auth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.6.5",
-    "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.3",
-    "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.8",
-    "cordova-plugin-em-settings": "git+https://github.com/e-mission/cordova-connection-settings.git#v1.2.2",
+    "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.4",
+    "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.9",
+    "cordova-plugin-em-settings": "git+https://github.com/e-mission/cordova-connection-settings.git#v1.2.3",
     "cordova-plugin-em-transition-notify": "git+https://github.com/e-mission/e-mission-transition-notify.git#v1.2.7",
     "cordova-plugin-em-unifiedlogger": "git+https://github.com/e-mission/cordova-unified-logger.git#v1.3.5",
     "cordova-plugin-em-usercache": "git+https://github.com/e-mission/cordova-usercache.git#v1.1.5",


### PR DESCRIPTION
This is a fix for the issue where the relative URL code on iOS doesn't work per
documentation.

Relative URL doesn't work: e-mission/e-mission-docs#732 (comment)
Appending strings does work: e-mission/e-mission-docs#732 (comment)

Includes fixes to:
- connection settings to return a string instead of a URL
    https://github.com/e-mission/cordova-connection-settings/pull/22
- server-communication and server-sync to concatenate directly using strings
  instead of using a relative URL
    https://github.com/e-mission/cordova-server-communication/pull/30
    https://github.com/e-mission/cordova-server-sync/pull/52