### PR TITLE
Backwards compat changes to ensure that all tokens start with the study name

### DIFF
--- a/www/js/config/dynamic_config.js
+++ b/www/js/config/dynamic_config.js
@@ -51,6 +51,7 @@ angular.module('emission.config.dynamic', ['emission.plugin.logger'])
             Logger.log("Successfully found the "+downloadURL+", result is " + JSON.stringify(result.data).substring(0,10));
             const parsedConfig = result.data;
             const connectionURL = parsedConfig.server? parsedConfig.server.connectUrl : "dev defaults";
+            _fillStudyName(parsedConfig);
             Logger.log("Successfully downloaded config with version "+parsedConfig.version
                 +" for "+parsedConfig.intro.translated_text.en.deployment_name
                 +" and data collection URL "+connectionURL);
@@ -69,6 +70,7 @@ angular.module('emission.config.dynamic', ['emission.plugin.logger'])
                     return undefined;
                 } else {
                     Logger.log("Found previously stored ui config, returning it");
+                    _fillStudyName(savedConfig);
                     return savedConfig;
                 }
             })
@@ -87,6 +89,26 @@ angular.module('emission.config.dynamic', ['emission.plugin.logger'])
         dc.isConfigChanged = true;
         console.log("Broadcasting event "+dc.UI_CONFIG_CHANGED);
         $rootScope.$broadcast(dc.UI_CONFIG_CHANGED, newConfig);
+    }
+
+    const _getStudyName = function(connectUrl) {
+      const orig_host = new URL(connectUrl).hostname
+      if (orig_host == "openpath-stage") { return "stage"; }
+      const first_domain = orig_host.split(".")[0];
+      const openpath_index = first_domain.find("-openpath");
+      if (openpath_index == -1) { return undefined; }
+      const study_name = first_domain.substr(0,openpath_index);
+      return study_name;
+    }
+
+    const _fillStudyName = function(config) {
+        if (!config.name) {
+            if (config.server) {
+                config.name = _getStudyName(config.server.connectUrl);
+            } else {
+                config.name = "dev";
+            }
+        }
     }
 
     dc.initByUser = function(urlComponents) {

--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -213,7 +213,17 @@ angular.module('emission.main.control',['emission.services',
                 if (response == null) {
                   $scope.settings.auth.email = "Not logged in";
                 } else {
-                  $scope.settings.auth.email = response;
+                    /*
+                     * Hack to support adding in the study as a prefix to any existing token.
+                     */
+                    if ($scope.ui_config && !response.startsWith("nrelop_")) {
+                        const newToken = "nrelop_"+$scope.ui_config.name+"_"+response;
+                        Logger.log("Found old style token, after prepending nrelop_"+$scope.ui_config.name+" new token is "+newToken);
+                        window.cordova.plugins.BEMJWTAuth.setPromptedAuthToken(newToken);
+                        $scope.settings.auth.email = newToken;
+                    } else {
+                        $scope.settings.auth.email = response;
+                    }
                 }
             });
         }, function(error) {

--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -86,7 +86,8 @@ angular.module('emission.intro', ['emission.splash.startprefs',
     var randomChars = Array.from(randomInts).map((b) => String.fromCharCode(b));
     var randomString = randomChars.join("");
     var validRandomString = window.btoa(randomString).replace(/[+/]/g, "");
-    return validRandomString.substring(0, length);
+    var truncatedRandomString = validRandomString.substring(0, length);
+    return "nrelop_"+$scope.ui_config.name+"_"+truncatedRandomString;
   }
 
   $scope.disagree = function() {


### PR DESCRIPTION
Related server changes:
https://github.com/e-mission/e-mission-server/commit/b73d671fb48e8bead7ee40bdb3e45c3befd32330
https://github.com/e-mission/e-mission-server/commit/087076005d5a272937b6415f5fe2c091f1d5b11e
https://github.com/e-mission/e-mission-server/commit/6e9f4d2bf054f8534cee8743715ac18efa3c7c55

Related PR comments:
https://github.com/e-mission/e-mission-docs/issues/732#issuecomment-1179828277

Basically, we:
- infer the study name from the connect URL
- ensure that any new autogenerated tokens have the study prefix
- fix up old style tokens to start with the study prefix

Once all the old style tokens are converted over, we can remove the final change.
Once we change the study config to include the name, *and* support config updates, we can remove the first change.