### PR TITLE
Quick "Cancel button" defect fix

### DIFF
--- a/www/js/control/uploadService.js
+++ b/www/js/control/uploadService.js
@@ -119,6 +119,7 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                         didCancel = false;
                         e.preventDefault();
                       } else {
+                        didCancel = false;
                         return newScope.data.reason;
                       }
                     }
@@ -161,7 +162,6 @@ angular.module('emission.services.upload', ['emission.plugin.logger'])
                         });
                     }).catch(onUploadError);
                 });
-
               }
             }).catch(onReadError);
           }).catch(onReadError);


### PR DESCRIPTION
UploadService.js
- Removed one unnecessary blank line
- Added line `didCancel = false` to the popup, in case the user clicked submit without giving it a name first and THEN hitting cancel, it would still upload. This line fixes that issue