### PR TITLE
Adding "Save OPcode" prompt after login during setup

### DIFF
--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -634,20 +634,11 @@ angular.module('emission.main.control',['emission.services',
         });
     }
 
-    var prepopulateQRMessage = {
-        message: $translate.instant('general-settings.qrcode-share-message'), // not supported on some apps (Facebook, Instagram)
-        subject: $translate.instant('general-settings.qrcode-share-subject') // fi. for email
-    }
-
     $scope.shareQR = function() {
-        //const c = $(".qrcode"); // selects the canvas element containing the QR code
-        //const cbase64 = c[0].toDataURL(); // converts the canvas element into base64 data
-        //prepopulateQRMessage.files = [cbase64]; // adds the base64 data into our share message
-
+        var prepopulateQRMessage = {};  
         const c = document.getElementsByClassName('qrcode-link');
         const cbase64 = c[0].getAttribute('href');
         prepopulateQRMessage.files = [cbase64];
-
         prepopulateQRMessage.url = $scope.settings.auth.email;
 
         window.plugins.socialsharing.shareWithOptions(prepopulateQRMessage, function(result) {

--- a/www/templates/intro/login.html
+++ b/www/templates/intro/login.html
@@ -3,6 +3,10 @@
 <center><h3>Login via anonymous token (OPcode) </h3></center>
 <center>OPcode {{randomToken}}</center></div>
 
+<div class="save-button">
+  <center><div class="col" ng-click="saveLogin('{{randomToken}}')" class="control-icon-button"> <br>Save your OPcode <i class="ion-ios-download-outline" style="font-size: 200%"></i></div></center>
+</div>
+
 <div class="intro-text">
 This unique randomly generated token (OPcode) is your identifier in the system.
 <p>&nbsp;</p>


### PR DESCRIPTION
intro.js
- Added the monospaced.qrcode to the libraries
- Added a saveLogin function
- Checks if token is empty (as is the case if the user selects the "Save your OPcode" button) and automatically fills in the token with the random token
- Otherwise, it uses the passed in token
- The token that gets displayed as an OPcode and shared is the $scope.currentToken, because when useing the $ionicPopup.show() function, the template requires a $scope variable in the HTML injection
- Added the shareQR function, which is a variation of the shareQR function seen in www/js/control/general-settings.js. It allows for sharing the QR image together with the OPcode text
- This should be later added as a directive, so that the code is not copied/pasted between these 2 files (which it is now), but for now the functionality works
- Added a currentToken scope variable which keeps track of the currentToken, which will be displayed on the saveToken popup
- Added an "alreadySaved" scope variable to know if the user has already saved their OPcode, so to not bug them twice about it
- Made sure that after scanning or entering in an OPcode manually, it prompts to save
- If a user saves their random token before logging in with their random token, it will not prompt them after logging in. Otherwise, it will.

login.html
- Added the "Save your OPcode" button underneath the randomly generated OPcode token during the setup/login screen

general-settings.js
- Changed the share message to be just the OPcode image and the OPcode text (copyable)
- This is because Shankari and I agreed that it should only save the QR image and the OPcode text, any additional text is confusing and excessive