### PR TITLE
Fix 'serve' deployment setup script

### DIFF
--- a/setup/setup_serve.sh
+++ b/setup/setup_serve.sh
@@ -15,3 +15,5 @@ npx bower update --allow-root
 
 echo "Pulling the plugin-specific UIs"
 npm run setup-serve
+
+npx cordova prepare


### PR DESCRIPTION
Fixes https://github.com/e-mission/e-mission-docs/issues/904

The `browser` platform was added in 460f6ee729805137908c694f11723d82bed69ea8, but could not be located unless `npx cordova prepare` is called.