### PR TITLE
"Upload Logs" UI fixes (REDO)

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -51,6 +51,11 @@ body.platform-ios {
   height: 40px;
 
 }
+.button.ng-binding.button-cancel {
+  background-color: #d02001;
+  height: 40px;
+  color: #ffffff
+}
 .selected_date_full.ng-binding {
   color: #01D0A7;
 }

--- a/www/js/control/uploadService.js
+++ b/www/js/control/uploadService.js
@@ -94,6 +94,8 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
             newScope.fromDirText = $translate.instant('upload-service.upload-from-dir',  {parentDir: parentDir});
             newScope.toServerText = $translate.instant('upload-service.upload-to-server',  {serverURL: uploadConfig});
 
+            var didCancel = true;
+
             const detailsPopup = $ionicPopup.show({
                 title: $translate.instant("upload-service.upload-database", { db: database }),
                 template: newScope.toServerText
@@ -101,13 +103,20 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                     +' placeholder="{{ \'upload-service.please-fill-in-what-is-wrong \' | translate}}">',
                 scope: newScope,
                 buttons: [
-                  { text: 'Cancel' },
+                  { 
+                    text: 'Cancel',
+                    onTap: function(e) {
+                        didCancel = true;
+                        detailsPopup.close();
+                    }
+                  },
                   {
                     text: '<b>Upload</b>',
                     type: 'button-positive',
                     onTap: function(e) {
                       if (!newScope.data.reason) {
                         //don't allow the user to close unless he enters wifi password
+                        didCancel = false;
                         e.preventDefault();
                       } else {
                         return newScope.data.reason;
@@ -120,6 +129,8 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
             Logger.log(Logger.LEVEL_INFO, "Going to upload " + database);
             const readFileAndInfo = [readDBFile(parentDir, database), detailsPopup];
             Promise.all(readFileAndInfo).then(([binString, reason]) => {
+              if(!didCancel)
+              {  
                 console.log("Uploading file of size "+binString.byteLength);
                 const progressScope = $rootScope.$new();
                 const params = {
@@ -127,13 +138,17 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                     tz: Intl.DateTimeFormat().resolvedOptions().timeZone
                 }
                 uploadConfig.forEach((url) => {
-                    const progressPopup = $ionicPopup.alert({
+                    const progressPopup = $ionicPopup.show({
                         title: $translate.instant("upload-service.upload-database",
                             {db: database}),
                         template: $translate.instant("upload-service.upload-progress",
                             {filesizemb: binString.byteLength / (1000 * 1000),
-                             serverURL: uploadConfig}),
+                             serverURL: uploadConfig})
+                            + '<center><ion-spinner></ion-spinner></center>',
                         scope: progressScope,
+                        buttons: [
+                            { text: '<b>Cancel</b>', type: 'button-cancel',  },
+                        ]
                     });
                     sendToServer(url, binString, params).then((response) => {
                         console.log(response);
@@ -146,6 +161,8 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                         });
                     }).catch(onUploadError);
                 });
+
+              }
             }).catch(onReadError);
           }).catch(onReadError);
         };


### PR DESCRIPTION
Redoing this commit because last time there were some whitespace/blame changes that I did not intend. This time they should be fixed

uploadService.js
- Added functionality on 'Cancel' button so that the button closes when you click it, instead of continuing to upload the logs
- Added didCancel variable which keeps track of whether the cancel button was clicked, or not, to either execute the rest of the function, or to not
- Switched the $ionicPopup.alert for the uploading popup to an $ionicPopup.show so that we could change the button text from "OK" to "Cancel"
- Added an ionic spinner in the Uploading popup
- Added the button type 'button-cancel' to make the cancel button display as red

style.css
- Created button type 'button-cancel' which makes buttons red with white text