### PR TITLE
Fixing display issues for diary styles

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -952,6 +952,21 @@ button.button.back-button.buttons.button-clear.header-item {
         bottom: -15px;
         box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
 }
+.start-time-tag-diarytoremove {
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  text-align: center;
+  background-color: #80D0FF;
+  color: black;
+  width: 16%;
+  height: 16px;
+  border-radius: 8px;
+  font-size: 9px;
+  position: absolute;
+  left: 1%;
+  top: 15px;
+  line-height: 16px;
+}
+
 
 .stop-time-tag {
         width: 68px;
@@ -972,6 +987,20 @@ button.button.back-button.buttons.button-clear.header-item {
         position: relative;
         top: -15px;
         box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+.stop-time-tag-diarytoremove {
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  text-align: center;
+  background-color: #0088ce;
+  color: white;
+  width: 16%;
+  height: 16px;
+  border-radius: 8px;
+  font-size: 9px;
+  position: absolute;
+  left: 1%;
+  bottom: 15px;
+  line-height: 16px;
 }
 .stop-time-tag-lower { /* this is used in both lists (infinite_scroll_list.js & list.js) around the differentCommon function */
         box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);

--- a/www/templates/diary/diary_list_item.html
+++ b/www/templates/diary/diary_list_item.html
@@ -1,5 +1,5 @@
 <div>
-    <div class="start-time-tag">{{tripgj.display_start_time}}</div>
+    <div class="start-time-tag-diarytoremove">{{tripgj.display_start_time}}</div>
     <div  style="padding-left: 19%;">
 
     <ion-item id="diary-item" style="background-color: transparent;" class="list-item">
@@ -31,7 +31,7 @@
         </div>
 
         <div class="row diary-arrow-container" ng-click="toDetail(tripgj.data.id)">
-            <leaflet class="col-90" geojson="tripgj" id="map_{{tripgj.data.id}}" defaults="defaults" height="150px"></leaflet>
+            <leaflet class="col-90" geojson="tripgj" id="map_{{tripgj.data.id}}" defaults="defaults" height="100px"></leaflet>
             <!-- Height needs to be specified directly in the HTML not in CSS otherwise
             zoom doesn't work. Mystery!! -->
             <button class="col-10 ion-ios-arrow-right"></button>
@@ -63,5 +63,5 @@
     </ion-item>
 
     </div>
-    <div ng-class="tripgj.common.stopTimeTagClass">{{tripgj.display_end_time}}</div>
+    <div class="stop-time-tag-diarytoremove">{{tripgj.display_end_time}}</div>
 </div>


### PR DESCRIPTION
style.css
- Added placeholder styles to match the older versions of the stop-time-tag and start-time-tag which were changed in the unification process

diary_list_item.html
- Used the new temporary styles for start/stop time tag
- Changed the height size of the map to be smaller, to accompany the vertically stacked buttons for mode and purpose