### PR TITLE
fix overlapping trip/place cards on android

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -75,17 +75,17 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   }
 
   $scope.getCardHeight = function(entry) {
-    let height = 0;
+    let height = 15; // 15 pixels of padding to account for iOS/Android rendering differences
     if (entry.key == 'analysis/confirmed_place') {
-      height = 178;
+      height += 178;
     } else if (entry.key == 'analysis/cleaned_untracked') {
-      height = 164;
+      height += 164;
     } else if (entry.key == 'analysis/confirmed_trip') {
       // depending on if ENKETO or MULTILABEL is set, or what mode is chosen,
       // we may have 1, 2, or 3 buttons at any given time
       // 242 is the height without any buttons, and each button adds 54 pixels
       const numButtons = entry.INPUTS?.length || 1;
-      height = 242 + (54 * numButtons)
+      height += 242 + (54 * numButtons)
     }
 
     if (entry.additionsList) {


### PR DESCRIPTION
Because of rendering differences between Android and iOS webviews, the hardcoded values here do not necessarily match the exact rendered height. It seems that all UI elements render much bigger on some, but not necessarily all, Android devices (it depends on screen size).

<img src=https://user-images.githubusercontent.com/15843932/230210472-c4664212-1c7d-4fbe-b903-cb31fdfc95f2.png width=300>

Ideally, our UI would be responsive and accommodate for this rather than relying on specific pixel values.
But for right now, I'm just going to leave an extra 15px as a buffer. This is a compromise between A) too close together on some Android and B) too far apart on iOS

<table>
<tr>
<td>
Android after fix:

<img src=https://user-images.githubusercontent.com/15843932/230210784-aa8558c5-48f6-47e9-9e5a-e7844aad83d2.png width=300>

</td>
<td>
iOS after fix:

<img src=https://user-images.githubusercontent.com/15843932/230211335-487b85fb-d7e3-45ee-bb3e-3e080aaecff2.png width=300>

</td>
</td>
</table>
