### PR TITLE
Fix Jumbled Profile Tab

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -706,8 +706,7 @@ background-image: none !important; }
 /* Light theme */
 .control-icon-button{
   text-align: center;
-  float: right;
-  height: 100%;
+  max-height: 56px;
   background-color: #6c757d;
   color: #fff;
   padding-top: 16px;
@@ -884,10 +883,21 @@ button.button.back-button.buttons.button-clear.header-item {
 }
 /* Profile tab */
 .control-list-item {
-  height: 50px; margin-top: 0.5px;
+  display: flex;
+  min-height: 50px;
+  margin-top: 0.5px;
+  justify-content: space-between;
 }
 .control-list-text {
-  padding: 15px; float: left;
+  padding-inline: 15px;
+  margin-block: auto;
+  max-width: calc(100% - 64px);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* number of lines to show */
+          line-clamp: 2; 
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
 }
 .control-list-toggle {
   float: right; margin-top: 5px; margin-right: 2px;

--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -7,6 +7,7 @@ angular.module('emission.main.control',['emission.services',
                                         'emission.splash.localnotify',
                                         'emission.splash.notifscheduler',
                                         'ionic-datepicker',
+                                        'ionic-toast',
                                         'ionic-datepicker.provider',
                                         'emission.splash.startprefs',
                                         'emission.main.metrics.factory',
@@ -21,7 +22,7 @@ angular.module('emission.main.control',['emission.services',
                $ionicScrollDelegate, $ionicPlatform,
                $state, $ionicPopup, $ionicActionSheet, $ionicPopover,
                $ionicModal, $stateParams,
-               $rootScope, KVStore, ionicDatePicker,
+               $rootScope, KVStore, ionicDatePicker, ionicToast,
                StartPrefs, ControlHelper, EmailHelper, UploadHelper,
                ControlCollectionHelper, ControlSyncHelper,
                CarbonDatasetHelper, NotificationScheduler, LocalNotify,
@@ -361,6 +362,12 @@ angular.module('emission.main.control',['emission.services',
         });
         $scope.getUserData();
     };
+
+    $scope.copyToClipboard = (textToCopy) => {
+        navigator.clipboard.writeText(textToCopy).then(() => {
+            ionicToast.show('{Copied to clipboard!}', 'bottom', false, 2000);
+        });
+    }
 
     $scope.returnToIntro = function() {
       var testReconsent = false

--- a/www/templates/control/main-control.html
+++ b/www/templates/control/main-control.html
@@ -1,7 +1,7 @@
 <ion-view view-title="{{'control.profile' | translate}}" ng-class="ion-view-background" translate-namespace="control">
   <ion-content>
     <div class="control-list-item">
-      <div class="control-list-text">{{settings.auth.opcode}}</div>
+      <div ng-click="copyToClipboard(settings.auth.opcode)" class="control-list-text">{{settings.auth.opcode}}</div>
       <div ng-click="returnToIntro()" id ="switch-user" class="control-icon-button"><i class="icon ion-log-out"></i></div>
     </div>
     <enketo-demographics-button></enketo-demographics-button>


### PR DESCRIPTION
I got tired of how messy the Profile tab looks on my Pixel 5.
This issue only affected some devices/display configurations (I'm guessing smaller screens with larger font scaling).

The issue has been tracked at least twice but was never fixed:
- https://github.com/e-mission/e-mission-docs/issues/442
- https://github.com/e-mission/e-mission-docs/issues/630

<table>
<tr>
<td>

### Before: 
<img src=https://github.com/e-mission/e-mission-phone/assets/15843932/85c15fa9-aa5b-4237-8a8c-737075535ace>

</td>
<td>

### After:
<img src=https://github.com/e-mission/e-mission-phone/assets/15843932/b1b6b6fd-1fd6-4c30-866f-bd22de6c3275>

</td>
</tr>
</table>

Also, since long OPcodes will display "..." now (instead of just running off the page), I added a quality-of-life feature to copy the OPCode by clicking it (only iOS)
>-On iOS, clicking the opcode will copy it to the clipboard (this is mostly for ease of development)
>-- On android, this would require extra permissions, so it does nothing
