### PR TITLE
Hide untracked time in "To Label" if previous or next trip has been labeled

### DIFF
--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -367,6 +367,18 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         // }
       }
 
+      /* don't display untracked time if the trips that came before and
+          after it are not displayed */
+      if (cTrip.key.includes('untracked')) {
+        const prevTrip = $scope.data.allTrips[$scope.data.allTrips.indexOf(cTrip) - 1];
+        const nextTrip = $scope.data.allTrips[$scope.data.allTrips.indexOf(cTrip) + 1];
+        const prevTripDisplayed = $scope.data.displayTrips.includes(prevTrip);
+        const nextTripDisplayed = $scope.data.displayTrips.includes(nextTrip);
+        if (prevTrip && !prevTripDisplayed || nextTrip && !nextTripDisplayed) {
+          return;
+        }
+      }
+
       // Add trip to the list
       $scope.data.displayTimelineEntries.push(cTrip);
 

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -345,9 +345,10 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     if (!alreadyFiltered) {
         $scope.data.displayTrips = $scope.data.allTrips;
     };
+    $scope.data.displayTrips.count = $scope.data.displayTrips.length;
     
     $scope.data.displayTimelineEntries = []
-    $scope.data.displayTrips.forEach((cTrip) => {
+    $scope.data.displayTrips.forEach((cTrip, i, displayTrips) => {
       const start_place = cTrip.start_confirmed_place;
       const end_place = cTrip.end_confirmed_place;
 
@@ -375,6 +376,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
         const prevTripDisplayed = $scope.data.displayTrips.includes(prevTrip);
         const nextTripDisplayed = $scope.data.displayTrips.includes(nextTrip);
         if (prevTrip && !prevTripDisplayed || nextTrip && !nextTripDisplayed) {
+          $scope.data.displayTrips.count -= 1;
           return;
         }
       }

--- a/www/js/diary/infinite_scroll_list.js
+++ b/www/js/diary/infinite_scroll_list.js
@@ -348,7 +348,7 @@ angular.module('emission.main.diary.infscrolllist',['ui-leaflet',
     $scope.data.displayTrips.count = $scope.data.displayTrips.length;
     
     $scope.data.displayTimelineEntries = []
-    $scope.data.displayTrips.forEach((cTrip, i, displayTrips) => {
+    $scope.data.displayTrips.forEach((cTrip) => {
       const start_place = cTrip.start_confirmed_place;
       const end_place = cTrip.end_confirmed_place;
 

--- a/www/templates/diary/infinite_scroll_list.html
+++ b/www/templates/diary/infinite_scroll_list.html
@@ -31,7 +31,7 @@
 
         <div class="control-list-item row">
             <div class="control-list-text col">
-                <div class="row" translate="diary.filter-display-status" translate-values="{displayTripsLength: data.displayTrips.length, allTripsLength: data.allTrips.length}"></div>
+                <div class="row" translate="diary.filter-display-status" translate-values="{displayTripsLength: data.displayTrips.count, allTripsLength: data.allTrips.length}"></div>
                 <div ng-if="data.allTrips.length > 0" class="row" translate="diary.filter-display-range" translate-values="{currentStart: data.allTrips.slice(-1)[0].start_ts * 1000, currentEnd: infScrollControl.currentEnd * 1000}"></div>
             </div>
             <div ng-click="readDataFromServer()" ng-if="!infScrollControl.reachedEnd" id="gray" class="control-icon-button"><i class="ion-ios-download"></i></div>


### PR DESCRIPTION
https://github.com/e-mission/e-mission-docs/issues/907
We'd like for untracked time to not remain in "To Label" after trips have been labeled.
With this PR, untracked time will only show if the trips before and after it are showing. Once either is labeled, the untracked time will disappear from "To Label"