### PR TITLE
Removing prevTrip, displaying trip date on trip item

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -110,7 +110,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         ctList.forEach($scope.populateBasicClasses);
         ctList.forEach((trip, tIndex) => {
             trip.nextTrip = ctList[tIndex+1];
-            trip.prevTrip = {display_date: trip.display_date};
             $scope.labelPopulateFactory.populateInputsAndInferences(trip, $scope.data.manualResultMap);
         });
         // Fill places on a reversed copy of the list so we fill from the bottom up
@@ -322,7 +321,6 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         // Pre-populate start and end names with &nbsp; so they take up the same amount of vertical space in the UI before they are populated with real data
         tripgj.start_display_name = "\xa0";
         tripgj.end_display_name = "\xa0";
-        tripgj.prevTrip = undefined;
     }
 
     const fillPlacesForTripAsync = function(tripgj) {

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -35,9 +35,10 @@
 		<div collection-repeat="trip in data.displayTrips">
             <div>
                 
-                <div ng-if='$index==0 || trip.prevTrip.display_date != trip.display_date'>
+                <!-- <div ng-if='$index==0 || trip.prevTrip.display_date != trip.display_date'>
                     <h2 class="hr-lines" translate> {{trip.display_date}}</h2>
-                </div>
+                </div> Commented out as we are not using prevTrip anymore. We should come back to 
+                this and implement some sort of horizontal line between trips-day-changing later on-->
 
                 <infinite-scroll-trip-item trip="trip" map-limiter="mapLimiter"></infinite-scroll-trip-item>
 

--- a/www/templates/diary/trip_list_item.html
+++ b/www/templates/diary/trip_list_item.html
@@ -24,7 +24,9 @@
                 
                 <!-- Distance and Time -->
                 <div class="row" style="padding:4px">
-                    <div class="col-90" style="font-size: 12px; color: #0088ce; text-align: center;"></div> <!-- Just for Spacing of the More Icon, Considering adding text "click for more!" -->
+                    <div class="col-90" style="font-size: 12px; text-align: center;">
+                      <b><u>{{trip.display_date}}</u></b>
+                    </div>
                     <div class="col-10">
                         <i class="ion-ios-more" style="font-size: 30px; color:black" ng-click="showDetail($event, trip)"></i>
                     </div>


### PR DESCRIPTION
infinite_scroll_list.js
- Removing prevTrip, because this was causing issues in the regression https://github.com/e-mission/e-mission-docs/issues/823 and we will replace it with another way to display the date to come

infinite_scroll_list.html
- Commenting out the hr-lines style that displays the trip date above the list of trips

trip_list_item.html
- Displaying the date from within the trip item
- Removed the previous styling that was unnecessary for this div since it previously didn't have any text inside it