### PR TITLE
Changed default screen to Dashboard

### DIFF
--- a/www/js/splash/startprefs.js
+++ b/www/js/splash/startprefs.js
@@ -177,7 +177,7 @@ angular.module('emission.splash.startprefs', ['emission.plugin.logger',
             $rootScope.redirectParams = undefined;
             return {state: redirState, params: redirParams};
           } else {
-            return {state: 'root.main.inf_scroll', params: {}};
+            return {state: 'root.main.metrics', params: {}};
           }
         } else {
           return {state: result, params: {}};


### PR DESCRIPTION
startprefs.js
- replaced inf_scroll as being the default open screen, to Dashboard (aka metrics)