### PR TITLE
Bump up versions of the dev chain and all other plugins

### DIFF
--- a/.github/workflows/android-automated-sdk-install.yml
+++ b/.github/workflows/android-automated-sdk-install.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Install to a new SDK root
       run: |
+        export JAVA_HOME=$JAVA_HOME_11_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         echo "New SDK root $ANDROID_SDK_ROOT"
         printf "Y\nY\nY\nY\nY\n" | bash setup/prereq_android_sdk_install.sh
@@ -47,6 +48,7 @@ jobs:
     - name: Verify that all packages are as expected
       shell: bash -l {0}
       run: |
+        export JAVA_HOME=$JAVA_HOME_11_X64
         echo "Comparing $ANDROID_SDK_ROOT and $NEW_ANDROID_SDK_ROOT"
         $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --list_installed > /tmp/existing_packages
         $NEW_ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --list_installed > /tmp/new_packages
@@ -56,6 +58,7 @@ jobs:
     - name: Verify that directory structure is consistent
       shell: bash -l -x {0}
       run: |
+        export JAVA_HOME=$JAVA_HOME_11_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         echo "New SDK root $ANDROID_SDK_ROOT"
         ls -al $ANDROID_SDK_ROOT

--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -50,6 +50,7 @@
         <preference name="AndroidXEnabled" value="true" />
         <resource-file src="google-services.json" target="app/google-services.json" />
         <hook src="hooks/before_build/android/android_set_provider.js" type="before_build" />
+        <hook src="hooks/before_build/android/android_change_compile_implementation.js" type="before_build" />
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
             <uses-library android:name="org.apache.http.legacy" android:required="false" />
         </config-file>

