### PR TITLE
Revert the QR code plugin to the one that we used before

### DIFF
--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="50" id="edu.berkeley.eecs.emission" ios-CFBundleVersion="48" version="3.2.7" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="51" id="edu.berkeley.eecs.emission" ios-CFBundleVersion="49" version="3.2.8" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>emission</name>
     <description>
         A commute pattern tracker and carbon footprint estimator.
@@ -42,6 +42,9 @@
         <preference name="WKWebViewOnly" value="true" />
         <preference name="WKSuspendInBackground" value="false" />
         <preference name="AutoHideSplashScreen" value="true" />
+        <config-file parent="NSCameraUsageDescription" target="*-Info.plist" mode="merge">
+            <string>To scan QR codes for the login token and the study</string>
+        </config-file>
     </platform>
     <platform name="android">
         <hook src="hooks/before_build/android/android_copy_locales.js" type="before_build" />
@@ -53,6 +56,7 @@
         <preference name="GradlePluginKotlinVersion" value="1.7.10" />
         <resource-file src="google-services.json" target="app/google-services.json" />
         <hook src="hooks/before_build/android/android_set_provider.js" type="before_build" />
+        <hook src="hooks/before_build/android/android_change_compile_implementation.js" type="before_build" />
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
             <uses-library android:name="org.apache.http.legacy" android:required="false" />
         </config-file>

--- a/hooks/before_build/android/android_change_compile_implementation.js
+++ b/hooks/before_build/android/android_change_compile_implementation.js
@@ -1,0 +1,48 @@
+/*
+ * A hook to change provider in order to match with the application name.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var et = require('elementtree');
+
+const LOG_NAME = "Changing compile to implementation ";
+
+var changeCompileToImplementation = function (file) {
+    if (fs.existsSync(file)) {
+        fs.readFile(file, 'utf8', function (err, data) {
+            var result = data.replace("compile", "implementation");
+            fs.writeFile(file, result, 'utf8', function (err) {
+                if (err) throw new Error(LOG_NAME + 'Unable to write into ' + file + ': ' + err);
+                console.log(LOG_NAME + "" + file + " updated...")
+            });
+        });
+    } else {
+        console.error("Could not find file "+file+" skipping compile -> implementation change");
+    }
+}
+
+module.exports = function (context) {
+    // If Android platform is not installed, don't even execute
+    if (!context.opts.platforms.includes('android')) return;
+
+    var config_xml = path.join(context.opts.projectRoot, 'config.xml');
+    var data = fs.readFileSync(config_xml).toString();
+    // If no data then no config.xml
+    if (data) {
+        var etree = et.parse(data);
+        console.log(LOG_NAME + "Retrieving application name...")
+        var applicationName = etree._root.attrib.id;
+        console.info(LOG_NAME + "Your application is " + applicationName);
+        const splitParts = applicationName.split(".")
+        var lastApplicationPart = splitParts[splitParts.length - 1];
+
+        var platformRoot = path.join(context.opts.projectRoot, 'platforms/android/')
+
+        console.log(LOG_NAME + "Updating barcode scanner gradle...");
+        var gradleFile = path.join(platformRoot, 'phonegap-plugin-barcodescanner/'+lastApplicationPart+'-barcodescanner.gradle');
+        changeCompileToImplementation(gradleFile);
+    } else {
+        throw new Error(LOG_NAME + "Could not retrieve application name.");
+    }
+}

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -1,6 +1,6 @@
 {
   "name": "edu.berkeley.eecs.emission",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "displayName": "emission",
   "license": "BSD-3-Clause",
   "repository": {
@@ -60,7 +60,9 @@
       "cordova-plugin-em-unifiedlogger": {},
       "cordova-plugin-em-usercache": {},
       "cordova-plugin-androidx-adapter": {},
-      "cordova-plugin-barcode-qrscanner": {}
+      "phonegap-plugin-barcodescanner": {
+        "ANDROID_SUPPORT_V4_VERSION": "27.+"
+      }
     }
   },
   "dependencies": {
@@ -87,7 +89,7 @@
     "cordova-plugin-x-socialsharing": "6.0.4",
     "fs-extra": "^9.0.1",
     "klaw-sync": "^6.0.0",
-    "cordova-plugin-barcode-qrscanner": "^3.0.12",
+    "phonegap-plugin-barcodescanner": "git+https://github.com/phonegap/phonegap-plugin-barcodescanner#v8.1.0",
     "@havesource/cordova-plugin-push": "git+https://github.com/havesource/cordova-plugin-push.git#4.0.0-dev.0"
   }
 }


### PR DESCRIPTION
We tried to migrate from `phonegap-plugin-barcodescanner` to the better supported `cordova-plugin-barcode-qrscanner`. However, I was not able to get the new plugin to work. The OS indicated that the app was accessing the camera, but we were not able to see the preview, even after I added a `show` to the code.

https://github.com/e-mission/e-mission-docs/issues/838#issuecomment-1474273170 https://github.com/e-mission/e-mission-docs/issues/838#issuecomment-1474344148

There doesn't seem to be an option to file issues or to communicate with the creator. So let's fall back to the older `phonegap-plugin-barcodescanner` We restore the `android_change_compile_implementation` hook so that we can change the `compile` to `implementation` and get the plugin to compile.

Bonus fix: Add the `NSCameraUsageDescription` via the config.xml so that we don't get a permission issue while running on iOS.

Testing done:
- Builds on both android and iOS
- Scanning launches on both android and iOS
- QR codes are scanned on both android and iOS