### PR TITLE
fix zero-duration places showing

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -322,7 +322,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
       $scope.data.displayTimelineEntries.push(cTrip);
       if ($scope.showPlaces && place) {
         // Places with duration less than 60 seconds will not be displayed
-        if (place.duration && place.duration < 60) return; 
+        if (!isNaN(place.duration) && place.duration < 60) return; 
 
         if (!place.display_end_time) {
           // If a place does not have a display_end_time, it is the last place


### PR DESCRIPTION
After any untracked time, a zero-duration place exists. We do not want to show this in the UI. Previously, we checked the existence of `place.duration` and if it was less than 60 seconds. If so, it would skip this place.

However, if `place.duration` exists but is 0, this would also be falsy in Javascript and it wouldn't skip. Instead we'll use `!isNan()` to make sure it is a number before doing the `<` comparison.