### PR TITLE
Fixed positioning issue on Android emulator

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -947,13 +947,13 @@ button.button.back-button.buttons.button-clear.header-item {
   background: #80D0FF;
   color: black;
   top: 0;
-  translate: -50% -50%;
+  transform: translate(-50%, -50%);
 }
 .stop-time-tag {
   background: #0088ce;
   color: white;
   bottom: 0;
-  translate: -50% 50%;
+  transform: translate(-50%, 50%);
 }
 
 .start-time-tag-diarytoremove {


### PR DESCRIPTION
style.css
- "translate: ..." is not a property detected by the old Android webkit, so we will use the classic notation "transform: translate(...)"

Testing: 
| Before | After |
:---:|:---:
| <img width="472" alt="Screen Shot 2023-04-05 at 10 37 21 AM" src="https://user-images.githubusercontent.com/61334340/230154235-6e67d247-bbb0-4a79-9b60-08aa398199c1.png"> | <img width="467" alt="image" src="https://user-images.githubusercontent.com/61334340/230154359-755d8631-6824-48e9-8e50-f68453bf9a98.png"> |

@shankari for visibility