### PR TITLE
Support overnight activities

### DIFF
--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -224,12 +224,13 @@ a.item-content {
 /* used for untracked time list items */
 .diary-card.greyed {
   color: #333;
-  background: hsl(0 30% 97%);
+  background: hsl(0 30% 96%);
 }
 
 .diary-card.greyed .card-title b {
+  font-size: 13px;
   color: #222;
-  padding: 5px 10px;
+  padding: 0 4px;
   background-color: #ffbbbb;
   border-radius: 5px;
 }
@@ -245,6 +246,13 @@ a.item-content {
   margin-left: 10px;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.card-date {
+  display: block;
+  white-space: break-spaces;
+  line-height: 1.25;
+  text-decoration: underline;
 }
 
 .diary-button {
@@ -493,24 +501,34 @@ enketo-notes-list, .notes-list {
 }
 
 .notes-list {
-  padding: 0 10px 5px 15px;
+  padding: 0 12px 5px 12px;
   text-align: center;
 }
 
 .notes-list-entry {
   display: grid;
-  grid-template-columns: 10fr 9fr 1fr;
+  grid-template-columns: 9fr 5fr 1fr;
+  gap: 5px;
   align-items: center;
   overflow: hidden;
-  font-size: 13px;
+  font-size: 12px;
   height: 40px;
 }
 
+/* the trash can should appear a bit larger */
 .notes-list-entry .icon {
-  font-size: 24px;
+  font-size: 22px;
 }
 
 /* the note's label will be left-aligned */
 .notes-list-entry b {
   text-align: left;
+  margin-left: 5px;
+}
+
+.notes-list-entry p {
+  font-size: inherit;
+  color: inherit;
+  margin: 0;
+  line-height: 1.2;
 }

--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -360,6 +360,7 @@ a.item-content {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   white-space: normal;
+  overflow: hidden;
 }
 .btn-input-wrap {
   white-space: normal;
@@ -505,28 +506,31 @@ enketo-notes-list, .notes-list {
   text-align: center;
 }
 
-.notes-list-entry {
+.notes-list-grid {
   display: grid;
   grid-template-columns: auto auto min-content;
-  gap: 8px;
+  grid-auto-rows: 40px;
   align-items: center;
-  overflow: hidden;
+  gap: 0 8px;
   font-size: 12px;
-  height: 40px;
+}
+
+.notes-list-grid > li {
+  display: contents;
 }
 
 /* the trash can should appear a bit larger */
-.notes-list-entry .icon {
+.notes-list-grid .icon {
   font-size: 22px;
 }
 
 /* the note's label will be left-aligned */
-.notes-list-entry b {
+.notes-list-grid b {
   text-align: left;
   margin-left: 5px;
 }
 
-.notes-list-entry p {
+.notes-list-grid p {
   font-size: inherit;
   color: inherit;
   margin: 0;

--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -507,8 +507,8 @@ enketo-notes-list, .notes-list {
 
 .notes-list-entry {
   display: grid;
-  grid-template-columns: 9fr 5fr 1fr;
-  gap: 5px;
+  grid-template-columns: auto auto min-content;
+  gap: 8px;
   align-items: center;
   overflow: hidden;
   font-size: 12px;

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -942,6 +942,10 @@ button.button.back-button.buttons.button-clear.header-item {
   font-size: 13px;
   box-shadow: 0 1px 2px rgb(0 0 0 / .1), 0 2px 4px rgb(0 0 0 / .2);
   z-index: 999;
+  white-space: pre-line;
+}
+.start-time-tag:empty, .stop-time-tag:empty {
+  display: none;
 }
 .start-time-tag {
   background: #80D0FF;
@@ -1903,4 +1907,15 @@ span.rz-bar-wrapper {
     height: 100%;
     -webkit-overflow-scrolling: touch !important;
     overflow: scroll !important;
+}
+
+.enketo-plugin input[name*="_date"],
+.enketo-plugin input[name*="_time"] {
+  display: flex !important;
+  max-width: 85%;
+}
+
+.enketo-plugin .question.inline-datetime {
+  display: inline-grid;
+  width: 50%;
 }

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -78,9 +78,9 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   $scope.getCardHeight = function(entry) {
     let height = 15; // 15 pixels of padding to account for iOS/Android rendering differences
     if (entry.key == 'analysis/confirmed_place') {
-      height += 178;
+      height += 174;
     } else if (entry.key == 'analysis/confirmed_untracked') {
-      height += 164;
+      height += 174;
     } else if (entry.key == 'analysis/confirmed_trip') {
       // depending on if ENKETO or MULTILABEL is set, or what mode is chosen,
       // we may have 1, 2, or 3 buttons at any given time

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -325,17 +325,19 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
       const start_place = cTrip.start_confirmed_place;
       const end_place = cTrip.end_confirmed_place;
 
-      // Add start place to the list
-      if ($scope.showPlaces && start_place && ($scope.data.displayTimelineEntries.length == 0 || $scope.data.displayTimelineEntries[$scope.data.displayTimelineEntries.length - 1]._id.$oid != start_place._id.$oid)) {
-        // Places with duration less than 60 seconds will not be displayed
-        if (!isNaN(start_place.duration) && start_place.duration < 60) return; 
+      // Add start place to the list, if not already present
+      let isInList = $scope.data.displayTimelineEntries.find(e => e._id.$oid == start_place._id.$oid);
+      if ($scope.showPlaces && start_place && !isInList) {
+        // Only display places with duration >= 60 seconds, or with no duration (i.e. currently ongoing)
+        if (isNaN(start_place.duration) || start_place.duration >= 60) {
+          $scope.data.displayTimelineEntries.push(start_place);
+        }
 
-        if (!start_place.display_start_time) {
+        // if (!start_place.display_start_time) {
           // If a start place does not have a display_start_time, it is the first place
           // We will set display_start_time to the beginning of the day
-          start_place.display_start_time = moment(start_place.exit_fmt_time).parseZone().startOf('day').format("h:mm A");
-        }
-        $scope.data.displayTimelineEntries.push(start_place);
+          // start_place.display_start_time = moment(start_place.exit_fmt_time).parseZone().startOf('day').format("h:mm A");
+        // }
       }
 
       // Add trip to the list
@@ -343,15 +345,16 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
 
       // Add end place to the list
       if ($scope.showPlaces && end_place) {
-        // Places with duration less than 60 seconds will not be displayed
-        if (!isNaN(end_place.duration) && end_place.duration < 60) return;
+        // Only display places with duration >= 60 seconds, or with no duration (i.e. currently ongoing)
+        if (isNaN(end_place.duration) && end_place.duration >= 60) {
+            $scope.data.displayTimelineEntries.push(end_place);
+        }
 
-        if (!end_place.display_end_time) {
+        // if (!end_place.display_end_time) {
           // If an end place does not have a display_end_time, it is the last place
           // We will set display_end_time to the end of the day
-          end_place.display_end_time = moment(end_place.enter_fmt_time).parseZone().endOf('day').format("h:mm A");
-        }
-        $scope.data.displayTimelineEntries.push(end_place);
+          // end_place.display_end_time = moment(end_place.enter_fmt_time).parseZone().endOf('day').format("h:mm A");
+        // }
       }
     });
   }

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -427,16 +427,16 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     }
 
     $scope.populateBasicClasses = function(tripgj) {
-        if (tripgj.start_ts || tripgj.enter_ts) {
-          tripgj.display_start_time = DiaryHelper.getLocalTimeString(tripgj.start_local_dt || tripgj.enter_local_dt);
-        }
-        tripgj.display_date = moment((tripgj.start_ts || tripgj.enter_ts || tripgj.end_ts || tripgj.exit_ts) * 1000).format('ddd DD MMM YYYY');
-        if (tripgj.end_ts || tripgj.exit_ts) {
-          tripgj.display_end_time = DiaryHelper.getLocalTimeString(tripgj.end_local_dt || tripgj.exit_local_dt);
-          tripgj.display_time = DiaryHelper.getFormattedTimeRange(
-                                  (tripgj.start_ts || tripgj.enter_ts),
-                                  (tripgj.end_ts || tripgj.exit_ts));
-        }
+        const beginTs = tripgj.start_ts || tripgj.enter_ts;
+        const endTs = tripgj.end_ts || tripgj.exit_ts;
+        const beginDt = tripgj.start_local_dt || tripgj.enter_local_dt;
+        const endDt = tripgj.end_local_dt || tripgj.exit_local_dt;
+        const isMultiDay = DiaryHelper.isMultiDay(beginTs, endTs);
+        tripgj.display_date = DiaryHelper.getFormattedDate(beginTs, endTs, isMultiDay);
+        tripgj.display_start_time = DiaryHelper.getLocalTimeString(beginDt, isMultiDay);
+        tripgj.display_end_time = DiaryHelper.getLocalTimeString(endDt, isMultiDay);
+        tripgj.display_duration = DiaryHelper.getFormattedDuration(beginTs, endTs);
+        tripgj.display_time = DiaryHelper.getFormattedTimeRange(beginTs, endTs);
         if (tripgj.distance) {
           tripgj.display_distance = ImperialConfig.getFormattedDistance(tripgj.distance);
           tripgj.display_distance_suffix = ImperialConfig.getDistanceSuffix;

--- a/www/js/plugin/logger.js
+++ b/www/js/plugin/logger.js
@@ -11,7 +11,7 @@ angular.module('emission.plugin.logger', [])
         display_msg = JSON.stringify(error);
       }
       // Check for OPcode DNE errors and prepend the title with "Invalid OPcode"
-      if (error.includes("403")) {
+      if (error.message.includes("403")) {
         title = "Invalid OPcode: " + title;
       }
       $ionicPopup.alert({"title": title, "template": display_msg});

--- a/www/js/plugin/logger.js
+++ b/www/js/plugin/logger.js
@@ -11,7 +11,7 @@ angular.module('emission.plugin.logger', [])
         display_msg = JSON.stringify(error);
       }
       // Check for OPcode DNE errors and prepend the title with "Invalid OPcode"
-      if (error.message.includes("403")) {
+      if (error.includes?.("403") || error.message?.includes?.("403")) {
         title = "Invalid OPcode: " + title;
       }
       $ionicPopup.alert({"title": title, "template": display_msg});

--- a/www/js/survey/enketo/answer.js
+++ b/www/js/survey/enketo/answer.js
@@ -64,7 +64,7 @@ angular.module('emission.survey.enketo.answer', [
         }
 
         const label = $translateMessageFormatInterpolation.interpolate(labelTemplate, labelVars);
-        return label;
+        return label.replace(/^[ ,]+|[ ,]+$/g, ''); // trim leading and trailing spaces and commas
       })
     }
   };
@@ -143,14 +143,16 @@ angular.module('emission.survey.enketo.answer', [
    */
   function resolveTimestamps(xmlDoc, timelineEntry) {
     // check for Date and Time fields
-    const date = xmlDoc.getElementsByTagName('Date')?.[0]?.innerHTML;
-    const start = xmlDoc.getElementsByTagName('Start_time')?.[0]?.innerHTML;
-    const end = xmlDoc.getElementsByTagName('End_time')?.[0]?.innerHTML;
+    const startDate = xmlDoc.getElementsByTagName('Start_date')?.[0]?.innerHTML;
+    const startTime = xmlDoc.getElementsByTagName('Start_time')?.[0]?.innerHTML;
+    const endDate = xmlDoc.getElementsByTagName('End_date')?.[0]?.innerHTML;
+    const endTime = xmlDoc.getElementsByTagName('End_time')?.[0]?.innerHTML;
 
-    if (!date || !start || !end) return null; // if any of the fields are missing, return null
+    // if any of the fields are missing, return null
+    if (!startDate || !startTime || !endDate || !endTime) return null; 
 
-    let additionStartTs = moment(date + 'T' + start).unix();
-    let additionEndTs = moment(date + 'T' + end).unix();
+    let additionStartTs = moment(startDate + 'T' + startTime).unix();
+    let additionEndTs = moment(endDate + 'T' + endTime).unix();
 
     if (additionStartTs > additionEndTs) {
       return undefined; // if the start time is after the end time, this is an invalid response

--- a/www/js/survey/enketo/enketo-add-note-button.js
+++ b/www/js/survey/enketo/enketo-add-note-button.js
@@ -57,8 +57,10 @@ angular.module('emission.survey.enketo.add-note-button',
     }
 
     return {
-      "Date": momentBegin.format('YYYY-MM-DD'),
+      // Enketo requires these specific date/time formats
+      "Start_date": momentBegin.format('YYYY-MM-DD'),
       "Start_time": momentBegin.format('HH:mm:ss.SSSZ'),
+      "End_date": momentStop.format('YYYY-MM-DD'),
       "End_time": momentStop.format('HH:mm:ss.SSSZ')
     }
   }

--- a/www/js/survey/enketo/enketo-notes-list.js
+++ b/www/js/survey/enketo/enketo-notes-list.js
@@ -19,7 +19,8 @@ angular.module('emission.survey.enketo.notes-list',
     };
   })
 
-  .controller("NotesListCtrl", function ($scope, $state, $element, $window, EnketoSurveyLaunch, $ionicPopup) {
+  .controller("NotesListCtrl", function ($scope, $state, $element, $window, $ionicPopup,
+                                EnketoSurveyLaunch, DiaryHelper) {
     console.log("Notes List Controller called");
 
     const getScrollElement = function() {
@@ -32,16 +33,23 @@ angular.module('emission.survey.enketo.notes-list',
       return $scope.scrollElement;
     }
 
-    $scope.setDisplayTime = function(entry) {
+    $scope.setDisplayDt = function(entry) {
       const timezone = $scope.timelineEntry.start_local_dt?.timezone
                       || $scope.timelineEntry.enter_local_dt?.timezone
                       || $scope.timelineEntry.end_local_dt?.timezone
                       || $scope.timelineEntry.exit_local_dt?.timezone;
       const beginTs = entry.data.start_ts || entry.data.enter_ts;
       const stopTs = entry.data.end_ts || entry.data.exit_ts;
-      const begin = moment.parseZone(beginTs*1000).tz(timezone).format("h:mm A");
-      const stop = moment.parseZone(stopTs*1000).tz(timezone).format("h:mm A");
-      return entry.displayTime = begin + " - " + stop;
+      let d;
+      if (DiaryHelper.isMultiDay(beginTs, stopTs)) {
+        d = `${moment.parseZone(beginTs*1000).tz(timezone).format('MMM D')} - ${moment.parseZone(stopTs*1000).tz(timezone).format('MMM D')}`
+      }
+      const begin = moment.parseZone(beginTs*1000).tz(timezone).format('LT');
+      const stop = moment.parseZone(stopTs*1000).tz(timezone).format('LT');
+      return entry.displayDt = {
+        date: d,
+        time: begin + " - " + stop
+      }
     }
 
     $scope.confirmDeleteEntry = (entry) => {

--- a/www/js/survey/enketo/launch.js
+++ b/www/js/survey/enketo/launch.js
@@ -72,6 +72,22 @@ angular.module('emission.survey.enketo.launch', [
       if (loadErrors.length > 0) {
         $ionicPopup.alert({template: "loadErrors: " + loadErrors.join(",")});
       }
+
+      // if the survey has any date or time questions, we will show them side-by-side
+      let firstDate;
+      $(".question").each((i, e) => {    
+        const date = $(e).find('input[name*="_date"]')?.get(0);
+        const time = $(e).find('input[name*="_time"]')?.get(0);
+        if (date || time) {
+          $(e).addClass('inline-datetime')
+        }
+        if (!firstDate && date) {
+          firstDate = [date, $(e)];
+        } else if (firstDate && firstDate[0].value == date?.value) {
+          $(e).hide();
+          firstDate[1].hide();
+        }
+      });
     });
   }
 

--- a/www/templates/diary/place_list_item.html
+++ b/www/templates/diary/place_list_item.html
@@ -1,11 +1,11 @@
 <div ng-if="configPlaceNotes">
     <!-- Place Item Template  -->
     <ion-item class="unified-diary-item" style="background-color: transparent;" class="list-item">
-        <div class="diary-card short" style="padding-block: 5px;">
+        <div class="diary-card short" style="padding-block: 12px">
             <div class="start-time-tag">{{place.display_start_time}}</div>
-            <div style="width: 100%; margin: auto; padding-block: 5px">
+            <div style="width: 100%; margin: auto">
                 <div class="row" style="font-size: 12px; place-content: center; padding: 8px">
-                    <b><u>{{place.display_date}}</u></b>
+                    <b class="card-date">{{place.display_date}}</b>
                 </div>
                 <div class="card-title">
                     <!-- Place (Destination of Prev. Trip) -->

--- a/www/templates/diary/trip_list_item.html
+++ b/www/templates/diary/trip_list_item.html
@@ -23,7 +23,7 @@
                     <!-- Distance and Time -->
                     <div class="row" style="padding:4px">
                         <div class="col-90" style="font-size: 12px; text-align: center;">
-                        <b><u>{{trip.display_date}}</u></b>
+                        <b class="card-date">{{trip.display_date}}</b>
                         </div>
                         <div class="col-10">
                             <i class="ion-ios-more" style="font-size: 30px; color:black" ng-click="showDetail($event, trip)"></i>

--- a/www/templates/diary/untracked_time_list_item.html
+++ b/www/templates/diary/untracked_time_list_item.html
@@ -1,15 +1,18 @@
 <div>
     <ion-item class="unified-diary-item" style="background-color: transparent;" class="list-item">
-        <div class="diary-card short greyed" style="padding-top: 15px;">
+        <div class="diary-card short greyed" style="padding-block: 12px">
             <div class="start-time-tag">{{triplike.display_start_time}}</div>
-            <div style="width: 100%; margin: auto; padding-block: 5px">
+            <div style="width: 100%; margin: auto">
+                <div class="row" style="font-size: 12px; place-content: center; padding: 8px">
+                    <b class="card-date">{{triplike.display_date}}</b>
+                </div>
                 <div class="card-title">
                     <b translate=".untracked-time-range"
                         translate-value-start="{{ triplike.display_start_time }}"
                         translate-value-end=" {{ triplike.display_end_time }}">
                     </b>
                 </div>
-                <div style="margin: 10px">
+                <div style="margin: 5px">
                     <div class="diary-street two-lines" ng-click="showDetail($event, trip)">
                         <i class="icon ion-location" style="font-size: 16px; left: 0; color: #80D0FF;"></i>
                         {{triplike.start_display_name}}

--- a/www/templates/survey/enketo/notes_list.html
+++ b/www/templates/survey/enketo/notes_list.html
@@ -3,7 +3,10 @@
         <ul>
             <li class="notes-list-entry" ng-repeat="entry in additionEntries | orderBy: ['data.start_ts', 'data.end_ts']">
                 <b class="two-lines" ng-click="editEntry(entry)">{{entry.data.label}}</b>
-                <i ng-click="editEntry(entry)">{{entry.displayTime || setDisplayTime(entry)}}</i>
+                <i ng-click="editEntry(entry)">
+                    <p>{{ entry.displayDt.date }}</p>
+                    <p>{{ entry.displayDt.time || setDisplayDt(entry).time }}</p>
+                </i>
                 <i class="icon ion-trash-a" ng-click="confirmDeleteEntry(entry)"></i>
             </li>
         </ul>

--- a/www/templates/survey/enketo/notes_list.html
+++ b/www/templates/survey/enketo/notes_list.html
@@ -1,7 +1,7 @@
 <div>
     <ion-item class="notes-list" style="background-color: transparent">
-        <ul>
-            <li class="notes-list-entry" ng-repeat="entry in additionEntries | orderBy: ['data.start_ts', 'data.end_ts']">
+        <ul class="notes-list-grid">
+            <li ng-repeat="entry in additionEntries | orderBy: ['data.start_ts', 'data.end_ts']">
                 <b class="two-lines" ng-click="editEntry(entry)">{{entry.data.label}}</b>
                 <i ng-click="editEntry(entry)">
                     <p>{{ entry.displayDt.date }}</p>


### PR DESCRIPTION
This PR allows overnight additions to be added, by resolving both "Start Date" and "End Date" from survey responses instead of only one "Date". Note that this only works if the survey itself includes the new fields.

This also fixes a few regressions that were introduced last week, and makes some styling tweaks since the cards now list out the dates of multi-day entries.

<table>
<tr>
<td>
Overnight place activities
<br>
<img src=https://user-images.githubusercontent.com/15843932/235825901-af4e7a50-f82d-48e5-bc00-b1742a98dcb0.png width=300>
</td>
<td>
Overnight untracked
<br>
<img src=https://user-images.githubusercontent.com/15843932/235822256-664bf64b-f93d-4eae-8d20-167d1906cf3c.png width=300>
</td>
</tr>

<tr>
<td>
Survey for overnight trip/place
<br>
<img src=https://user-images.githubusercontent.com/15843932/235826042-6a91a41a-0bff-4188-bceb-6c0029ed4b39.png width=300>
</td>
<td>
Survey for same-day trip/place
<br>
<img src=https://user-images.githubusercontent.com/15843932/235826175-4d4e7d9c-fc11-4264-9b66-da6ecd536807.png width=300>
</td>
</tr>
</table>
