### PR TITLE
Add support for e-car to give people a better sense of their carbon f…

### DIFF
--- a/www/json/trip_confirm_options.json.sample
+++ b/www/json/trip_confirm_options.json.sample
@@ -6,8 +6,10 @@
             "ALL": {"range": [0, -1], "mets": 4.9}
        }, "co2PerMeter": 0.00728},
        {"text":"Scooter share","value":"scootershare", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.00894},
-       {"text":"Drove Alone","value":"drove_alone", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.22031},
-       {"text":"Shared Ride","value":"shared_ride", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.11015},
+       {"text":"Gas Car Drove Alone","value":"drove_alone", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.22031},
+       {"text":"Gas Car Shared Ride","value":"shared_ride", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.11015},
+       {"text":"E-Car Drove Alone","value":"e_car_drove_alone", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.08216},
+       {"text":"E-Car Shared Ride","value":"e_car_shared_ride", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.04108},
        {"text":"Taxi/Uber/Lyft","value":"taxi", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.30741},
        {"text":"Bus","value":"bus", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.20727},
        {"text":"Train","value":"train", "met_equivalent": "IN_VEHICLE", "co2PerMeter": 0.12256},


### PR DESCRIPTION
…ootprint

Also duplicated at: https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-1212776169

Since we are NREL, we want to also support the difference in energy intensity between car vs. e-car.

Estimates for the average e-car:
- From Andrew Kotz: 3 - 4 miles/kWH = 333 - 250 WH/mile
- From Andy's Leaf: 244 WH/mile
- From my Leaf (4.2 miles/kWH average, probably because I am in the SF Bay Area): 238 WH/mile

Let's go with 250 WH/mile (0.25 kWH/VMT) since most of the numbers seem to be clustered around there, and 250 is a nice round number 😄

So we will add entries for:
- e_car_drove_alone: 250 WH/mile (versus e-bike at 22 WH/mile)
- e_car_shared_ride:  125 WH/mile (versus e-bike at 22 WH/mile)

We will continue to use 1166 lb per MWH, consistent with egrid estimate for CO at the time of the CEO mini-pilot
https://www.epa.gov/egrid/power-profiler#/RMPA

1,000,000 WH = 1166 lb
250 WH = (250 * 1166) / 1000000 = 0.2915 lb
125 WH = (125 * 1166) / 1000000 = 0.1458 lb

- e_car_drove_alone: 0.2915 lb/mile
- e_car_shared_ride:  0.1458 lb/mile

We want the values in kg/PkmT

0.2915 lb = 1 mile
0.1322 kg = 1.609 km
(0.1322 / 1.609) = 0.08216 kg/PkmT (versus 0.00728 for e-bike, so the magnitude seems right)

0.1458 lb = 1 mile
0.0661 kg = 1.609 meters
(0.0661 / 1.609) = 0.04108 kg/PkmT (half of drove_alone) so the magnitude seems right

- e_car_drove_alone: 0.08216 kg/meter
- e_car_shared_ride:  0.04108 kg/meter

Testing done:
- Labeled a bunch of trips as e-car
- Ensured that the carbon footprint dropped significantly