### PR TITLE
Ensure that the map works properly on the iOS diary view as well

### DIFF
--- a/www/js/diary/diary_list_item.js
+++ b/www/js/diary/diary_list_item.js
@@ -4,7 +4,8 @@
 
 angular.module('emission.main.diary.diarylistitem', [
     'ui-leaflet',
-    'emission.main.diary.list'
+    'emission.main.diary.list',
+    'emission.services',
 ])
 
 .directive("diaryListItem", function(){
@@ -21,7 +22,7 @@ angular.module('emission.main.diary.diarylistitem', [
 .controller("DiaryListItemCtrl", function(
                                         $scope,
                                         SurveyOptions,
-                                        $state
+                                        $state, Config
 ){
     $scope.surveyOpt = SurveyOptions.MULTILABEL;
     const DEFAULT_ITEM_HT = 335;
@@ -32,4 +33,17 @@ angular.module('emission.main.diary.diarylistitem', [
             tripId: param
         });
     }
+    angular.extend($scope, {
+        defaults: {
+            zoomControl: false,
+            dragging: false,
+            zoomAnimation: true,
+            touchZoom: false,
+            scrollWheelZoom: false,
+            doubleClickZoom: false,
+            boxZoom: false,
+        }
+    });
+
+    angular.extend($scope.defaults, Config.getMapTiles())
 });

--- a/www/js/diary/list.js
+++ b/www/js/diary/list.js
@@ -51,20 +51,6 @@ angular.module('emission.main.diary.list',['ui-leaflet',
     // CommonGraph.updateCurrent();
   };
 
-  angular.extend($scope, {
-      defaults: {
-          zoomControl: false,
-          dragging: false,
-          zoomAnimation: true,
-          touchZoom: false,
-          scrollWheelZoom: false,
-          doubleClickZoom: false,
-          boxZoom: false,
-      }
-  });
-
-  angular.extend($scope.defaults, Config.getMapTiles())
-
 //   moment.locale('en', {
 //   relativeTime : {
 //       future: "in %s",


### PR DESCRIPTION
The map tile location is configured in the `emission.services` module, `Config` service. Whenever we want to display a map, we read the tile location from the config and merge it with the existing map settings.

Before the refactor in 086dd85904f9be677ef2dd547f21d41119b36580, we displayed the list maps directly from `DiaryListCtrl`, so we configured it there.

As part of that refactor, we display the list map from the newly created `diaryListItem` directive, defined in `www/js/diary/diary_list_item.js`. However, the map tile configuration code was not moved in there.

This commit moves it in.

Testing done:
- without this change, the app tried to load maps from `ionic:://`, which would fail
- with this change, the app will try to load maps from `https://`, which succeeds The maps are now visible in the diary screen on iOS.

