### PR TITLE
Renamed confirmed_place in compositetrip to end_confirmed_place

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -161,8 +161,8 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         Logger.log("Received batch of size "+ctList.length);
         ctList.forEach((ct, i) => {
           
-          if ($scope.showPlaces && ct.confirmed_place) {
-            const cp = ct.confirmed_place;
+          if ($scope.showPlaces && ct.end_confirmed_place) {
+            const cp = ct.end_confirmed_place;
             cp.getNextEntry = () => ctList[i + 1];
             $scope.populateBasicClasses(cp);
             $scope.labelPopulateFactory.populateInputsAndInferences(cp, $scope.data.manualResultMap);
@@ -318,7 +318,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     
     $scope.data.displayTimelineEntries = []
     $scope.data.displayTrips.forEach((cTrip) => {
-      const place = cTrip.confirmed_place;
+      const place = cTrip.end_confirmed_place;
       $scope.data.displayTimelineEntries.push(cTrip);
       if ($scope.showPlaces && place) {
         // Places with duration less than 60 seconds will not be displayed
@@ -432,8 +432,8 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
             $scope.$apply(() => {
                 tripgj.start_display_name = startName;
                 tripgj.end_display_name = endName;
-                if (tripgj.confirmed_place) {
-                  tripgj.confirmed_place.display_name = endName;
+                if (tripgj.end_confirmed_place) {
+                  tripgj.end_confirmed_place.display_name = endName;
                 }
             });
         });

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -446,12 +446,12 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
             return ctList.phone_data.map((ct) => {
               ct.data._id = ct._id["$oid"];
               ct.data.key = ct.metadata.origin_key;
-              if (ct.data.confirmed_place) {
-                const cp_id = ct.data.confirmed_place._id;
-                const cpKey = ct.data.confirmed_place.metadata.key;
-                ct.data.confirmed_place = ct.data.confirmed_place.data;
-                ct.data.confirmed_place._id = cp_id;
-                ct.data.confirmed_place.key = cpKey;
+              if (ct.data.end_confirmed_place) {
+                const cp_id = ct.data.end_confirmed_place._id;
+                const cpKey = ct.data.end_confirmed_place.metadata.key;
+                ct.data.end_confirmed_place = ct.data.end_confirmed_place.data;
+                ct.data.end_confirmed_place._id = cp_id;
+                ct.data.end_confirmed_place.key = cpKey;
               }
               return ct.data;
             });


### PR DESCRIPTION
infinite_scroll_list.js
- renamed every reference to [confirmedTrip].confirmed_place to [confirmedTrip].end_confirmed_place

services.js
- renamed the insertion of confirmed_place to end_confirmed_place

@shankari for visibility. This is the matching e-mission-phone PR to https://github.com/shankari/e-mission-server/pull/10

Testing:

| Here is it being read in from the server | <img width="1633" alt="Screen Shot 2023-04-05 at 12 42 23 PM" src="https://user-images.githubusercontent.com/61334340/230175245-526302d2-9ae4-4452-9121-a380d5dcfbfe.png"> |
:---:|:---:
| Here is it being used in infinite_scroll_list.js | <img width="1624" alt="Screen Shot 2023-04-05 at 12 42 53 PM" src="https://user-images.githubusercontent.com/61334340/230175351-42a9c10c-d0c4-40d0-a7a2-00012665914c.png"> |
| Here is it displaying properly | ![Simulator Screen Shot - iPhone 11 - 2023-04-05 at 12 41 20](https://user-images.githubusercontent.com/61334340/230175430-237cb03f-690a-495c-883d-eef62faaf8e8.png) |

