### PR TITLE
Lock down the version of ruby used instead of "the default"

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Print the xcode setup
       run: xcodebuild -version -sdk
 
+    - name: Print the brew and ruby versions
+      run: |
+        echo "brew version is "`brew --version`
+        echo "ruby version is" `ruby --version`
+
     - name: Print applications through dmg
       run: ls /Applications
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Pre-requisites
     ```
 
     </details>
+- if you are not on the most recent version of OSX, `homebrew`
+    - this allows us to install the current version of cocoapods without
+      running into ruby incompatibilities - e.g.
+      https://github.com/CocoaPods/CocoaPods/issues/11763
 
 Important
 ---

--- a/setup/activate_native.sh
+++ b/setup/activate_native.sh
@@ -8,7 +8,6 @@ echo "Verifying $ANDROID_HOME or $ANDROID_SDK_ROOT is set"
 if [ -z $ANDROID_HOME ] && [ -z $ANDROID_SDK_ROOT ];
 then
     echo "ANDROID_HOME and ANDROID_SDK_ROOT not set, android SDK not found"
-    exit 1
 fi
 
 echo "Activating sdkman, and by default, gradle"

--- a/setup/export_shared_dep_versions.sh
+++ b/setup/export_shared_dep_versions.sh
@@ -1,9 +1,14 @@
 export NVM_VERSION=0.39.0
 export NODE_VERSION=14.18.1
 export NPM_VERSION=6.14.15
-export RUBY_VERSION=2.6.0
+# make sure that this is a stable version from
+# so that https://github.com/postmodern/ruby-versions
+# ideally, this would be the same version as the CI
+# Looks like brew supports only major and minor, not patch version
+export RUBY_VERSION=2.7
 export COCOAPODS_VERSION=1.11.2
 export GRADLE_VERSION=7.1.1
+export OSX_EXP_VERSION=12
 
 export NVM_DIR="$HOME/.nvm"
-export RUBY_PATH=$HOME/.gem/ruby/$RUBY_VERSION/bin
+export RUBY_PATH=$HOME/.gem/ruby/$RUBY_VERSION.0/bin

--- a/setup/setup_ios_native.sh
+++ b/setup/setup_ios_native.sh
@@ -4,8 +4,26 @@ set -e
 # Setup the development environment
 source setup/setup_shared.sh
 
-echo "Installing cocoapods"
+# Importing rvm keys
+curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
+
+# Download and install rvm
+echo "Installing stable rvm"
+curl -sSL https://get.rvm.io | bash -s stable
+
+# Enable rvm
+source /Users/kshankar/.rvm/scripts/rvm
+
+# Download and install ruby
+echo "Installing ruby $RUBY_VERSION"
+rvm install ruby-$RUBY_VERSION
+
+echo "Switching to ruby version $RUBY_VERSION"
+rvm use $RUBY_VERSION
+
 export PATH=$RUBY_PATH:$PATH
+echo "Installing cocoapods"
 gem install --no-document --user-install cocoapods -v $COCOAPODS_VERSION
 
 source setup/setup_shared_native.sh


### PR DESCRIPTION
- install rvm, just like we install nvm - this involves importing keys so that the rvm install can be validated
- source the script
- install the desired version of ruby
- use that to install the correct version of cocoapods