### PR TITLE
Add display app version

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -707,6 +707,15 @@ background-image: none !important; }
   font-size:20px;
 }
 
+.control-version-number{
+  text-align: center;
+  float: right;
+  height: 100%;
+  color: #000;
+  padding-top: 16px;
+  width: 64px;
+  font-size:20px;
+}
 
 #switch-user.control-icon-button{
   background-color: #E0A1A1 !important;

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -711,7 +711,7 @@ background-image: none !important; }
   text-align: center;
   float: right;
   height: 100%;
-  color: #000;
+  color: rgb(114, 114, 114);
   padding-top: 16px;
   width: 64px;
   font-size:20px;

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -82,7 +82,8 @@
         "sync": "Sync",
         "transition-notify": "Transition Notify",
         "button-accept": "I accept",
-        "view-qrc": "My OPcode"
+        "view-qrc": "My OPcode",
+        "app-version": "App Version"
     },
 
     "general-settings":{

--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -343,6 +343,7 @@ angular.module('emission.main.control',['emission.services',
         $scope.settings.tnotify = {};
         $scope.settings.auth = {};
         $scope.settings.connect = {};
+        $scope.settings.clientAppVer = ClientStats.getAppVersion();
         $scope.settings.channel = function(newName) {
           return arguments.length ? (UpdateCheck.setChannel(newName)) : $scope.settings.storedChannel;
         };

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -188,7 +188,9 @@
             <div class="row" ng-include="'templates/control/transition-notify-display-detail.html'"></div>
         </ion-item>
       </ion-list>
-
+    </div>
+    <div class="control-list-item">
+      <div class="control-list-text">{{settings.clientAppVer}}</div>
     </div>
   </ion-content>
 </ion-view>

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -190,7 +190,8 @@
       </ion-list>
     </div>
     <div class="control-list-item">
-      <div class="control-list-text">{{settings.clientAppVer}}</div>
+      <div class="control-list-text" translate>{{'.app-version'}}</div>
+      <div class="control-version-number">{{settings.clientAppVer}}</div>
     </div>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
Created a section at the bottom of the Profile screen that displays the current app version

general-settings.js
- Added to the settings scope, clientAppVer which calls the ClientStats model to use the get app version function

style.css
- Created a new div class to display the app version

en.json
- Added an english translation for "App Version"

main-control.html
- Added div to display of the app version at the bottom
- Added app version translation into the HTML
- Used the new css style for the version number