### PR TITLE
Disable trip filters if additions are enabled

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -61,7 +61,11 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
       $scope.enbs.initConfig(tripSurveyName, placeSurveyName);
     });
     $scope.checkPermissionsStatus();
-    $scope.initFilters();
+    // we will show filters if 'additions' are not configured
+    // https://github.com/e-mission/e-mission-docs/issues/894
+    if (configObj.survey_info?.buttons == undefined) {
+      $scope.initFilters();
+    }
     $scope.setupInfScroll();
   };
 
@@ -325,7 +329,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
   $scope.recomputeDisplayTimelineEntries = function() {
     console.log("recomputing display timeline now");
     let alreadyFiltered = false;
-    $scope.filterInputs.forEach((f) => {
+    $scope.filterInputs?.forEach((f) => {
         if (f.state == true) {
             if (alreadyFiltered) {
                 Logger.displayError("multiple filters not supported!", undefined);

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -5,10 +5,16 @@
         <button class="button button-icon" ng-click="increaseHeight()">
             <i class="icon ion-arrow-resize"></i>
         </button>
-        <select ng-model="selFilter" ng-change="updateFilterSel(selFilter)">
+        <select ng-if="filterInputs" ng-model="selFilter" ng-change="updateFilterSel(selFilter)">
             <option ng-repeat="filter in filterInputs" value="{{filter.key}}" translate>
                 {{filter.text}}
             </option>
+            <option value="show-all" translate>
+                {{'.show-all'}}
+            </option>
+        </select>
+        <!-- if there are no filter inputs, just show "All Trips" and disable the select -->
+        <select ng-if="!filterInputs" style="appearance: button; -webkit-appearance: button; pointer-events: none">
             <option value="show-all" translate>
                 {{'.show-all'}}
             </option>


### PR DESCRIPTION
https://github.com/e-mission/e-mission-docs/issues/894

If either trip- or place- additions are enabled, the `<select>` for filters will appear as shown at the top here:

<img src=https://user-images.githubusercontent.com/15843932/236892749-6e0098cc-bf11-4760-8673-1f48e0ee3f94.png width=300>