### PR TITLE
recompute the app status on resume as well

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -646,6 +646,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
       if ($state.$current == "root.main.diary.list") {
         $scope.startTime = moment().utc()
       }
+      $scope.checkPermissionsStatus();
     })
 
     $ionicPlatform.ready().then(function() {


### PR DESCRIPTION
This ensures that if we click on the notification even when the app is in the background but not yet killed, we show the popup

Testing done:
- installed app with correct permissions
- changed settings to incorrect WITHOUT killing the app
- clicked on notification
- got the popup

This still won't necessarily work if we were ever only on the profile screen, but it might be a partial fix for https://github.com/e-mission/e-mission-phone/pull/964#issuecomment-1535422099

And will certainly work for people who just leave the app running in the background like they should