### PR TITLE
🐛 Fix final inference being overwritten by enbs

### DIFF
--- a/www/js/survey/enketo/enketo-add-note-button.js
+++ b/www/js/survey/enketo/enketo-add-note-button.js
@@ -164,7 +164,6 @@ angular.module('emission.survey.enketo.add-note-button',
         // initialize additions array as empty if it doesn't already exist
         timelineEntry.additionsList ||= [];
         enbs.populateManualInputs(timelineEntry, enbs.SINGLE_KEY, manualResultMap[enbs.SINGLE_KEY]);
-        timelineEntry.finalInference = {};
     } else {
         console.log("timelineEntry information not yet bound, skipping fill");
     }


### PR DESCRIPTION
https://github.com/e-mission/e-mission-docs/issues/903

Yellow label buttons for inferred modes were not showing on the label screen for some time now. This is because the finalInference, in the trip object, was being overwritten in `EnketoNotesButtonService`/`enbs` (in `enketo-add-note-button`).

This is because the logic for `enketo-add-note-button` was based on the logic for `enketo-trip-button`. `finalInference` is not relevant to additions, so we will just remove that line.