### PR TITLE
:bug: [backwards compat] Adds default survey info if it doesn't exist

### DIFF
--- a/www/js/config/dynamic_config.js
+++ b/www/js/config/dynamic_config.js
@@ -54,6 +54,7 @@ angular.module('emission.config.dynamic', ['emission.plugin.logger'])
             const parsedConfig = result.data;
             const connectionURL = parsedConfig.server? parsedConfig.server.connectUrl : "dev defaults";
             _fillStudyName(parsedConfig);
+            _backwardsCompatSurveyFill(parsedConfig);
             Logger.log("Successfully downloaded config with version "+parsedConfig.version
                 +" for "+parsedConfig.intro.translated_text.en.deployment_name
                 +" and data collection URL "+connectionURL);
@@ -71,6 +72,7 @@ angular.module('emission.config.dynamic', ['emission.plugin.logger'])
                 } else {
                     Logger.log("Found previously stored ui config, returning it");
                     _fillStudyName(savedConfig);
+                    _backwardsCompatSurveyFill(savedConfig);
                     return savedConfig;
                 }
             })
@@ -138,6 +140,26 @@ angular.module('emission.config.dynamic', ['emission.plugin.logger'])
                 config.name = _getStudyName(config.server.connectUrl);
             } else {
                 config.name = "dev";
+            }
+        }
+    }
+
+    const _backwardsCompatSurveyFill = function(config) {
+        if (!config.survey_info) {
+            config.survey_info = {
+              "surveys": {
+                "UserProfileSurvey": {
+                  "formPath": "json/demo-survey-v2.json",
+                  "version": 1,
+                  "compatibleWith": 1,
+                  "dataKey": "manual/demographic_survey",
+                  "labelTemplate": {
+                    "en": "Answered",
+                    "es": "Contestada"
+                  }
+                }
+              },
+              "trip-labels": "MULTILABEL"
             }
         }
     }


### PR DESCRIPTION
The default survey info is MULTILABEL, with the default demographic survey of `json/demo-survey-v2.json`

We fill it in if it doesn't exist, both while loading data from the server and from local storage. So we will fix this in both cases:
- if users join a study that doesn't have the survey config
- if users joined a study when it had a survey config, and have updated the app

This fixes https://github.com/e-mission/e-mission-docs/issues/895

Testing done:
- joined the NREL commute study, which doesn't have the study config
- before this change, was able to reproduce the error
- after this change, was not able to reproduce the error - got a 500 error from the server because it has not yet been upgraded
- before this change, was not able to load the demographic survey
- after this change, was able to load the demographic survey - although for my token, got an error because the survey was changed after I filled it out ``` (anonymous function) — enketo-bundle.js:21554 (anonymous function) — enketo-bundle.js:21293 (anonymous function) — enketo-bundle.js:49382 _loadForm — service.js:85 showModal — service.js:225 promiseReactionJob ``` - worked for another token