### PR TITLE
🚑 Fix Angular Annotations in logger.ts

### DIFF
--- a/www/js/plugin/logger.ts
+++ b/www/js/plugin/logger.ts
@@ -2,7 +2,8 @@ import angular from 'angular';
 
 angular.module('emission.plugin.logger', [])
 
-.factory('Logger', function($window, $ionicPopup) {
+// explicit annotations needed in .ts files - Babel does not fix them (see webpack.prod.js)
+.factory('Logger', ['$window', '$ionicPopup', function($window, $ionicPopup) {
     var loggerJs: any = {};
     loggerJs.log = function(message) {
         $window.Logger.log($window.Logger.LEVEL_DEBUG, message);
@@ -21,7 +22,7 @@ angular.module('emission.plugin.logger', [])
       $window.Logger.log($window.Logger.LEVEL_ERROR, title + display_msg);
     }
     return loggerJs;
-});
+}]);
 
 export const logDebug = (message: string) =>
   window['Logger'].log(window['Logger'].LEVEL_DEBUG, message);


### PR DESCRIPTION
fixes https://github.com/e-mission/e-mission-docs/issues/955#issuecomment-1688470738

We use a Babel plugin `angularjs-annotate` to fix our bad, implicitly annotated, Angular code. This way, it still works when bundled. But we only have Babel apply this to .js files.
I moved a little bit of Angular code to .ts (the "Logger" service). I don't expect we will usually put Angular code in .ts files, so I'm just going to explicitly type it in the one place we do.