### PR TITLE
Ensure that we check for remote push type only if the push format is …

### DIFF
--- a/www/js/splash/remotenotify.js
+++ b/www/js/splash/remotenotify.js
@@ -47,7 +47,7 @@ angular.module('emission.splash.remotenotify', ['emission.plugin.logger',
         Logger.log("data = "+JSON.stringify(data));
         if (angular.isDefined(data.additionalData) &&
             angular.isDefined(data.additionalData.payload) &&
-            angular.isDefined(data.additionalData.payload.alert_type))
+            angular.isDefined(data.additionalData.payload.alert_type)) {
             if(data.additionalData.payload.alert_type == "website") {
                 var webpage_spec = data.additionalData.payload.spec;
                 if (angular.isDefined(webpage_spec) &&
@@ -68,7 +68,8 @@ angular.module('emission.splash.remotenotify', ['emission.plugin.logger',
                     $ionicPopup.alert("webpage was not specified correctly. spec is "+JSON.stringify(popup_spec));
                 }
             }
-        });
+        }
+      });
     }
 
     remoteNotify.init();


### PR DESCRIPTION
…valid

Not quite sure how this ever worked - I guess we didn't test it with invalid
format pushes.

Add braces to ensure that the remote notify types are only checked if the format is valid.
Without this, they are checked every time, which may crash if the push is of an invalid format

Encountered this because we apparently got a push of format `{'foreground': true, ...}`
Not sure who sent it, but we got a backtrace because of it