### PR TITLE
Support scanning QR codes to login as well

### DIFF
--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -98,6 +98,7 @@ angular.module('emission.main.control',['emission.services',
     }
 
     $scope.viewQRCode = function($event) {
+        $scope.tokenURL = "emission://login_token?token="+$scope.settings.auth.email;
         if ($scope.qrp) {
             $scope.qrp.show($event);
         } else {

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -123,7 +123,7 @@ angular.module('emission.intro', ['emission.splash.startprefs',
     $scope.login($scope.randomToken);
   };
 
-  $scope.loginExisting = function() {
+  $scope.typeExisting = function() {
     $scope.data = {};
     const tokenPopup = $ionicPopup.show({
         template: '<input type="String" ng-model="data.existing_token">',
@@ -158,6 +158,25 @@ angular.module('emission.intro', ['emission.splash.startprefs',
     }).catch(function(err) {
         $scope.alertError(err);
     });
+  };
+
+  $scope.scanExisting = function() {
+    const EXPECTED_PREFIX = "emission://login_token?token=";
+    cordova.plugins.barcodeScanner.scan(
+      function (result) {
+          if (result.format == "QR_CODE" &&
+              result.cancelled == false &&
+              result.text.startsWith(EXPECTED_PREFIX)) {
+              const extractedToken = result.text.substring(EXPECTED_PREFIX.length, result.length);
+              Logger.log("From QR code, extracted token "+extractedToken);
+              $scope.login(extractedToken);
+          } else {
+              $ionicPopup.alert({template: "invalid token format"+result.text});
+          }
+      },
+      function (error) {
+          $ionicPopup.alert({template: "Scanning failed: " + error});
+      });
   };
 
   $scope.login = function(token) {

--- a/www/templates/control/qrc.html
+++ b/www/templates/control/qrc.html
@@ -10,7 +10,7 @@
         </div>
         <div class="row">
             <div class="col"></div>
-            <qrcode class="col" aria-label="qrcode for user email" data="{{settings.auth.email}}" size="220" download></qrcode>
+            <qrcode class="col" aria-label="qrcode for user email" data="{{tokenURL}}" size="220" download></qrcode>
             <div class="col"></div>
         </div>
         <div class="row"><br /></div>

--- a/www/templates/intro/login.html
+++ b/www/templates/intro/login.html
@@ -13,9 +13,14 @@ please be prepared to provide this token.
 <button class="button button-block button-balanced" ng-click="loginNew()">Login as {{randomToken}}</button>
 
 If you already have a token from a previous install, you can use it instead to retain the same account. Note that there are no incorrect tokens. If you enter a token that does not match an existing one, we will create a new account.
-<div class="intro-space"></div>
-<button class="button button-block button-energized" ng-click="loginExisting()">Login with existing token</button>
-</div>
+    <div class="intro-space"></div>
+    <button class="button button-block button-energized" ng-click="typeExisting()">Type existing token</button>
 
+    <center> <b> - OR - </b> </center>
+
+    <div class="intro-space"></div>
+    <button class="button button-block button-royal" ng-click="scanExisting()">Scan existing token</button>
+</div> <!-- program_or_study == 'study' -->
+</div> <!-- overall div -->
 
 </ion-content>


### PR DESCRIPTION
Summary of changes:
- Have the generated QR code encode a full URL beginning with emission:// and
  including a login_token path. This ensures that we can check the QR code for
  validity and will not get arbitrary tokens like https://foo.bar that we then
  think are an autogenerated token
(https://github.com/e-mission/e-mission-docs/issues/724#issuecomment-1151617879)
- Add buttons to type or scan the QR code
- If scan, read the value, verify that it is a QR code, verify that it starts
  with the correct prefix, and then continue with the login

Testing done:
- scanned a QR code generated from the profile screen and ensured that we were
  able to login

This fixes: https://github.com/e-mission/e-mission-phone/pull/841