### PR TITLE
Adding scan OPcode button to login page

### DIFF
--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -148,6 +148,29 @@ angular.module('emission.intro', ['emission.splash.startprefs',
             onTap: function(e) {
               return null;
             }
+          },{
+            text: '<b>Scan OPcode</b>',
+            type: 'button-positive',
+            onTap: function(e) {
+              cordova.plugins.barcodeScanner.scan(
+                function (result) {
+                // the code from here is copied and pasted from https://www.sitepoint.com/scanning-qr-code-cordova/
+                // this is not how the feature is intended to be developed, this is just to test it out to see if scanning a qr code works
+                  if(!result.cancelled)
+                  {
+                    alert("Barcode type is: " + result.format);
+                    alert("Decoded text is: " + result.text);
+                  }
+                  else
+                  {
+                    alert("You have cancelled scan");
+                  }
+                },
+                function (error) {
+                    alert("Scanning failed: " + error);
+                }
+              );
+            }
           }
         ]
     });
@@ -159,6 +182,27 @@ angular.module('emission.intro', ['emission.splash.startprefs',
         $scope.alertError(err);
     });
   };
+
+  $scope.scanQRCode = function() {
+    cordova.plugins.barcodeScanner.scan(
+      function (result) {
+          if (result.format == "QR_CODE" &&
+              result.cancelled == false) {
+              try {
+                  const bikeLabel = getScannedLabel(result.text);
+                  resolve(bikeLabel);
+              } catch(e) {
+                  reject(e);
+              }
+          } else {
+              reject(new Error("invalid QR code"+result.text));
+          }
+      },
+      function (error) {
+          reject(error);
+      }
+    );
+  }
 
   $scope.login = function(token) {
     window.cordova.plugins.BEMJWTAuth.setPromptedAuthToken(token).then(function(userEmail) {


### PR DESCRIPTION
index.html
- Added scripts needed to run scan QR code

intro.js
- Added button to "enter existing token" popover called "Scan OPcode" which has some test scan-qrcode code thrown in there. This code is not intended to be final, I just want to make sure it works first
- Right now, my emulator does not have a camera so this fails saying "Scanning failed: unable to detect video capture device"
- Added a $scope.scanQRCode function but it also does not have any meaninful code in it. This is how I think we should do it (by having the scanQRCode function and then calling it from the popover button), but I was struggling to get the function to call. I don't know how to type it (is it just "$scope.scanQRCode();" and it starts working?)