### PR TITLE
Fix validation error on trip confirm survey

### DIFF
--- a/www/js/survey/enketo/answer.js
+++ b/www/js/survey/enketo/answer.js
@@ -138,6 +138,8 @@ angular.module('emission.survey.enketo.answer', [
    * @param {XMLDocument} xmlDoc survey answer object
    * @param {object} trip trip object
    * @returns {object} object with `start_ts` and `end_ts`
+   *    - null if no timestamps are resolved
+   *    - undefined if the timestamps are invalid
    */
   function resolveTimestamps(xmlDoc, timelineEntry) {
     // check for Date and Time fields

--- a/www/js/survey/enketo/service.js
+++ b/www/js/survey/enketo/service.js
@@ -156,7 +156,7 @@ angular.module('emission.survey.enketo.service', [
       };
       if (_state.opts.timelineEntry) {
         let timestamps = EnketoSurveyAnswer.resolveTimestamps(xmlDoc, _state.opts.timelineEntry);
-        if (timestamps == undefined) {
+        if (timestamps === undefined) {
           // timestamps were resolved, but they are invalid
           return new Error($translate.instant('survey.enketo-timestamps-invalid')); //"Timestamps are invalid. Please ensure that the start time is before the end time.");
         }


### PR DESCRIPTION
The Trip Confirm survey does not have Start Time and End Time. Thus, no timestamps are resolved from it. `resolveTimestamps()` returns `null`.

The issue was in `service.js`.
We should check strict equality here with `===`, not loose equality with `==`. We need to distinguish `null` and `undefined`, but in Javascript, `null == undefined` is `true`.

Also added a bit to the annotation to clarify the expected return value from `resolveTimestamps()`