### PR TITLE
"Upload Logs" UI fixes

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -51,6 +51,11 @@ body.platform-ios {
   height: 40px;
 
 }
+.button.ng-binding.button-cancel {
+  background-color: #d02001;
+  height: 40px;
+  color: #ffffff
+}
 .selected_date_full.ng-binding {
   color: #01D0A7;
 }

--- a/www/js/control/uploadService.js
+++ b/www/js/control/uploadService.js
@@ -103,26 +103,26 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                     +' placeholder="{{ \'upload-service.please-fill-in-what-is-wrong \' | translate}}">',
                 scope: newScope,
                 buttons: [
-                  { 
+                { 
                     text: 'Cancel',
                     onTap: function(e) {
                         didCancel = true;
                         detailsPopup.close();
                     }
-                  },
-                  {
+                },
+                {
                     text: '<b>Upload</b>',
                     type: 'button-positive',
                     onTap: function(e) {
                         didCancel = false;
                         if (!newScope.data.reason) {
-                        //don't allow the user to close unless he enters wifi password
+                            //don't allow the user to close unless he enters wifi password
                             e.preventDefault();
                         } else {
                             return newScope.data.reason;
                         }
                     }
-                  }
+                }
                 ]
             });
 
@@ -141,14 +141,14 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                 uploadConfig.forEach((url) => {
                     const progressPopup = $ionicPopup.show({
                         title: $translate.instant("upload-service.upload-database",
-                            { db: database }),
+                            {db: database}),
                         template: $translate.instant("upload-service.upload-progress",
                             {filesizemb: binString.byteLength / (1000 * 1000),
                             serverURL: uploadConfig}) 
                             + '<center><ion-spinner></ion-spinner></center>',
                         scope: progressScope,
                         buttons: [
-                        { text: '<b>Cancel</b>', type: 'button-cancel',  },
+                            { text: '<b>Cancel</b>', type: 'button-cancel',  },
                         ]
                     });
                     sendToServer(url, binString, params).then((response) => {

--- a/www/js/control/uploadService.js
+++ b/www/js/control/uploadService.js
@@ -94,6 +94,8 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
             newScope.fromDirText = $translate.instant('upload-service.upload-from-dir',  {parentDir: parentDir});
             newScope.toServerText = $translate.instant('upload-service.upload-to-server',  {serverURL: uploadConfig});
 
+            var didCancel = true;
+
             const detailsPopup = $ionicPopup.show({
                 title: $translate.instant("upload-service.upload-database", { db: database }),
                 template: newScope.toServerText
@@ -101,25 +103,35 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                     +' placeholder="{{ \'upload-service.please-fill-in-what-is-wrong \' | translate}}">',
                 scope: newScope,
                 buttons: [
-                  { text: 'Cancel' },
+                  { 
+                    text: 'Cancel',
+                    onTap: function(e) {
+                        didCancel = true;
+                        detailsPopup.close();
+                    }
+                  },
                   {
                     text: '<b>Upload</b>',
                     type: 'button-positive',
                     onTap: function(e) {
-                      if (!newScope.data.reason) {
+                        didCancel = false;
+                        if (!newScope.data.reason) {
                         //don't allow the user to close unless he enters wifi password
-                        e.preventDefault();
-                      } else {
-                        return newScope.data.reason;
-                      }
+                            e.preventDefault();
+                        } else {
+                            return newScope.data.reason;
+                        }
                     }
                   }
                 ]
             });
 
+            
             Logger.log(Logger.LEVEL_INFO, "Going to upload " + database);
             const readFileAndInfo = [readDBFile(parentDir, database), detailsPopup];
             Promise.all(readFileAndInfo).then(([binString, reason]) => {
+            if(!didCancel)
+            {
                 console.log("Uploading file of size "+binString.byteLength);
                 const progressScope = $rootScope.$new();
                 const params = {
@@ -127,13 +139,17 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                     tz: Intl.DateTimeFormat().resolvedOptions().timeZone
                 }
                 uploadConfig.forEach((url) => {
-                    const progressPopup = $ionicPopup.alert({
+                    const progressPopup = $ionicPopup.show({
                         title: $translate.instant("upload-service.upload-database",
-                            {db: database}),
+                            { db: database }),
                         template: $translate.instant("upload-service.upload-progress",
                             {filesizemb: binString.byteLength / (1000 * 1000),
-                             serverURL: uploadConfig}),
+                            serverURL: uploadConfig}) 
+                            + '<center><ion-spinner></ion-spinner></center>',
                         scope: progressScope,
+                        buttons: [
+                        { text: '<b>Cancel</b>', type: 'button-cancel',  },
+                        ]
                     });
                     sendToServer(url, binString, params).then((response) => {
                         console.log(response);
@@ -142,10 +158,11 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                             title: $translate.instant("upload-service.upload-success"),
                             template: $translate.instant("upload-service.upload-details",
                                 {filesizemb: binString.byteLength / (1000 * 1000),
-                                 serverURL: uploadConfig})
+                                serverURL: uploadConfig})
                         });
                     }).catch(onUploadError);
                 });
+            }
             }).catch(onReadError);
           }).catch(onReadError);
         };

--- a/www/templates/control/qrc.html
+++ b/www/templates/control/qrc.html
@@ -4,7 +4,7 @@
         <div class="row">
             <div class="col"></div>
             <center>
-            <h3 text-align="center"> <span translate>{{'.qrcode'}}</span> </h3> 
+            <h3 text-align="center"> <span translate>{{'.qrcode'}}</span> </h3> <ion-spinner></ion-spinner>
             </center>
             <div class="col"></div>
         </div>
@@ -25,6 +25,6 @@
             <button class="col" style="height: 100%; background-color: #01D0A7" ng-click="shareQR()" class="control-icon-button">  <i class="ion-share" style="color: white; font-size: 200%"></i></button>
             <div class="col"></div>
         </div>
-    
+        
     <!--</ion-content>-->
 </ion-popover-view>


### PR DESCRIPTION
uploadService.js
- Added functionality on 'Cancel' button so that the button closes when you click it, instead of continuing to upload the logs
- Added didCancel variable which keeps track of whether the cancel button was clicked, or not, to either execute the rest of the function, or to not
- Switched the $ionicPopup.alert for the uploading popup to an $ionicPopup.show so that we could change the button text from "OK" to "Cancel"
- Added an ionic spinner in the Uploading popup
- Added the button type 'button-cancel' to make the cancel button display as red

style.css
- Created button type 'button-cancel' which makes buttons red with white text