### PR TITLE
Fixed date separator displaying wrong date

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -109,7 +109,11 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         Logger.log("Received batch of size "+ctList.length);
         ctList.forEach($scope.populateBasicClasses);
         ctList.forEach((trip, tIndex) => {
-            trip.nextTrip = ctList[tIndex+1];
+            if (tIndex == 0) {
+              trip.prevTrip = {display_date: trip.display_date};
+            } else {
+              trip.prevTrip = ctList[tIndex-1];
+            }
             $scope.labelPopulateFactory.populateInputsAndInferences(trip, $scope.data.manualResultMap);
         });
         // Fill places on a reversed copy of the list so we fill from the bottom up
@@ -320,6 +324,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         // Pre-populate start and end names with &nbsp; so they take up the same amount of vertical space in the UI before they are populated with real data
         tripgj.start_display_name = "\xa0";
         tripgj.end_display_name = "\xa0";
+        tripgj.prevTrip = undefined;
     }
 
     const fillPlacesForTripAsync = function(tripgj) {

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -34,16 +34,12 @@
 		<ion-list>
 		<div ng-repeat="trip in data.displayTrips">
             <div>
-
-                <div ng-show="$index==0">
+                
+                <div ng-if='$index==0 || trip.prevTrip.display_date != trip.display_date'>
                     <h2 class="hr-lines" translate> {{trip.display_date}}</h2>
                 </div>
 
                 <infinite-scroll-trip-item trip="trip" map-limiter="mapLimiter"></infinite-scroll-trip-item>
-                
-                <div ng-if="trip.display_date != trip.nextTrip.display_date && trip.nextTrip.display_date != undefined">
-                    <h2 class="hr-lines" translate> {{trip.nextTrip.display_date}} </h2>
-                </div>
 
             </div>
         </div>


### PR DESCRIPTION
infinite_scroll_list.html
- Removed the trip.nextTrip.display_date div
- Changed the ng-show="$index==0" to an ng-if, so that I can concatenate the next change
- Added an OR to also display the date for a trip if the previous day's date is different than the current day's date

infinite_scroll_list.js
- Added an attribute to all trips called "prevTrip", which sets to undefined by default
- Got rid of the nextTrip attribute which is only set within that particular ctList.forEach((trip, tIndex) loop
- Replaced the nextTrip attribute set with a check: if it is the first trip in our list, it sets the prevTrip.display_date to its own display_date. Otherwise (all other trips) it sets the prevTrip object to the previous object in the list