### PR TITLE
Show the "replaced mode" only for e-bikes in a program

### DIFF
--- a/www/js/survey/multilabel/multi-label-ui.js
+++ b/www/js/survey/multilabel/multi-label-ui.js
@@ -166,6 +166,7 @@ angular.module('emission.survey.multilabel.buttons',
   };
 
   var expandInputsIfNecessary = function(inputType, inputValue) {
+    console.log("Experimenting with expanding inputs for type "+inputType+" and value "+inputValue);
     if (inputType == "MODE") {
         if (inputValue == "e-bike") {
             if ($scope.displayInputDetails != $scope.fullInputDetails) {
@@ -290,8 +291,14 @@ angular.module('emission.survey.multilabel.buttons',
 
       ConfirmHelper.inputParamsPromise.then((inputParams) => $scope.inputParams = inputParams);
       console.log("Finished initializing directive, displayInputDetails = ", $scope.displayInputDetails);
+      $scope.$watch('trip', function(newTrip, oldTrip, scope) {
+        console.log("TRIP CHANGED in directive, old trip is", oldTrip, "new trip is", newTrip,
+            ", with mode "+ newTrip.userInput["MODE"].value);
+        expandInputsIfNecessary("MODE", newTrip.userInput["MODE"].value);
+      });
       $scope.currViewState = findViewState();
   }
+
 
   $ionicPlatform.ready().then(function() {
     Logger.log("UI_CONFIG: about to call configReady function in MultiLabelCtrl");

--- a/www/js/survey/multilabel/trip-confirm-services.js
+++ b/www/js/survey/multilabel/trip-confirm-services.js
@@ -4,34 +4,44 @@ angular.module('emission.survey.multilabel.services', ['ionic', 'emission.i18n.u
     var ch = {};
     ch.init = function(ui_config) {
         Logger.log("About to start initializing the confirm helper for " + ui_config.intro.program_or_study);
-        const labelWidth = ui_config.intro.program_or_study == 'program'? 'col-33' : 'col-50';
-        const btnWidth = ui_config.intro.program_or_study == 'program'? '80' : '115';
+        const labelWidth = {"base": "col-50", "intervention": "col-33"};
+        const btnWidth = {"base": "115", "intervention": "80"};
         ch.INPUTS = ["MODE", "PURPOSE"];
         ch.inputDetails = {
             "MODE": {
                 labeltext: $translate.instant(".mode"),
                 choosetext: $translate.instant(".choose-mode"),
-                width: labelWidth,
-                btnWidth: btnWidth,
+                width: labelWidth["base"],
+                btnWidth: btnWidth["base"],
                 key: "manual/mode_confirm",
                 otherVals: {},
             },
             "PURPOSE": {
                 labeltext: $translate.instant(".purpose"),
                 choosetext: $translate.instant(".choose-purpose"),
-                width: labelWidth,
-                btnWidth: btnWidth,
+                width: labelWidth["base"],
+                btnWidth: btnWidth["base"],
                 key: "manual/purpose_confirm",
                 otherVals: {},
             }
         }
         if (ui_config.intro.program_or_study == 'program') {
+            // store a copy of the base input details
+            ch.baseInputDetails = angular.copy(ch.inputDetails);
+
+            // then add the program specific information by adding the REPLACED_MODE
+            // and resetting the widths
             ch.INPUTS.push("REPLACED_MODE");
+            for (const [key, value] of Object.entries(ch.inputDetails)) {
+                value.width = labelWidth["intervention"];
+                value.btnWidth = btnWidth["intervention"];
+            };
+            console.log("Finished resetting label widths ",ch.inputDetails);
             ch.inputDetails["REPLACED_MODE"] = {
                 labeltext: $translate.instant(".replaces"),
                 choosetext: $translate.instant(".choose-replaced-mode"),
-                width: labelWidth,
-                btnWidth: btnWidth,
+                width: labelWidth["intervention"],
+                btnWidth: btnWidth["intervention"],
                 key: "manual/replaced_mode",
                 otherVals: {}
             }

--- a/www/templates/survey/multilabel/multi-label-ui.html
+++ b/www/templates/survey/multilabel/multi-label-ui.html
@@ -1,12 +1,12 @@
 <!-- Label -->
  <div class="row" style="margin-top: 0px">
-  <div ng-repeat="input in userInputDetails" class={{input.width}} style="text-align: center;font-size: 14px;font-weight: 600;" ng-attr-id="{{ 'userinputlabel' + input.name }}" translate>
+  <div ng-repeat="input in displayInputDetails" class={{input.width}} style="text-align: center;font-size: 14px;font-weight: 600;" ng-attr-id="{{ 'userinputlabel' + input.name }}" translate>
     {{input.labeltext}}
   </div>
  </div>
 <!-- Buttons (if confirmed) -->
 <div class="row input-confirm-row">
-    <div ng-repeat="input in userInputDetails" class={{input.width}} style="text-align: center;" ng-attr-id="{{ 'userinput' + input.name }}">
+   <div ng-repeat="input in displayInputDetails" class={{input.width}} style="text-align: center;" ng-attr-id="{{ 'userinput' + input.name }}">
         <div ng-if="trip.userInput[input.name]" class="input-confirm-container">
             <button ng-click ="openPopover($event, trip, input.name)" style="width: {{input.btnWidth}}px" class="button btn-input-confirm btn-input-confirm-green">
                 {{trip.userInput[input.name].text}}


### PR DESCRIPTION
Show the "replaced mode" only for e-bikes in a program

Based on feedback from program admins, and from NREL modelers who are using the
data, we don't really need the replaced mode for non-program interventions.
This also reduces user confusion ("what is the replaced mode?" is an FAQ)
and user burden.

Caveats:
- Currently, this is hardcoded to an e-bike intervention, pending
  implementation of https://github.com/e-mission/e-mission-docs/issues/755
- EDIT: ~This currently does not work for initial load; will be fixed in the next commit~ (fixed in https://github.com/e-mission/e-mission-phone/pull/874/commits/aba9dfb242fcb8d04f33030a9162d9c454472d1d)

Changes:
- change the inputDetails initialization to create a baseInputDetails in the
  case of programs. inputDetails will have all three options (MODE, PURPOSE,
  REPLACED_MODE), baseInputDetails will have only the two base options
- read them in the directive init as `fullInputDetails` (always exists) and
  `baseInputDetails` (only for programs)
- change the directive HTML to display `displayInputDetails`
- initialize `displayInputDetails` to `baseInputDetails` if it exists (program case)
    or `fullInputDetails` if it does not (study case)
- when the user chooses a value, we switch the `displayInputDetails` to
  `fullInputDetails` or `baseInputDetails` depending on the type of install
    (program vs. study) and the current mode.

Testing done:
- Select e-bike, changes to 3 labels
- Change purpose, stays at 3 labels
- Select walking, changes to 2 labels
- Change purpose, stays at 2 labels

