### PR TITLE
:ambulance: final fix for the backwards compat code

### DIFF
--- a/www/js/intro.js
+++ b/www/js/intro.js
@@ -205,9 +205,13 @@ angular.module('emission.intro', ['emission.splash.startprefs',
         // Backwards compat hack to fill in the `app_required` based on the
         // old-style "program_or_study"
         // remove this at the end of 2023 when all programs have been migrated over
-        $scope.ui_config.intro.app_required = $scope.ui_config?.intro.app_required || $scope.ui_config?.intro.program_or_study == 'program';
+        if ($scope.ui_config.intro.app_required == undefined) {
+            $scope.ui_config.intro.app_required = $scope.ui_config?.intro.program_or_study == 'program';
+        }
         $scope.ui_config.opcode = $scope.ui_config.opcode || {};
-        $scope.ui_config.opcode.autogen = $scope.ui_config?.opcode?.autogen || $scope.ui_config?.intro.program_or_study == 'study';
+        if ($scope.ui_config.opcode.autogen == undefined) {
+            $scope.ui_config.opcode.autogen = $scope.ui_config?.intro.program_or_study == 'study';
+        }
         $scope.init();
       });
     });


### PR DESCRIPTION
Before this, we had

```
$scope.ui_config.intro.app_required = $scope.ui_config?.intro.app_required || $scope.ui_config?.intro.program_or_study == 'program';
```

This worked fine for backward compat, but in the case of a program where the app was not required, we ended up with

`false || true` which is `true`

Taking out the fancy javascript and going to a simpler, more verbose check of whether the property is undefined before overriding it

Testing done:
- Before this, denver CASR said that the app was required
- After this, it said that it was voluntary