### PR TITLE
Replace finally with try + catch

### DIFF
--- a/www/js/survey/enketo/enketo-demographics.js
+++ b/www/js/survey/enketo/enketo-demographics.js
@@ -88,7 +88,7 @@ angular.module('emission.survey.enketo.demographics',
   $scope.initForm = function() {
     $scope.loading = true;
     return EnketoDemographicsService.loadPriorDemographicSurvey().then((lastSurvey) => {
-        $scope.$apply(() => $scope.existingSurvey = lastSurvey);
+        $scope.$apply(() => { $scope.loading = false; $scope.existingSurvey = lastSurvey});
         console.log("ENKETO: existing survey ", $scope.existingSurvey);
         if (!$scope.existingSurvey) {
             /*
@@ -106,7 +106,7 @@ angular.module('emission.survey.enketo.demographics',
                 console.log("demographic survey result ", result);
               }).catch(e => console.trace(e));
         }
-    }).finally(() => {
+    }).catch(() => {
         $scope.$apply(() => {$scope.loading = false;});
     });
   };


### PR DESCRIPTION
Using finally with a promise that returns a value does not work

This fixes https://github.com/e-mission/e-mission-docs/issues/876#issuecomment-1502459998 After hours of fiddling around and stepping through the `prefilledSurveyResponse`, and checkout out an old value and commenting out the changes between working and non-working one by one, I found that the error was that I had a `finally` in a promise which returned a value.

Replacing the `finally` with duplicate code in the then and in a new catch works beautifully.

Testing done:
- Logged in as user without a survey; blank survey is loaded
- Logged in as user with an existing survey; the loading page is shown and then the existing survey