### PR TITLE
Stagger loading of the trajectory information

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -40,7 +40,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   // Add option
 
   const placeLimiter = new Bottleneck({ maxConcurrent: 2, minTime: 500 });
-
+  $scope.mapLimiter = new Bottleneck({ maxConcurrent: 3, minTime: 100 });
   $scope.data = {};
   $scope.tripFilterFactory = $injector.get($scope.surveyOpt.filter);
   $scope.filterInputs = $scope.tripFilterFactory.configuredFilters;

--- a/www/js/diary/infinite_scroll_trip_item.js
+++ b/www/js/diary/infinite_scroll_trip_item.js
@@ -20,7 +20,8 @@ angular.module('emission.main.diary.infscrolltripitem', [
     return{
       restrict: 'E',
       scope: {
-        trip: '='
+        trip: '=',
+        mapLimiter: '='
       },
       controller: 'TripItemCtrl',
       templateUrl: 'templates/diary/trip_list_item.html'
@@ -48,6 +49,7 @@ angular.module('emission.main.diary.infscrolltripitem', [
     console.log("Trip before tripgj transformation ", $scope.trip);
 
     // Converting trip to tripgj
+    $scope.mapLimiter.schedule(() =>
     Timeline.confirmedTrip2Geojson($scope.trip).then((tripgj) => {
       $scope.$apply(() => {
           $scope.tripgj = $scope.trip;
@@ -67,7 +69,8 @@ angular.module('emission.main.diary.infscrolltripitem', [
           // $scope.tripgj.percentages = DiaryHelper.getPercentages($scope.trip);
           // console.log("Section Percentages are ", $scope.tripgj.percentages);
       });
-    });
+    })
+    );
     console.log("Trip's Date is ", $scope.trip.display_date);
     console.log("Trip in Trip Item Ctrl is ", $scope.trip);
 

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -771,7 +771,7 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
         ];
 
         return Promise.all(fillPromises).then(function([locationList]) {
-          Logger.log("Retrieved "+locationList.phone_data.length+" points");
+          Logger.log("Retrieved "+locationList.phone_data.length+" points at "+(new Date()));
           var features = [
             confirmedPlace2Geojson(trip, trip.start_loc, "start_place"),
             confirmedPlace2Geojson(trip, trip.end_loc, "end_place"),

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -39,7 +39,7 @@
                     <h2 class="hr-lines" translate> {{trip.display_date}}</h2>
                 </div>
 
-                <infinite-scroll-trip-item trip="trip"></infinite-scroll-trip-item>
+                <infinite-scroll-trip-item trip="trip" map-limiter="mapLimiter"></infinite-scroll-trip-item>
                 
                 <div ng-if="trip.display_date != trip.nextTrip.display_date && trip.nextTrip.display_date != undefined">
                     <h2 class="hr-lines" translate> {{trip.nextTrip.display_date}} </h2>


### PR DESCRIPTION
This will avoid overloading the network, and will prevent the app from hanging on older/lower memory phones.

High level changes:
- create a "bottleneck" limiter for the map loading, similar to the address loading
- we could choose to fill in the maps in the list, similar to the addresses - however, to avoid putting more code into the list, we pass in the limiter into the directive - directive loads maps using the limiter - limiter ensures that map loading is staggered

Testing done:
- Label screen loads

For a more detailed description of the issue and the fix, please see the comments in the related PR