### PR TITLE
Display a loading screen while waiting for the prior survey to load

### DIFF
--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -421,6 +421,7 @@
         "button-decline": "Stop"
     },
     "survey": {
+        "loading-prior-survey": "Loading prior survey responses...",
         "prev-survey-found": "Found previous survey response",
         "use-prior-response": "Use prior response",
         "edit-response": "Edit response",

--- a/www/js/survey/enketo/enketo-demographics.js
+++ b/www/js/survey/enketo/enketo-demographics.js
@@ -86,6 +86,7 @@ angular.module('emission.survey.enketo.demographics',
   }
 
   $scope.initForm = function() {
+    $scope.loading = true;
     return EnketoDemographicsService.loadPriorDemographicSurvey().then((lastSurvey) => {
         $scope.$apply(() => $scope.existingSurvey = lastSurvey);
         console.log("ENKETO: existing survey ", $scope.existingSurvey);
@@ -105,6 +106,8 @@ angular.module('emission.survey.enketo.demographics',
                 console.log("demographic survey result ", result);
               }).catch(e => console.trace(e));
         }
+    }).finally(() => {
+        $scope.$apply(() => {$scope.loading = false;});
     });
   };
 
@@ -117,7 +120,7 @@ angular.module('emission.survey.enketo.demographics',
 
   $ionicPlatform.ready(() => $scope.init());
 })
-.factory("EnketoDemographicsService", function(UnifiedDataLoader, $window) {
+.factory("EnketoDemographicsService", function(UnifiedDataLoader, $window, $ionicLoading, $translate) {
   var eds = {};
   console.log("Creating EnketoDemographicsService");
   eds.key = "manual/demographic_survey";
@@ -138,7 +141,7 @@ angular.module('emission.survey.enketo.demographics',
   eds.loadPriorDemographicSurvey = function() {
     const tq = $window.cordova.plugins.BEMUserCache.getAllTimeQuery();
     return UnifiedDataLoader.getUnifiedMessagesForInterval(eds.key, tq)
-        .then(answers => _getMostRecent(answers));
+        .then(answers => _getMostRecent(answers))
   }
 
   return eds;

--- a/www/templates/survey/enketo/inline.html
+++ b/www/templates/survey/enketo/inline.html
@@ -1,5 +1,7 @@
 <ion-content class="enketo-plugin overflow-scroll" translate-namespace="survey">
 
+  <div ng-if="loading" style="font-weight: bold; font-size: 2em;" translate>{{'.loading-prior-survey'}}</div>
+  <div ng-if="!loading">
   <div ng-if="existingSurvey">
     <!-- If there is an existing survey, we want to ask the user whether they want to use it-->
     <div ng-if="editSurveyAnswer === undefined" class="col" style="margin-top: 25%;" translate-namespace="survey">
@@ -29,5 +31,6 @@
   <div ng-if="!existingSurvey">
     <!-- We want to show the survey if we don't have a prior response -->
     <ng-include src="'templates/survey/enketo/form-base.html'"></ng-include>
+  </div>
   </div>
 </ion-content>


### PR DESCRIPTION
- Set and unset a `loading` scope variable
- Display a loading message if the loading variable is set and the survey if not
- Add an internationalizable message indicating that the data is loading

Testing done:
- when the user clicks on the "next" button in the save token quickly, the loading screen is displayed
- when the user takes some time to click on the "next" button, the loading screen is not displayed