### PR TITLE
Fixed diary screen checkmark box display issue

### DIFF
--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -27,7 +27,7 @@
                 <div class="row" translate="diary.filter-display-status" translate-values="{displayTripsLength: data.displayTrips.length, allTripsLength: data.allTrips.length}"></div>
                 <div ng-if="data.allTrips.length > 0" class="row" translate="diary.filter-display-range" translate-values="{currentStart: data.allTrips.slice(-1)[0].start_ts * 1000, currentEnd: infScrollControl.currentEnd * 1000}"></div>
             </div>
-            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" id="gray" class="diary-button"><i class="ion-ios-download"></i></div>
+            <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" id="gray" class="control-icon-button"><i class="ion-ios-download"></i></div>
             <div ng-if="infScrollControl.reachedEnd" id="green" class="control-icon-button"><i class="ion-checkmark"></i></div>
         </div>
 


### PR DESCRIPTION
For some reason the `class="control-icon-button"` was pushed to line 31, but not this line 30 so the display was incorrect
- changed class from "diary-button" (the incorrect style) to "control-icon-button" (the correct style)

I confirmed this is the fix for this issue by doing the following:
_Since I did not have enough unlabeled trips on my emulator (using the `test_july_22` test data) to trigger the `ng-if="!infScrollControl.reachedEnd"`, I set the `infScrollControl.reachedEnd` to always be `false` for my testing_

Here is how it was displaying before this change:
<img width="1204" alt="Screen Shot 2022-09-29 at 9 45 18 AM" src="https://user-images.githubusercontent.com/61334340/193080509-595aaadd-c142-467d-a230-218211e957e9.png">

Here is how it displays after this change:
<img width="1203" alt="Screen Shot 2022-09-29 at 9 49 22 AM" src="https://user-images.githubusercontent.com/61334340/193080543-d77096a0-13c3-4e7e-93f9-db9927f238b0.png">
