### PR TITLE
fixed diary street name overlap

### DIFF
--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -296,6 +296,14 @@ a.item-content {
   font-style: normal;
   font-weight: normal;
   font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.two-lines {
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
   white-space: normal;
 }
 

--- a/www/templates/diary/trip_list_item.html
+++ b/www/templates/diary/trip_list_item.html
@@ -62,15 +62,15 @@
 
                     <!-- Row, containing Detail Screen button and Trip Origin/Destination -->
                     <div class="row" style="padding: 4px">
-                        <div class="col-100">
+                        <div class="col-100" style="width: 100%;">
                             <!-- Origin for Trip -->
-                            <div class="diary-street" ng-click="showDetail($event, trip)">
+                            <div class="diary-street two-lines" ng-click="showDetail($event, trip)">
                                 <i class="icon ion-ios-location" style="font-size: 16px; left: 0; color: #80D0FF;"></i>
                                 {{trip.start_display_name}}
                                 </div>
 
                             <!-- Destination for Trip -->
-                            <div class="diary-street" ng-click="showDetail($event, trip)">
+                            <div class="diary-street two-lines" ng-click="showDetail($event, trip)">
                                 <i class="icon ion-ios-location" style="font-size: 16px; left: 0; color: #0088ce;"></i>
                                 {{trip.end_display_name}}
                             </div>


### PR DESCRIPTION
main.diary.css
- added overflow styles to the diary-street css style which allows the ellipses ending to populate
- added a two-lines style that can be used in conjunction with diary-street to make it ellipses after 2 lines instead of just 1

trip_list_item.html
- added diary-street two-lines as the styles for both diary-street lines
- added a 100% width to the col-100 div so that it doesn't try to ellipses past the end of the div (which it was doing before without this 100% width)