### PR TITLE
Fix untracked time displays

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -78,7 +78,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     let height = 15; // 15 pixels of padding to account for iOS/Android rendering differences
     if (entry.key == 'analysis/confirmed_place') {
       height += 178;
-    } else if (entry.key == 'analysis/cleaned_untracked') {
+    } else if (entry.key == 'analysis/confirmed_untracked') {
       height += 164;
     } else if (entry.key == 'analysis/confirmed_trip') {
       // depending on if ENKETO or MULTILABEL is set, or what mode is chosen,

--- a/www/templates/diary/untracked_time_list_item.html
+++ b/www/templates/diary/untracked_time_list_item.html
@@ -20,6 +20,7 @@
                     </div>
                 </div>
             </div>
+            <enketo-notes-list ng-if="triplike.additionsList.length" timeline-entry="triplike" addition-entries="triplike.additionsList"></enketo-notes-list>
             <div class="stop-time-tag">{{triplike.display_end_time}}</div>
         </div>
     </ion-item>


### PR DESCRIPTION
- Change the key in item height determination from cleaned untracked to confirmed untracked to be consistent with https://github.com/e-mission/e-mission-server/pull/13/commits/157e6f9e9dd83204b1eb32963c4b1a9fb813cee7
- Added notes list to untracked time as well, displaying `triplike.additionsList`