--- a/hooks/before_build/android/android_change_compile_implementation.js
+++ b/hooks/before_build/android/android_change_compile_implementation.js
@@ -1,0 +1,54 @@
+/*
+ * A hook to change provider in order to match with the application name.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var et = require('elementtree');
+
+const PROVIDER = "edu.berkeley.eecs.emission.provider";
+const ACCOUNT_TYPE = "eecs.berkeley.edu";
+const LOG_NAME = "Changing Providers: ";
+
+var changeCompileToImplementation = function (file) {
+    if (fs.existsSync(file)) {
+        fs.readFile(file, 'utf8', function (err, data) {
+            var result = data.replace("compile", "implementation");
+            fs.writeFile(file, result, 'utf8', function (err) {
+                if (err) throw new Error(LOG_NAME + 'Unable to write into ' + file + ': ' + err);
+                console.log(LOG_NAME + "" + file + " updated...")
+            });
+        });
+    } else {
+        console.error("Could not find file "+file+" skipping compile -> implementation change");
+    }
+}
+
+module.exports = function (context) {
+    // If Android platform is not installed, don't even execute
+    if (!context.opts.platforms.includes('android')) return;
+
+    var config_xml = path.join(context.opts.projectRoot, 'config.xml');
+    var data = fs.readFileSync(config_xml).toString();
+    // If no data then no config.xml
+    if (data) {
+        var etree = et.parse(data);
+        console.log(LOG_NAME + "Retrieving application name...")
+        var applicationName = etree._root.attrib.id;
+        console.info(LOG_NAME + "Your application is " + applicationName);
+        const splitParts = applicationName.split(".")
+        var lastApplicationPart = splitParts[splitParts.length - 1];
+
+        var platformRoot = path.join(context.opts.projectRoot, 'platforms/android/')
+
+        console.log(LOG_NAME + "Updating barcode scanner gradle...");
+        var gradleFile = path.join(platformRoot, 'phonegap-plugin-barcodescanner/'+lastApplicationPart+'-barcodescanner.gradle');
+        changeCompileToImplementation(gradleFile);
+
+        console.log(LOG_NAME + "Updating badge gradle...");
+        var gradleFile = path.join(platformRoot, 'cordova-plugin-badge/'+lastApplicationPart+'-badge.gradle');
+        changeCompileToImplementation(gradleFile);
+    } else {
+        throw new Error(LOG_NAME + "Could not retrieve application name.");
+    }
+}

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -8,9 +8,9 @@
     "url": "git+https://github.com/e-mission/e-mission-phone.git"
   },
   "devDependencies": {
-    "cordova": "10.0.0",
-    "@ionic/cli": "6.12.0",
-    "bower": "1.8.8"
+    "cordova": "11.1.0",
+    "@ionic/cli": "6.20.8",
+    "bower": "1.8.14"
   },
   "cordova": {
     "platforms": [
@@ -19,7 +19,7 @@
     ],
     "plugins": {
       "@havesource/cordova-plugin-push": {
-        "ANDROID_SUPPORT_V13_VERSION": "28.0.0",
+        "ANDROIDX_CORE_VERSION": "1.6.+",
         "FCM_VERSION": "18.+",
         "IOS_FIREBASE_MESSAGING_VERSION": "~> 6.32.2"
       },
@@ -60,13 +60,13 @@
     }
   },
   "dependencies": {
-    "cordova-android": "10.1.0",
+    "cordova-android": "11.0.0",
     "cordova-ios": "6.2.0",
-    "cordova-plugin-advanced-http": "3.2.2",
-    "cordova-plugin-androidx-adapter": "git+https://github.com/dpa99c/cordova-plugin-androidx-adapter.git",
-    "cordova-plugin-app-version": "0.1.12",
+    "cordova-plugin-advanced-http": "3.3.1",
+    "cordova-plugin-androidx-adapter": "1.1.3",
+    "cordova-plugin-app-version": "0.1.14",
     "cordova-plugin-customurlscheme": "5.0.2",
-    "cordova-plugin-device": "2.0.3",
+    "cordova-plugin-device": "2.1.0",
     "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.7.5",
     "cordova-plugin-em-opcodeauth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.7.0",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.5",
@@ -75,15 +75,15 @@
     "cordova-plugin-em-unifiedlogger": "git+https://github.com/e-mission/cordova-unified-logger.git#v1.3.5",
     "cordova-plugin-em-usercache": "git+https://github.com/e-mission/cordova-usercache.git#v1.1.5",
     "cordova-plugin-email-composer": "git+https://github.com/katzer/cordova-plugin-email-composer.git#0.10.1",
-    "cordova-plugin-file": "6.0.2",
+    "cordova-plugin-file": "7.0.0",
     "cordova-plugin-inappbrowser": "5.0.0",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-ionic-webview": "5.0.0",
-    "cordova-plugin-local-notification": "https://github.com/timkellypa/cordova-plugin-local-notifications.git#083ccca0f4eee8fbec0cde1edd32207c286d2a04",
-    "cordova-plugin-x-socialsharing": "6.0.3",
+    "cordova-plugin-local-notification": "https://github.com/levanax/cordova-plugin-local-notifications.git#0362bc731a3f2241acadcc6a0cc63776806e851c",
+    "cordova-plugin-x-socialsharing": "6.0.4",
     "fs-extra": "^9.0.1",
     "klaw-sync": "^6.0.0",
     "phonegap-plugin-barcodescanner": "git+https://github.com/phonegap/phonegap-plugin-barcodescanner#v8.1.0",
-    "@havesource/cordova-plugin-push": "2.0.0"
+    "@havesource/cordova-plugin-push": "3.0.1"
   }
 }

--- a/setup/android_sdk_packages
+++ b/setup/android_sdk_packages
@@ -1,7 +1,6 @@
-build-tools;30.0.1                                    
-build-tools;30.0.2                                    
-build-tools;30.0.3                                    
 build-tools;31.0.0                                    
+build-tools;32.0.0                                    
+build-tools;33.0.2                                    
 emulator                                              
 extras;google;google_play_services                    
 extras;intel;Hardware_Accelerated_Execution_Manager   
@@ -9,6 +8,8 @@ patcher;v4
 platform-tools                                        
 platforms;android-30                                  
 platforms;android-31                                  
+platforms;android-32                                  
+platforms;android-33                                  
 system-images;android-22;google_apis;x86_64           
 system-images;android-23;google_apis;x86_64           
 system-images;android-24;google_apis_playstore;x86    
@@ -16,7 +17,8 @@ system-images;android-25;google_apis_playstore;x86
 system-images;android-26;google_apis_playstore;x86    
 system-images;android-27;google_apis_playstore;x86    
 system-images;android-28;google_apis_playstore;x86_64 
-system-images;android-29;google_apis_playstore;x86    
 system-images;android-29;google_apis_playstore;x86_64 
-system-images;android-30;google_apis_playstore;x86    
 system-images;android-30;google_apis_playstore;x86_64 
+system-images;android-31;google_apis_playstore;x86_64 
+system-images;android-32;google_apis_playstore;x86_64 
+system-images;android-33;google_apis_playstore;x86_64 

--- a/setup/prereq_android_sdk_install.sh
+++ b/setup/prereq_android_sdk_install.sh
@@ -1,4 +1,4 @@
-TOOLS_VERSION=8092744
+TOOLS_VERSION=9477386
 TOOLS_ZIP_FILENAME=commandlinetools-mac-${TOOLS_VERSION}_latest.zip
 
 echo "Installing command line tools from $TOOLS_ZIP_FILENAME"


### PR DESCRIPTION
- android CLI version to the latest
- android sdk packages to the latest
- cordova, ionic and bower to the latest
- all non-OpenPATH plugins to the latest versions

Some of these (`cordova-plugin-badge`/`phonegap-plugin-barcodescanner`) ran into an issue with using `compile` when they actually needed `implementation` for the new gradle.

The badge is a dependency of the local notification plugin, so I migrated from `timkellypa` to `levanax` who has some commits that have fixed it and some other issues. This fixes it for the local notification plugin but not for the `cordova-plugin-badge` which is pulled in as a dependency from elsewere

I fixed that and the barcodescanner by adding a new hook that renames `compile` to `implementation` before build.

Testing done: builds

This is the next step in the upgrade and addresses https://github.com/e-mission/e-mission-docs/issues/838#issuecomment-1465021443