### PR TITLE
:construction_worker: Enable the CI for `maint_upgrade_*` branches as…

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,9 +6,13 @@ name: osx-build-android
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
   pull_request:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '5 4 * * 0'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -6,9 +6,13 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: 
+        - master
+        - maint_upgrade_**
   pull_request:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -6,9 +6,13 @@ name: osx-build-ios
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
   pull_request:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '5 4 * * 0'

--- a/.github/workflows/serve-install.yml
+++ b/.github/workflows/serve-install.yml
@@ -6,9 +6,13 @@ name: osx-serve-install
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
   pull_request:
-    branches: [ master ]
+    branches:
+        - master
+        - maint_upgrade_**
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '5 4 * * 0'


### PR DESCRIPTION
… well

So that we can check in our updates in bite-size chunks without having a giant PR that is hard to look into later
This is based on the new workflow cheat sheet
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

And is related to the upgrade issue at
https://github.com/e-mission/e-mission-docs/issues/838