### PR TITLE
Display the trip directly instead of displaying a copy generated afte…

### DIFF
--- a/www/js/diary/infinite_scroll_trip_item.js
+++ b/www/js/diary/infinite_scroll_trip_item.js
@@ -52,17 +52,15 @@ angular.module('emission.main.diary.infscrolltripitem', [
     $scope.mapLimiter.schedule(() =>
     Timeline.confirmedTrip2Geojson($scope.trip).then((tripgj) => {
       $scope.$apply(() => {
-          $scope.tripgj = $scope.trip;
-          $scope.tripgj.data = tripgj;
-          $scope.tripgj.common = {};
-          $scope.tripgj.common.earlierOrLater = '';
-          $scope.tripgj.pointToLayer = DiaryHelper.pointFormat;
+          $scope.trip.data = tripgj;
+          $scope.trip.common = {};
+          $scope.trip.common.earlierOrLater = '';
+          $scope.trip.pointToLayer = DiaryHelper.pointFormat;
 
-          console.log("Is our trip a draft? ", DiaryHelper.isDraft($scope.tripgj));
-          $scope.tripgj.isDraft = DiaryHelper.isDraft($scope.tripgj);
-          console.log("Tripgj == Draft: ", $scope.tripgj.isDraft);
-
-          console.log("Tripgj in Trip Item Ctrl is ", $scope.tripgj);
+          console.log("Is our trip a draft? ", DiaryHelper.isDraft($scope.trip));
+          $scope.trip.isDraft = DiaryHelper.isDraft($scope.trip);
+          console.log("Tripgj == Draft: ", $scope.trip.isDraft);
+          console.log("Tripgj in Trip Item Ctrl is ", $scope.trip);
 
           // var tc = getTripComponents($scope.tripgj);
           // $scope.tripgj.sections = tc[3];

--- a/www/templates/diary/trip_list_item.html
+++ b/www/templates/diary/trip_list_item.html
@@ -11,7 +11,7 @@
             <div class="diary-map-shell" ng-click="showDetail($event, trip)">
             <leaflet
             class="diary-map"
-            geojson="tripgj"
+            geojson="trip"
             defaults="mapCtrl.defaults"
             id="$index"
             data-tap-disabled="true"
@@ -33,8 +33,8 @@
                     <div
                         class="diary-distance-time"
                         translate=".distance-in-time"
-                        translate-value-distance="{{ tripgj.display_distance }} {{tripgj.display_distance_suffix }}"
-                        translate-value-time="{{ tripgj.display_time }}">
+                        translate-value-distance="{{ trip.display_distance }} {{trip.display_distance_suffix }}"
+                        translate-value-time="{{ trip.display_time }}">
                     </div>
                 </div>
 
@@ -42,15 +42,15 @@
                 <div class="diary-modes-percents">
                     <span
                         class="diary-modes-percents-text"
-                        ng-if="!tripgj.isDraft"
-                        ng-repeat="sectionPct in tripgj.percentages"
+                        ng-if="!trip.isDraft"
+                        ng-repeat="sectionPct in trip.percentages"
                     >
                         <span class="diary-modes-percents-icon {{sectionPct.icon}}"></span>
                         <span>{{sectionPct.pct}}%</span>
                     </span>
                     <button
                     class="diary-draft-button"
-                    ng-if="tripgj.isDraft"
+                    ng-if="trip.isDraft"
                     ng-click="explainDraft($event)"
                   >
                     <span translate>{{'.draft'}}</span>


### PR DESCRIPTION
…r we get the trajectories

This ensures that we display at least part of the trip information even while waiting for the trajectory data

This is a test to see if we can fix
https://github.com/e-mission/e-mission-docs/issues/819