### PR TITLE
Support filtering on base/expanded labels as well 

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -222,6 +222,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   }
 
   $scope.recomputeDisplayTrips = function() {
+    console.log("recomputing display trips now");
     let alreadyFiltered = false;
     $scope.filterInputs.forEach((f) => {
         if (f.state == true) {

--- a/www/js/survey/multilabel/infinite_scroll_filters.js
+++ b/www/js/survey/multilabel/infinite_scroll_filters.js
@@ -15,7 +15,7 @@ angular.module('emission.survey.multilabel.infscrollfilters',[
 .factory('MultiLabelInfScrollFilters', function(Logger, ConfirmHelper, $translate){
     var sf = {};
     var unlabeledCheck = function(t) {
-       return ConfirmHelper.INPUTS
+       return t.INPUTS
            .map((inputType, index) => !angular.isDefined(t.userInput[inputType]))
            .reduce((acc, val) => acc || val, false);
     }

--- a/www/js/survey/multilabel/multi-label-ui.js
+++ b/www/js/survey/multilabel/multi-label-ui.js
@@ -180,10 +180,6 @@ angular.module('emission.survey.multilabel.buttons',
       isOther = true
       ConfirmHelper.checkOtherOption(inputType, checkOtherOptionOnTap, $scope);
     }
-    // special check for programs
-    // TODO: make this part of the dynamic config
-    MultiLabelService.expandInputsIfNecessary($scope.trip);
-    MultiLabelService.updateVerifiability($scope.trip);
     closePopover(inputType);
   };
 
@@ -365,6 +361,9 @@ angular.module('emission.survey.multilabel.buttons',
   }
 
   mls.updateTripProperties = function(trip, viewScope) {
+    // special check for programs
+    // TODO: make this part of the dynamic config
+    mls.expandInputsIfNecessary(trip);
     mls.inferFinalLabels(trip);
     mls.updateVerifiability(trip);
     mls.updateVisibilityAfterDelay(trip, viewScope);

--- a/www/js/survey/multilabel/multi-label-ui.js
+++ b/www/js/survey/multilabel/multi-label-ui.js
@@ -165,29 +165,6 @@ angular.module('emission.survey.multilabel.buttons',
       }
   };
 
-  var expandInputsIfNecessary = function(inputType, inputValue) {
-    console.log("Experimenting with expanding inputs for type "+inputType+" and value "+inputValue);
-    if (inputType == "MODE") {
-        if (inputValue == "e-bike") {
-            if ($scope.displayInputDetails != $scope.fullInputDetails) {
-                Logger.log("Found e-bike mode in a program, displaying full details");
-                $scope.displayInputDetails = $scope.fullInputDetails;
-            } else {
-                Logger.log("Found e-bike mode in a study, already displaying full details", $scope.displayInputDetails == $scope.fullInputDetails);
-            }
-        } else {
-            if ($scope.baseInputDetails) {
-                Logger.log("Found non e-bike mode in a program, displaying base details");
-                $scope.displayInputDetails = $scope.baseInputDetails;
-            } else {
-                Logger.log("Found non e-bike mode in a study, nothing to change");
-            }
-        }
-    } else {
-        Logger.log("Non-mode change, ignoring");
-    }
-  }
-
   $scope.choose = function (inputType) {
     ClientStats.addReading(ClientStats.getStatKeys().SELECT_LABEL, {
       "userInput":  angular.toJson($scope.editingTrip.userInput),
@@ -205,7 +182,8 @@ angular.module('emission.survey.multilabel.buttons',
     }
     // special check for programs
     // TODO: make this part of the dynamic config
-    expandInputsIfNecessary(inputType, $scope.selected[inputType].value);
+    MultiLabelService.expandInputsIfNecessary($scope.trip);
+    MultiLabelService.updateVerifiability($scope.trip);
     closePopover(inputType);
   };
 
@@ -241,30 +219,12 @@ angular.module('emission.survey.multilabel.buttons',
   $scope.init = function() {
       console.log("During initialization, trip is ", $scope.trip);
       console.log("Invoked multilabel directive controller for labels "+ConfirmHelper.INPUTS);
-      // We used to just have one set of input details here
-      // but now we need to display different sets of inputs
-      // if it is the intervention in a program (e.g. e-bike)
-      // in which case we want to display the replaced mode
-      // So we now have fullInputDetails (always present) and
-      // baseInputDetails (version without replaced mode, only for programs)
-      // and toggle between them based on program vs. study and mode
+      // We used to fill in the `name` for each input detail entry here
+      // and store the set of input details in the controller
+      // however, with the functionality of having the replaced mode
+      // only shown for certain trips, we are storing the details in the trip.
+      // which means that we really don't want to initialize it here.
       // https://github.com/e-mission/e-mission-docs/issues/764
-      $scope.fullInputDetails = angular.copy(ConfirmHelper.inputDetails);
-      for (const [key, value] of Object.entries($scope.fullInputDetails)) {
-        value.name = key;
-      };
-      $scope.displayInputDetails = $scope.fullInputDetails;
-
-      console.log("After copying input details", $scope.fullInputDetails);
-
-      if (ConfirmHelper.baseInputDetails) {
-        $scope.baseInputDetails = angular.copy(ConfirmHelper.baseInputDetails);
-        for (const [key, value] of Object.entries($scope.baseInputDetails)) {
-          value.name = key;
-        };
-        $scope.displayInputDetails = $scope.baseInputDetails;
-      }
-      console.log("After copying base input details", $scope.baseInputDetails);
 
       $scope.popovers = {};
       ConfirmHelper.INPUTS.forEach(function(item, index) {
@@ -290,12 +250,7 @@ angular.module('emission.survey.multilabel.buttons',
 
 
       ConfirmHelper.inputParamsPromise.then((inputParams) => $scope.inputParams = inputParams);
-      console.log("Finished initializing directive, displayInputDetails = ", $scope.displayInputDetails);
-      $scope.$watch('trip', function(newTrip, oldTrip, scope) {
-        console.log("TRIP CHANGED in directive, old trip is", oldTrip, "new trip is", newTrip,
-            ", with mode "+ newTrip.userInput["MODE"].value);
-        expandInputsIfNecessary("MODE", newTrip.userInput["MODE"].value);
-      });
+      console.log("Finished initializing directive, popovers = ", $scope.popovers);
       $scope.currViewState = findViewState();
   }
 
@@ -352,6 +307,7 @@ angular.module('emission.survey.multilabel.buttons',
         });
         trip.finalInference = {};
         mls.inferFinalLabels(trip);
+        mls.expandInputsIfNecessary(trip);
         mls.updateVerifiability(trip);
     } else {
         console.log("Trip information not yet bound, skipping fill");
@@ -473,6 +429,38 @@ angular.module('emission.survey.multilabel.buttons',
     }
   }
 
+  /*
+   * Uses either 2 or 3 labels depending on the type of install (program vs. study)
+   * and the primary mode. The current hardcoded example if the user selects
+   * "e-bike" for an e-bike study, will expand once we really support dynamic config.
+   * https://github.com/e-mission/e-mission-docs/issues/764
+   *
+   * This used to be in the controller, where it really should be, but we had
+   * to move it to the service because we need to invoke it from the list view
+   * as part of filtering "To Label" entries.
+   *
+   * TODO: Move it back later after the diary vs. label unification
+   */
+  mls.expandInputsIfNecessary = function(trip) {
+    console.log("Reading expanding inputs for ", trip);
+    const inputValue = trip.userInput["MODE"]? trip.userInput["MODE"].value : undefined;
+    console.log("Experimenting with expanding inputs for mode "+inputValue);
+    if (ConfirmHelper.isProgram) {
+        if (inputValue == "e-bike") {
+            Logger.log("Found e-bike mode in a program, displaying full details");
+            trip.inputDetails = ConfirmHelper.inputDetails;
+            trip.INPUTS = ConfirmHelper.INPUTS;
+        } else {
+            Logger.log("Found non e-bike mode in a program, displaying base details");
+            trip.inputDetails = ConfirmHelper.baseInputDetails;
+            trip.INPUTS = ConfirmHelper.BASE_INPUTS;
+        }
+    } else {
+        Logger.log("study, not program, already displaying full details", trip.inputDetails == ConfirmHelper.inputDetails);
+    }
+  }
+
+
   /**
    * MODE (becomes manual/mode_confirm) becomes mode_confirm
    */
@@ -494,7 +482,7 @@ angular.module('emission.survey.multilabel.buttons',
   mls.updateVerifiability = function(trip) {
     var allGreen = true;
     var someYellow = false;
-    for (const inputType of ConfirmHelper.INPUTS) {
+    for (const inputType of trip.INPUTS) {
         const green = trip.userInput[inputType];
         const yellow = trip.finalInference[inputType] && !green;
         if (yellow) someYellow = true;

--- a/www/js/survey/multilabel/trip-confirm-services.js
+++ b/www/js/survey/multilabel/trip-confirm-services.js
@@ -9,6 +9,7 @@ angular.module('emission.survey.multilabel.services', ['ionic', 'emission.i18n.u
         ch.INPUTS = ["MODE", "PURPOSE"];
         ch.inputDetails = {
             "MODE": {
+                name: "MODE",
                 labeltext: $translate.instant(".mode"),
                 choosetext: $translate.instant(".choose-mode"),
                 width: labelWidth["base"],
@@ -17,6 +18,7 @@ angular.module('emission.survey.multilabel.services', ['ionic', 'emission.i18n.u
                 otherVals: {},
             },
             "PURPOSE": {
+                name: "PURPOSE",
                 labeltext: $translate.instant(".purpose"),
                 choosetext: $translate.instant(".choose-purpose"),
                 width: labelWidth["base"],
@@ -26,8 +28,10 @@ angular.module('emission.survey.multilabel.services', ['ionic', 'emission.i18n.u
             }
         }
         if (ui_config.intro.program_or_study == 'program') {
+            ch.isProgram = true;
             // store a copy of the base input details
             ch.baseInputDetails = angular.copy(ch.inputDetails);
+            ch.BASE_INPUTS = angular.copy(ch.INPUTS);
 
             // then add the program specific information by adding the REPLACED_MODE
             // and resetting the widths
@@ -38,6 +42,7 @@ angular.module('emission.survey.multilabel.services', ['ionic', 'emission.i18n.u
             };
             console.log("Finished resetting label widths ",ch.inputDetails);
             ch.inputDetails["REPLACED_MODE"] = {
+                name: "REPLACED_MODE",
                 labeltext: $translate.instant(".replaces"),
                 choosetext: $translate.instant(".choose-replaced-mode"),
                 width: labelWidth["intervention"],

--- a/www/templates/survey/multilabel/multi-label-ui.html
+++ b/www/templates/survey/multilabel/multi-label-ui.html
@@ -1,12 +1,12 @@
 <!-- Label -->
  <div class="row" style="margin-top: 0px">
-  <div ng-repeat="input in displayInputDetails" class={{input.width}} style="text-align: center;font-size: 14px;font-weight: 600;" ng-attr-id="{{ 'userinputlabel' + input.name }}" translate>
+  <div ng-repeat="input in trip.inputDetails" class={{input.width}} style="text-align: center;font-size: 14px;font-weight: 600;" ng-attr-id="{{ 'userinputlabel' + input.name }}" translate>
     {{input.labeltext}}
   </div>
  </div>
 <!-- Buttons (if confirmed) -->
 <div class="row input-confirm-row">
-   <div ng-repeat="input in displayInputDetails" class={{input.width}} style="text-align: center;" ng-attr-id="{{ 'userinput' + input.name }}">
+   <div ng-repeat="input in trip.inputDetails" class={{input.width}} style="text-align: center;" ng-attr-id="{{ 'userinput' + input.name }}">
         <div ng-if="trip.userInput[input.name]" class="input-confirm-container">
             <button ng-click ="openPopover($event, trip, input.name)" style="width: {{input.btnWidth}}px" class="button btn-input-confirm btn-input-confirm-green">
                 {{trip.userInput[input.name].text}}


### PR DESCRIPTION
The previous change worked fine (c0876131a550943a1a832838f7f541eab0297025,
aba9dfb242fcb8d04f33030a9162d9c454472d1d), and I even merged it before
realizing that it didn't work for filters.

For both the verify check code and the 'to label' filters, we used to iterate
through all the possible user inputs. For programs, that includes replaced mode.
But we don't show the replaced mode for non e-bike trips, so it is never filled
out, and we always show the trip as "To Label".

Fixing this required significant restructuring, or maybe finally bowing to
reality, since the computations for the filtering run outside the directive
controller. The only shared data structure is the trip, so we need to put the
desired INPUTs into the trip. And since some of the computation happens before
the trip is assigned to a directive, we need to assign the appropriate inputs
on load in the service. Note that we can potentially change this later as part
of the diary/label unification when we stop using `collection-repeat` and start
using `ng-repeat`.

Changes:
- move the `expandInputsIfNecessary` code to the service
- invoke it before computing verifiability while populating trip inputs
- change `expandInputsIfNecessary` to move the relevant input storage into the trip
    - trip INPUTS
    - trip inputDetails
- this allows us to remove the `$watch` on the trip

- remove the code to add the name to the input details based on the key by
  hardcoding during creation instead
- this allows us to remove all references to input details in the directive
  controller scope since it is now in the trip

- change the filters (`updateVerifiability` and `unlabeledCheck`) to use trip
  labels instead of static labels
- change the template to read input details from the trip

Testing done:
- Changed label to/from e-bike
- Confimed that it moved to/from the "To label" and "All Trips" screens