### PR TITLE
:bug: Customize the privacy policy when displayed from the profile

### DIFF
--- a/www/js/control/general-settings.js
+++ b/www/js/control/general-settings.js
@@ -174,6 +174,24 @@ angular.module('emission.main.control',['emission.services',
     $ionicPlatform.ready().then(function() {
         DynamicConfig.configReady().then(function(newConfig) {
             $scope.ui_config = newConfig;
+            // backwards compat hack to fill in the raw_data_use for programs that don't have it
+            const default_raw_data_use = {
+                "en": `to monitor the ${newConfig.intro.program_or_study}, send personalized surveys or provide recommendations to participants`,
+                "es": `para monitorear el ${newConfig.intro.program_or_study}, enviar encuestas personalizadas o proporcionar recomendaciones a los participantes`
+            }
+            Object.entries(newConfig.intro.translated_text).forEach(([lang, val]) => {
+                val.raw_data_use = val.raw_data_use || default_raw_data_use[lang];
+            });
+            // TODO: we should be able to use $translate for this, right?
+            $scope.template_text = newConfig.intro.translated_text[$scope.lang];
+            if (!$scope.template_text) {
+                $scope.template_text = newConfig.intro.translated_text["en"]
+            }
+            // Backwards compat hack to fill in the `app_required` based on the
+            // old-style "program_or_study"
+            // remove this at the end of 2023 when all programs have been migrated over
+            $scope.ui_config.app_required = $scope.ui_config?.intro.app_required || $scope.ui_config?.intro.program_or_study == 'program';
+            $scope.ui_config.opcode.autogen = $scope.ui_config?.opcode.autogen || $scope.ui_config?.intro.program_or_study == 'study';
             $scope.refreshScreen();
         });
     });


### PR DESCRIPTION
Per Google requirements, we display the privacy policy from the control screen as well, and pass in the `$scope` variable so that it can be configured correctly. However, most of the customizable text in the policy is from the `$scope.translated_text` variable, which needs to be filled in with the correct locale.

And then we added several backward compatibility hacks in https://github.com/e-mission/e-mission-phone/pull/981

This commit copies over the `translated_text` selection and the backward compatibility hacks so that the in-app privacy policy is also generated properly