### PR TITLE
Configurable Notification Schedules

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -84,6 +84,7 @@
     <script src="js/splash/storedevicesettings.js"></script>
     <script src="js/splash/localnotify.js"></script>
     <script src="js/splash/remotenotify.js"></script>
+    <script src="js/splash/notifScheduler.js"></script>
     <script src="js/join/join-ctrl.js"></script>
     <script src="js/controllers.js"></script>
     <script src="js/services.js"></script>

--- a/www/js/splash/notifScheduler.js
+++ b/www/js/splash/notifScheduler.js
@@ -1,0 +1,110 @@
+'use strict';
+
+angular.module('emission.splash.notifscheduler',
+                    ['emission.plugin.kvstore',,
+                    'emission.plugin.logger',
+                    'emission.stats.clientstats'])
+
+.factory('NotificationScheduler', function($http, $window, $ionicPlatform,
+                                            ClientStats, KVStore, Logger) {
+
+    const scheduler = {};
+
+    const sampleScheme = {
+        title: '** Please take a moment to label your trips',
+        text: 'Click here to open the app and view unlabeled trips',
+        schedule: [
+            { start: '2023-05-06', end: '2023-05-13', intervalInDays: 1 /* daily */ },
+        ],
+        defaultTime: '21:00' // user can override this to their preference
+    }
+
+    const momentRange = (startDate, stopDate, step) => {
+        const startM = moment(startDate);
+        const stopM = moment(stopDate);
+        const diff = stopM.diff(startM, 'days');
+        const range = [];
+        for (let i = 0; i < diff; i+=step) {
+            range.push(moment(startDate).add(i, 'days'));
+        }
+        return range;
+    };
+
+    const calcNotifTimes = (scheme, timeOfDay) => {
+        const notifTimes = [];
+        for (const s of scheme.schedule) {
+            const notifDays = momentRange(s.start, s.end, s.intervalInDays);
+            for (const d of notifDays) {
+                const notifTime = moment(d.format('YYYY-MM-DD')+' '+timeOfDay, 'YYYY-MM-DD HH:mm');
+                notifTimes.push(notifTime);
+            }
+        }
+        return notifTimes;
+    }
+
+    const areAlreadyScheduled = (notifs, notifTimes) => {
+        for (const t of notifTimes) {
+            if (!notifs.some((n) => moment(n.at).isSame(t))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    const scheduleNotifs = (notifTimes) => {
+        cordova.plugins.notification.local.addActions('reminder-actions', [
+            { id: 'action', title: 'Change Time' }
+        ]);
+
+        const nots = notifTimes.map((n) => {
+            const nDate = n.toDate();
+            const seconds = nDate.getTime() / 1000;
+            return {
+                id: seconds,
+                title: sampleScheme.title,
+                text: sampleScheme.text,
+                trigger: {at: nDate},
+                actions: 'reminder-actions'
+            }
+        });
+        cordova.plugins.notification.local.schedule(nots);
+
+        cordova.plugins.notification.local.getScheduled((notifs) => {
+            // Logger.log(`Got ${notifs.length} scheduled notifications: ${JSON.stringify(notifs)}`);
+        });
+    }
+
+    scheduler.getUserPrefReminderTime = () => {
+        return KVStore.get('userPrefReminderTime').then((result) => {
+            if (result == null) {
+                return sampleScheme.defaultTime;
+            } else {
+                return result;
+            }
+        });
+    }
+
+    scheduler.update = () => {
+        scheduler.getUserPrefReminderTime().then((prefTimeOfDay) => {
+            const notifTimes = calcNotifTimes(sampleScheme, prefTimeOfDay);
+            Logger.log("Notif times = "+JSON.stringify(notifTimes));
+
+            cordova.plugins.notification.local.getScheduled((notifs) => {
+                Logger.log(`Got ${notifs.length} scheduled notifications: ${JSON.stringify(notifs)}`);
+                if (areAlreadyScheduled(notifs, notifTimes)) {
+                    Logger.log("Already scheduled, not scheduling again");
+                } else {
+                    cordova.plugins.notification.local.cancelAll();
+                    Logger.log("Not already scheduled, scheduling now");
+                    scheduleNotifs(notifTimes);
+                }
+            });
+        });
+    }
+
+    $ionicPlatform.ready().then(() => {
+        scheduler.update();
+    });
+
+    return scheduler;
+});

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -14,6 +14,14 @@
       <div ng-click="viewQRCode($event)" class="control-icon-button"><i class="ion-ios-grid-view"></i></div>
     </div>
     <div class="control-list-item">
+      <div class="control-list-text">Time of Day for Reminders ({{settings.notification.prefReminderTime}})</div>
+      <div class="control-icon-button" style="position: relative">
+        <i class="ion-clock"></i>
+        <input type="time" name="timeOfDay" ng-model="settings.notification.prefReminderTimeVal" ng-change="updatePrefReminderTime()"
+          style="position: absolute; height: 100%; inset: 0; display: flex; opacity: 0;">
+      </div>
+    </div>
+    <div class="control-list-item">
       <div class="control-list-text" translate>{{'.tracking'}}</div>
       <label ng-click="userStartStopTracking()" class="toggle control-list-toggle toggle-color">
         <input type="checkbox" ng-checked="settings.collect.trackingOn">


### PR DESCRIPTION
Per https://github.com/e-mission/e-mission-docs/issues/900, this PR will implement "a more flexible notification system that can be tailored to any of multiple "schemes" and also consider the user's preference for the timing of the notification."

The interval of the notifications (i.e. daily? weekly?), will be determined by the user's assignment to one of many groups.
The time of day at which the notification comes (i.e. noon? 8pm?) will be specified by the user.

The user's chosen reminder time is stored and loaded with `KVStore`.
The configurable "scheme" or interval of notification is not fully implemented, but I have hardcoded a `sampleScheme` to demonstrate the structure that will be expected when configuring schemes:

```js
// remind daily for 1 week, with reminders at 9 PM by default

const dailySampleScheme = {
    title: '** Please take a moment to label your trips',
    text: 'Click here to open the app and view unlabeled trips',
    schedule: [
        { start: '2023-05-06', end: '2023-05-13', intervalInDays: 1 /* daily */ },
    ],
    defaultTime: '21:00' // user can override this to their preference
}
```

Other schemes might look something like like this:

```js
// remind once weekly from June through August, with reminders at noon by default

const weeklySampleScheme = {
    title: '** Please take a moment to label your trips',
    text: 'Click here to open the app and view unlabeled trips',
    schedule: [
        { start: '2023-06-01', end: '2023-08-31', intervalInDays: 7 /* weekly */ },
    ],
    defaultTime: '12:00' // user can override this to their preference
}
```