### PR TITLE
Initial implementation of item height changes when the replaced mode …

### DIFF
--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -47,7 +47,7 @@
   and (min-device-width: 320px) 
   and (max-device-width: 568px)
   and (-webkit-min-device-pixel-ratio: 2) {
-    .angular-leaflet-map { height: 150px; width: 245px; }
+    .angular-leaflet-map { position: absolute; height: 82.8%; width: 46.8%; }
 }
 
 /* ----------- iPhone 6 ----------- */
@@ -57,7 +57,7 @@
   and (min-device-width: 375px) 
   and (max-device-width: 667px) 
   and (-webkit-min-device-pixel-ratio: 2) { 
-    .angular-leaflet-map { height: 150px; width: 295px; }
+    .angular-leaflet-map { position: absolute; height: 82.8%; width: 46.8%; }
 }
 
 /* ----------- iPhone 6+ ----------- */
@@ -67,7 +67,7 @@
   and (min-device-width: 414px) 
   and (max-device-width: 736px) 
   and (-webkit-min-device-pixel-ratio: 3) { 
-    .angular-leaflet-map { height: 150px; width: 330px; }
+    .angular-leaflet-map { position: absolute; height: 82.8%; width: 46.8%; }
 }
 
 
@@ -208,7 +208,7 @@ a.item-content {
 
 .diary-card {
   width: 100%;
-  height: 330px;
+  height: min-content;
   margin: 0;
   border: 2px solid rgba(0, 136, 206, 0.2);
   box-sizing: border-box;
@@ -330,16 +330,15 @@ a.item-content {
 
 .diary-map {
   float: left;
-  width: 100%;
   z-index: -1; /* Can't zoom in or out of the map with this implemented */
   overflow: hidden;
-  border-radius: 30px 0px 0px 50px;
+  border-radius: 30px 0px 0px 30px;
   /* height must be specified in the html */
 }
 
 .diary-map-shell {
   float: left;
-  width: 50%;
+  width: 100%;
 }
 
 .diary-infos {

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -47,6 +47,14 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
 
   $scope.labelPopulateFactory = $injector.get($scope.surveyOpt.service);
 
+  $scope.getTripHeight = function(trip) {
+    if(trip.INPUTS[2]) {
+      return 460;
+    } else {
+      return 390;
+    }
+  }
+
   $scope.getActiveFilters = function() {
     return $scope.filterInputs.filter(sf => sf.state).map(sf => sf.key);
   }

--- a/www/js/survey/multilabel/multi-label-ui.js
+++ b/www/js/survey/multilabel/multi-label-ui.js
@@ -183,6 +183,22 @@ angular.module('emission.survey.multilabel.buttons',
     closePopover(inputType);
   };
 
+  var getScrollElement = function() {
+    if (!$scope.scrollElement) {
+        console.log("scrollElement is not cached, trying to read it ");
+        const ionItemElement = $element.closest('ion-item')
+        if (ionItemElement) {
+            console.log("ionItemElement is defined, we are in a list, finding the parent scroll");
+            $scope.scrollElement = ionItemElement.closest('ion-content');
+        } else {
+            console.log("ionItemElement is defined, we are in a detail screen, ignoring");
+        }
+    }
+    // TODO: comment this out after testing to avoid log spew
+    console.log("Returning scrollElement ", $scope.scrollElement);
+    return $scope.scrollElement;
+  }
+
   $scope.store = function (inputType, input, isOther) {
     if(isOther) {
       // Let's make the value for user entered inputs look consistent with our
@@ -205,7 +221,12 @@ angular.module('emission.survey.multilabel.buttons',
           tripToUpdate.userInput[inputType].write_ts = Date.now();
         }
         let viewScope = findViewScope();
-       MultiLabelService.updateTripProperties(tripToUpdate, viewScope);  // Redo our inferences, filters, etc. based on this new information
+        MultiLabelService.updateTripProperties(tripToUpdate, viewScope);  // Redo our inferences, filters, etc. based on this new information
+        // KS: this will currently always trigger for a program
+        // we might want to trigger it only if it changed to/from an e-bike
+        // you may also need to experiment with moving this up or down depending on timing
+        const scrollElement = getScrollElement();
+        scrollElement? scrollElement.trigger('scroll-resize') : console.log("not in list, skipping resize");
       });
     });
     if (isOther == true)

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -32,7 +32,7 @@
         </div>
 
 		<ion-list>
-		<div collection-repeat="trip in data.displayTrips">
+		<div collection-repeat="trip in data.displayTrips" item-height="getTripHeight(trip)">
             <div>
                 
                 <!-- <div ng-if='$index==0 || trip.prevTrip.display_date != trip.display_date'>

--- a/www/templates/diary/trip_list_item.html
+++ b/www/templates/diary/trip_list_item.html
@@ -8,19 +8,22 @@
 
         <div class="diary-card">
             <!-- Leaflet Map -->
+            <div style="width: 50%; float: left;">
             <div class="diary-map-shell" ng-click="showDetail($event, trip)">
             <leaflet
             class="diary-map"
             geojson="trip"
             defaults="mapCtrl.defaults"
             id="$index"
-            data-tap-disabled="true"
-            height="342px">
-            
+            data-tap-disabled="true">
+
+
             </leaflet>
             </div>
+            </div>
             <!-- Trip Information -->
-            <div class="diary-infos" style="padding-top: 10px" ng-click="showDetail($event, trip)">
+            <div style="width: 50%; float: right;">
+            <div class="diary-infos" style="padding-top: 10px; width: 100%;" ng-click="showDetail($event, trip)">
                 
                 <!-- Distance and Time -->
                 <div class="row" style="padding:4px">
@@ -64,7 +67,7 @@
 
                     <!-- Row, containing Detail Screen button and Trip Origin/Destination -->
                     <div class="row" style="padding: 4px">
-                        <div class="col-100" style="width: 100%;">
+                        <div class="col-100" style="width: 100%; height: 70px">
                             <!-- Origin for Trip -->
                             <div class="diary-street two-lines" ng-click="showDetail($event, trip)">
                                 <i class="icon ion-location" style="font-size: 16px; left: 0; color: #80D0FF;"></i>
@@ -80,7 +83,8 @@
                     </div>
                 </div>
               </div>
-              <div class="diary-infos" style="padding-top: 10px">
+
+              <div class="diary-infos" style="padding-top: 10px; padding-bottom: 10px; width: 100%;">
                 <!-- Mode and Purpose Selection -->
                 <div class="row" style="margin-top: 0px; padding: 4px">
                     <!-- Assumes that the trip labels have already been
@@ -91,14 +95,13 @@
 
                         <linkedsurvey element-tag="{{surveyOpt.elementTag}}" class="col" trip="trip"></linkedsurvey>
                     </div>
-                    
+
                     <verifycheck linkedtag="{{surveyOpt.elementTag}}" style="padding: 8px" class="col-10 diarycheckmark-container center-vert center-horiz"></verifycheck>
                 </div> 
             </div>
         </div>
-
+        </div>
         <!-- End Time Tag -->
         <div class="stop-time-tag">{{trip.display_end_time}}</div>
     </ion-item>
 </div>
-


### PR DESCRIPTION
…is displayed

Changes by @sebastianbarry

- main.diary.css - Changed the way the map displays, so that it is variable and changes with the height of the trip item - Changed the way the diary card displays as min-content, dynamic, instead of a static hard-coded pixel value

- infinite_scroll_list.js - Added a function that returns a hard-coded pixel height value for the trip item in the template's collection-repeat

- infinite_scroll_list.html - Added the dynamic collection-repeat "item-height" attribute that is calling the function we made in the controller

- trip_list_item.html - Added some styling to the elements so that they display properly with the dynamic height now

Changes by @shankari

- Find the closest ancestor scroll element if present
- Cache it for future use
- Call scroll-resize on it

Testing done:
https://github.com/e-mission/e-mission-docs/issues/831#issuecomment-1316411689

Pending testing:
- test in all locations where we use the linked survey - at least infinite scroll, diary, diary detail and infinite scroll detail - also include others found through a recursive search

Pending improvement:
- only trigger the resize if the original value or the new value is e-bike

Testing done:
Connected via the inspector and verified that the item height changed when the mode was changed to/from e-bike. The distance between items also remained the same, unlike with the prior implementation where the card size changed, but the item size did not, so the gap between items narrowed.