### PR TITLE
🐛 Fix extra pipeline range request every time a trip is labeled + handle network error better

### DIFF
--- a/www/js/diary/LabelTab.tsx
+++ b/www/js/diary/LabelTab.tsx
@@ -17,7 +17,7 @@ import LabelListScreen from "./LabelListScreen";
 import { createStackNavigator } from "@react-navigation/stack";
 import LabelScreenDetails from "./LabelDetailsScreen";
 import { NavigationContainer } from "@react-navigation/native";
-import { compositeTrips2TimelineMap, getUnprocessedInputs, populateBasicClasses, populateCompositeTrips } from "./timelineHelper";
+import { compositeTrips2TimelineMap, getAllUnprocessedInputs, getLocalUnprocessedInputs, populateBasicClasses, populateCompositeTrips } from "./timelineHelper";
 import { fillLocationNamesOfTrip, resetNominatimLimiter } from "./addressNamesHelper";
 
 let labelPopulateFactory, labelsResultMap, notesResultMap, showPlaces;
@@ -103,7 +103,7 @@ const LabelTab = () => {
   async function loadTimelineEntries() {
     try {
       const pipelineRange = await CommHelper.getPipelineRangeTs();
-      [labelsResultMap, notesResultMap] = await getUnprocessedInputs(pipelineRange, labelPopulateFactory, enbs);
+      [labelsResultMap, notesResultMap] = await getAllUnprocessedInputs(pipelineRange, labelPopulateFactory, enbs);
       Logger.log("After reading unprocessedInputs, labelsResultMap =" + JSON.stringify(labelsResultMap)
                                                 + "; notesResultMap = " + JSON.stringify(notesResultMap));
       setPipelineRange(pipelineRange);
@@ -235,7 +235,7 @@ const LabelTab = () => {
   const timelineMapRef = useRef(timelineMap);
   async function repopulateTimelineEntry(oid: string) {
     if (!timelineMap.has(oid)) return console.error("Item with oid: " + oid + " not found in timeline");
-    const [newLabels, newNotes] = await getUnprocessedInputs(pipelineRange, labelPopulateFactory, enbs);
+    const [newLabels, newNotes] = await getLocalUnprocessedInputs(pipelineRange, labelPopulateFactory, enbs);
     const repopTime = new Date().getTime();
     const newEntry = {...timelineMap.get(oid), justRepopulated: repopTime};
     populateBasicClasses(newEntry);

--- a/www/js/diary/LabelTab.tsx
+++ b/www/js/diary/LabelTab.tsx
@@ -17,7 +17,7 @@ import LabelListScreen from "./LabelListScreen";
 import { createStackNavigator } from "@react-navigation/stack";
 import LabelScreenDetails from "./LabelDetailsScreen";
 import { NavigationContainer } from "@react-navigation/native";
-import { compositeTrips2TimelineMap, populateBasicClasses, populateCompositeTrips } from "./timelineHelper";
+import { compositeTrips2TimelineMap, getUnprocessedInputs, populateBasicClasses, populateCompositeTrips } from "./timelineHelper";
 import { fillLocationNamesOfTrip, resetNominatimLimiter } from "./addressNamesHelper";
 
 let labelPopulateFactory, labelsResultMap, notesResultMap, showPlaces;
@@ -41,8 +41,9 @@ const LabelTab = () => {
   const $rootScope = getAngularService('$rootScope');
   const $state = getAngularService('$state');
   const $ionicPopup = getAngularService('$ionicPopup');
+  const Logger = getAngularService('Logger');
   const Timeline = getAngularService('Timeline');
-  const DiaryHelper = getAngularService('DiaryHelper');
+  const CommHelper = getAngularService('CommHelper');
   const SurveyOptions = getAngularService('SurveyOptions');
   const enbs = getAngularService('EnketoNotesButtonService');
 
@@ -99,15 +100,17 @@ const LabelTab = () => {
     setDisplayedEntries(entriesToDisplay);
   }, [timelineMap, filterInputs]);
 
-  function loadTimelineEntries() {
-    Timeline.getUnprocessedLabels(labelPopulateFactory, enbs).then(([pipelineRange, manualResultMap, enbsResultMap]) => {
-      if (pipelineRange.end_ts) {
-        labelsResultMap = manualResultMap;
-        notesResultMap = enbsResultMap;
-        console.log("After reading in the label controller, manualResultMap " + JSON.stringify(manualResultMap), manualResultMap);
-      }
+  async function loadTimelineEntries() {
+    try {
+      const pipelineRange = await CommHelper.getPipelineRangeTs();
+      [labelsResultMap, notesResultMap] = await getUnprocessedInputs(pipelineRange, labelPopulateFactory, enbs);
+      Logger.log("After reading unprocessedInputs, labelsResultMap =" + JSON.stringify(labelsResultMap)
+                                                + "; notesResultMap = " + JSON.stringify(notesResultMap));
       setPipelineRange(pipelineRange);
-    });
+    } catch (error) {
+      Logger.displayError("Error while loading pipeline range", error);
+      setIsLoading(false);
+    }
   }
 
   // once pipelineRange is set, load the most recent week of data
@@ -232,7 +235,7 @@ const LabelTab = () => {
   const timelineMapRef = useRef(timelineMap);
   async function repopulateTimelineEntry(oid: string) {
     if (!timelineMap.has(oid)) return console.error("Item with oid: " + oid + " not found in timeline");
-    const [_, newLabels, newNotes] = await Timeline.getUnprocessedLabels(labelPopulateFactory, enbs);
+    const [newLabels, newNotes] = await getUnprocessedInputs(pipelineRange, labelPopulateFactory, enbs);
     const repopTime = new Date().getTime();
     const newEntry = {...timelineMap.get(oid), justRepopulated: repopTime};
     populateBasicClasses(newEntry);

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -64,7 +64,8 @@ const TimelineScrollList = ({ listEntries, queriedRange, pipelineRange, loadMore
   } else if (listEntries && listEntries.length == 0) {
     /* Condition: we've loaded all travel and set `listEntries`, but it's empty. Show 'no travel'. */
     return noTravelBanner;
-  } else {
+  } else if (listEntries) {
+    /* Condition: we've successfully loaded and set `listEntries`, so show the list */
     return (
       <FlashList inverted
         data={reversedListEntries}

--- a/www/js/diary/services.js
+++ b/www/js/diary/services.js
@@ -129,39 +129,6 @@ angular.module('emission.main.diary.services', ['emission.plugin.logger',
       });
     });
 
-    timeline.getUnprocessedLabels = function(manualFactory, enbs) {
-        /*
-         Because with the confirmed trips, all prior labels have been
-         incorporated into the trip.
-         */
-        return CommHelper.getPipelineRangeTs().then(function(result) {
-            const pendingLabelQuery = {key: "write_ts",
-                startTs: result.end_ts - 10,
-                endTs: moment().unix() + 10
-            }
-            var manualPromises = manualFactory.MANUAL_KEYS.map(function(inp_key) {
-              return UnifiedDataLoader.getUnifiedMessagesForInterval(
-                  inp_key, pendingLabelQuery).then(manualFactory.extractResult);
-            });
-            var enbsPromises = enbs.MANUAL_KEYS.map(function(inp_key) {
-              return UnifiedDataLoader.getUnifiedMessagesForInterval(
-                  inp_key, pendingLabelQuery).then(enbs.extractResult);
-            });
-            const manualConfirmResults = {};
-            const enbsConfirmResults = {};
-            return Promise.all([...manualPromises, ...enbsPromises]).then((comboResults) => {
-                const manualResults = comboResults.slice(0, manualPromises.length);
-                const enbsResults = comboResults.slice(manualPromises.length);
-                manualFactory.processManualInputs(manualResults, manualConfirmResults);
-                enbs.processManualInputs(enbsResults, enbsConfirmResults);
-                return [result, manualConfirmResults, enbsConfirmResults];
-            });
-        }).catch((err) => {
-            Logger.displayError("while reading confirmed trips", err);
-            return [{}, {}];
-        });
-    };
-
     // DB entries retrieved from the server have '_id', 'metadata', and 'data' fields.
     // This function returns a shallow copy of the obj, which flattens the
     // 'data' field into the top level, while also including '_id' and 'metadata.key'

--- a/www/js/diary/timelineHelper.ts
+++ b/www/js/diary/timelineHelper.ts
@@ -82,9 +82,27 @@ export function populateCompositeTrips(ctList, showPlaces, labelsFactory, labels
   });
 }
 
+const getUnprocessedInputQuery = (pipelineRange) => ({
+  key: "write_ts",
+  startTs: pipelineRange.end_ts - 10,
+  endTs: moment().unix() + 10
+});
+
+function getUnprocessedResults(labelsFactory, notesFactory, labelsPromises, notesPromises) {
+  return Promise.all([...labelsPromises, ...notesPromises]).then((comboResults) => {
+    const labelsConfirmResults = {};
+    const notesConfirmResults = {};
+    const labelResults = comboResults.slice(0, labelsPromises.length);
+    const notesResults = comboResults.slice(labelsPromises.length);
+    labelsFactory.processManualInputs(labelResults, labelsConfirmResults);
+    notesFactory.processManualInputs(notesResults, notesConfirmResults);
+    return [labelsConfirmResults, notesConfirmResults];
+  });
+}
+
 /**
- * @description Gets inputs (labels or Enketo responses) that were recorded after the given
- * pipeline range and have not yet been processed on the server.
+ * @description Gets unprocessed inputs (labels or Enketo responses) that were recorded after the given
+ * pipeline range and have not yet been pushed to the server.
  * @param pipelineRange an object with start_ts and end_ts representing the range of time
  *     for which travel data has been processed through the pipeline on the server
  * @param labelsFactory the Angular factory for processing labels (MultilabelService or
@@ -92,28 +110,36 @@ export function populateCompositeTrips(ctList, showPlaces, labelsFactory, labels
  * @param notesFactory the Angular factory for processing notes (EnketoNotesButtonService)
  * @returns Promise an array with 1) results for labels and 2) results for notes
  */
-export function getUnprocessedInputs(pipelineRange, labelsFactory, notesFactory) {
+export function getLocalUnprocessedInputs(pipelineRange, labelsFactory, notesFactory) {
+  const BEMUserCache = window['cordova'].plugins.BEMUserCache;
+  const tq = getUnprocessedInputQuery(pipelineRange);
+  const labelsPromises = labelsFactory.MANUAL_KEYS.map((key) =>
+    BEMUserCache.getMessagesForInterval(key, tq, true).then(labelsFactory.extractResult)
+  );
+  const notesPromises = notesFactory.MANUAL_KEYS.map((key) =>
+    BEMUserCache.getMessagesForInterval(key, tq, true).then(notesFactory.extractResult)
+  );
+  return getUnprocessedResults(labelsFactory, notesFactory, labelsPromises, notesPromises);
+}
+
+/**
+ * @description Gets all unprocessed inputs (labels or Enketo responses) that were recorded after the given
+ * pipeline range, including those on the phone and that and have been pushed to the server but not yet processed.
+ * @param pipelineRange an object with start_ts and end_ts representing the range of time
+ *     for which travel data has been processed through the pipeline on the server
+ * @param labelsFactory the Angular factory for processing labels (MultilabelService or
+ *     EnketoTripButtonService)
+ * @param notesFactory the Angular factory for processing notes (EnketoNotesButtonService)
+ * @returns Promise an array with 1) results for labels and 2) results for notes
+ */
+export function getAllUnprocessedInputs(pipelineRange, labelsFactory, notesFactory) {
   const UnifiedDataLoader = getAngularService('UnifiedDataLoader');
-  const pendingLabelQuery = {
-    key: "write_ts",
-    startTs: pipelineRange.end_ts - 10,
-    endTs: moment().unix() + 10
-  };
-  const manualPromises = labelsFactory.MANUAL_KEYS.map(function(inp_key) {
-    return UnifiedDataLoader.getUnifiedMessagesForInterval(
-      inp_key, pendingLabelQuery).then(labelsFactory.extractResult);
-  });
-  const enbsPromises = notesFactory.MANUAL_KEYS.map(function (inp_key) {
-    return UnifiedDataLoader.getUnifiedMessagesForInterval(
-      inp_key, pendingLabelQuery).then(notesFactory.extractResult);
-  });
-  const manualConfirmResults = {};
-  const enbsConfirmResults = {};
-  return Promise.all([...manualPromises, ...enbsPromises]).then((comboResults) => {
-    const manualResults = comboResults.slice(0, manualPromises.length);
-    const enbsResults = comboResults.slice(manualPromises.length);
-    labelsFactory.processManualInputs(manualResults, manualConfirmResults);
-    notesFactory.processManualInputs(enbsResults, enbsConfirmResults);
-    return [manualConfirmResults, enbsConfirmResults];
-  });
+  const tq = getUnprocessedInputQuery(pipelineRange);
+  const labelsPromises = labelsFactory.MANUAL_KEYS.map((key) =>
+    UnifiedDataLoader.getUnifiedMessagesForInterval(key, tq, true).then(labelsFactory.extractResult)
+  );
+  const notesPromises = notesFactory.MANUAL_KEYS.map((key) =>
+    UnifiedDataLoader.getUnifiedMessagesForInterval(key, tq, true).then(notesFactory.extractResult)
+  );
+  return getUnprocessedResults(labelsFactory, notesFactory, labelsPromises, notesPromises);
 }


### PR DESCRIPTION
Resolves a bug tracked in https://github.com/e-mission/e-mission-docs/issues/948

The pipeline range should only be fetched when the label screen is initialized or refreshed. When a trip is labeled, we should not need to fetch the pipeline range - this was happening because the old `getUnprocessedLabels` function called `getPipelineRangeTs` every time it was called.

This function was rewritten into `getUnprocessedInputs` in `timelineHelper.ts`. It will accept the pipelineRange as an argument.

Now in LabelTab, only on init / refresh will we request the pipelineRange. Subsequent calls to `getUnprocessedLabels` will use the already-fetched pipelineRange.

We will also handle errors better - if retrieving pipeline range fails (network error), we should show error popup and stop loading spinner.

Testing done:
-Labeled several trips - all labels appeared within ~1 second. -Disconnected network, tried labeling trips - all labels appeared within ~1 second. -While network disconnected, tried refreshing label screen - popup "Error while loading pipeline range". Same result on app launch while network disconnected.

extra tidying note:
- removed getAngularService("DiaryHelper") from LabelTab because it no longer used (the functions that were previously used there had already been moved to the new Typescript file diaryHelper.ts)