### PR TITLE
Process start_places and remove copies

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -160,7 +160,13 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     Timeline.readAllCompositeTrips(currEnd, ONE_WEEK).then((ctList) => {
         Logger.log("Received batch of size "+ctList.length);
         ctList.forEach((ct, i) => {
-          
+          if ($scope.showPlaces && ct.start_confirmed_place) {
+            const cp = ct.start_confirmed_place;
+            cp.getNextEntry = () => ctList[i];
+            $scope.populateBasicClasses(cp);
+            $scope.labelPopulateFactory.populateInputsAndInferences(cp, $scope.data.manualResultMap);
+            $scope.enbs.populateInputsAndInferences(cp, $scope.data.enbsResultMap);
+          }
           if ($scope.showPlaces && ct.end_confirmed_place) {
             const cp = ct.end_confirmed_place;
             cp.getNextEntry = () => ctList[i + 1];
@@ -318,18 +324,36 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     
     $scope.data.displayTimelineEntries = []
     $scope.data.displayTrips.forEach((cTrip) => {
-      const place = cTrip.end_confirmed_place;
-      $scope.data.displayTimelineEntries.push(cTrip);
-      if ($scope.showPlaces && place) {
+      const start_place = cTrip.start_confirmed_place;
+      const end_place = cTrip.end_confirmed_place;
+      
+      // Add start place to the list
+      if ($scope.showPlaces && start_place && $scope.data.displayTimelineEntries.length == 0 || $scope.showPlaces && start_place && $scope.data.displayTimelineEntries[$scope.data.displayTimelineEntries.length - 1]._id.$oid != start_place._id.$oid) {
         // Places with duration less than 60 seconds will not be displayed
-        if (!isNaN(place.duration) && place.duration < 60) return; 
+        if (!isNaN(start_place.duration) && start_place.duration < 60) return; 
 
-        if (!place.display_end_time) {
-          // If a place does not have a display_end_time, it is the last place
-          // We will set display_end_time to the end of the day
-          place.display_end_time = moment(place.enter_fmt_time).parseZone().endOf('day').format("h:mm A");
+        if (!start_place.display_start_time) {
+          // If a start place does not have a display_start_time, it is the first place
+          // We will set display_start_time to the beginning of the day
+          start_place.display_start_time = moment(start_place.exit_fmt_time).parseZone().startOf('day').format("h:mm A");
         }
-        $scope.data.displayTimelineEntries.push(place);
+        $scope.data.displayTimelineEntries.push(start_place);
+      }
+      
+      // Add trip to the list
+      $scope.data.displayTimelineEntries.push(cTrip);
+
+      // Add end place to the list
+      if ($scope.showPlaces && end_place) {
+        // Places with duration less than 60 seconds will not be displayed
+        if (!isNaN(end_place.duration) && end_place.duration < 60) return; 
+
+        if (!end_place.display_end_time) {
+          // If an end place does not have a display_end_time, it is the last place
+          // We will set display_end_time to the end of the day
+          end_place.display_end_time = moment(end_place.enter_fmt_time).parseZone().endOf('day').format("h:mm A");
+        }
+        $scope.data.displayTimelineEntries.push(end_place);
       }
     });
   }
@@ -402,8 +426,12 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     }
 
     $scope.populateBasicClasses = function(tripgj) {
-        tripgj.display_start_time = DiaryHelper.getLocalTimeString(tripgj.start_local_dt || tripgj.enter_local_dt);
-        tripgj.display_date = moment((tripgj.start_ts || tripgj.enter_ts) * 1000).format('ddd DD MMM YYYY');
+        if (tripgj.start_local_dt || tripgj.enter_local_dt) {
+          tripgj.display_start_time = DiaryHelper.getLocalTimeString(tripgj.start_local_dt || tripgj.enter_local_dt);
+        } else if (tripgj.end_local_dt || tripgj.exit_local_dt) {
+          tripgj.display_end_time = DiaryHelper.getLocalTimeString(tripgj.end_local_dt || tripgj.exit_local_dt);
+        }
+        tripgj.display_date = moment((tripgj.start_ts || tripgj.enter_ts || tripgj.end_ts || tripgj.exit_ts) * 1000).format('ddd DD MMM YYYY');
         if (tripgj.end_ts || tripgj.exit_ts) {
           tripgj.display_end_time = DiaryHelper.getLocalTimeString(tripgj.end_local_dt || tripgj.exit_local_dt);
           tripgj.display_time = DiaryHelper.getFormattedTimeRange(
@@ -430,6 +458,9 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         ];
         Promise.all(fillPromises).then(function([startName, endName]) {
             $scope.$apply(() => {
+                if (tripgj.start_confirmed_place) {
+                  tripgj.start_confirmed_place.display_name = startName;
+                }
                 tripgj.start_display_name = startName;
                 tripgj.end_display_name = endName;
                 if (tripgj.end_confirmed_place) {

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -446,12 +446,29 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
             return ctList.phone_data.map((ct) => {
               ct.data._id = ct._id["$oid"];
               ct.data.key = ct.metadata.origin_key;
+              if (ct.data.start_confirmed_place) {
+                const cp_id = ct.data.start_confirmed_place._id;
+                const cpKey = ct.data.start_confirmed_place.metadata.key;
+                ct.data.start_confirmed_place = ct.data.start_confirmed_place.data;
+                ct.data.start_confirmed_place._id = cp_id;
+                ct.data.start_confirmed_place.key = cpKey;
+                if (!ct.data.start_confirmed_place.enter_ts) {
+                  ct.data.start_confirmed_place.enter_ts = moment(ct.data.start_confirmed_place.exit_fmt_time).parseZone().startOf('day').unix()
+                  ct.data.start_confirmed_place.enter_fmt_time = moment(ct.data.start_confirmed_place.exit_fmt_time).parseZone().startOf('day').format()
+                  ct.data.start_confirmed_place.enter_local_dt = moment2localdate(moment.unix(ct.data.start_confirmed_place.enter_ts).tz(ct.metadata.time_zone), ct.metadata.time_zone)
+                }
+              }
               if (ct.data.end_confirmed_place) {
                 const cp_id = ct.data.end_confirmed_place._id;
                 const cpKey = ct.data.end_confirmed_place.metadata.key;
                 ct.data.end_confirmed_place = ct.data.end_confirmed_place.data;
                 ct.data.end_confirmed_place._id = cp_id;
                 ct.data.end_confirmed_place.key = cpKey;
+                if (!ct.data.end_confirmed_place.exit_ts) {
+                  ct.data.end_confirmed_place.exit_ts = moment(ct.data.end_confirmed_place.enter_fmt_time).parseZone().endOf('day').unix()
+                  ct.data.end_confirmed_place.exit_fmt_time = moment(ct.data.end_confirmed_place.enter_fmt_time).parseZone().endOf('day').format()
+                  ct.data.end_confirmed_place.exit_local_dt = moment2localdate(moment.unix(ct.data.end_confirmed_place.exit_ts).tz(ct.metadata.time_zone), ct.metadata.time_zone)
+                }
               }
               return ct.data;
             });

--- a/www/js/survey/enketo/enketo-notes-list.js
+++ b/www/js/survey/enketo/enketo-notes-list.js
@@ -34,7 +34,9 @@ angular.module('emission.survey.enketo.notes-list',
 
     $scope.setDisplayTime = function(entry) {
       const timezone = $scope.timelineEntry.start_local_dt?.timezone
-                      || $scope.timelineEntry.enter_local_dt?.timezone;
+                      || $scope.timelineEntry.enter_local_dt?.timezone
+                      || $scope.timelineEntry.end_local_dt?.timezone
+                      || $scope.timelineEntry.exit_local_dt?.timezone;
       const beginTs = entry.data.start_ts || entry.data.enter_ts;
       const stopTs = entry.data.end_ts || entry.data.exit_ts;
       const begin = moment.parseZone(beginTs*1000).tz(timezone).format("h:mm A");


### PR DESCRIPTION
infinite_scroll_list.js
- Added a processing to populateBasicClasses for the start_confirmed_places like how we do with end_confirmed_place for readAllCompositeTrips
- Split the end_confirmed_place processing to add in the display_end_time and other things to process the same for both end_confirmed_place and start_confirmed_place for recomputeDisplayTimelineEntries
- Added end_ts and exit_ts checks for the start_confirmed_place in populateBasicClasses
- Added fillPlacesForTripAsync section for start_confirmed_place

services.js
- Added in a section to fill in the data for ct.data.start_confirmed_place like how we do with end_confirmed_place
- Added a new section at the end of both start_ and end_confirmed_place to add in exit_ts/enter_ts, enter_fmt_time, and enter_local_dt like how all the other places have when they come in at this point

enketo-notes-list.js
- Added in a section to check both end_local_dt and exit_local_dt in case of the first start_confirmed_place