### PR TITLE
Update Scripts: download settings controls during setup, add serve-prod

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -8,6 +8,7 @@
     "url": "git+https://github.com/e-mission/e-mission-phone.git"
   },
   "scripts": {
+    "setup-native": "./bin/download_settings_controls.js",
     "build": "npx webpack --config webpack.prod.js && npx cordova build",
     "build-dev": "npx webpack --config webpack.dev.js && npx cordova build",
     "build-dev-android": "npx webpack --config webpack.dev.js && npx cordova build android",

--- a/package.serve.json
+++ b/package.serve.json
@@ -10,6 +10,7 @@
   "scripts": {
     "setup-serve": "./bin/download_settings_controls.js && ./bin/setup_autodeploy.js",
     "serve": "webpack --config webpack.dev.js && concurrently -k \"phonegap --verbose serve\" \"webpack --config webpack.dev.js --watch\"",
+    "serve-prod": "webpack --config webpack.prod.js && concurrently -k \"phonegap --verbose serve\" \"webpack --config webpack.prod.js --watch\"",
     "serve-only": "phonegap --verbose serve"
   },
   "devDependencies": {
@@ -23,6 +24,7 @@
     "@ionic/cli": "6.20.8",
     "@types/luxon": "^3.3.0",
     "babel-loader": "^9.1.2",
+    "babel-plugin-angularjs-annotate": "^0.10.0",
     "babel-plugin-optional-require": "^0.3.1",
     "concurrently": "^8.0.1",
     "cordova": "^11.1.0",

--- a/setup/setup_shared_native.sh
+++ b/setup/setup_shared_native.sh
@@ -10,6 +10,8 @@ cp setup/google-services.fake.for_ci.json google-services.json
 echo "Setting up all npm packages"
 npm install
 
+npm run setup-native
+
 # By default, node doesn't fail if any of the steps fail. This makes it hard to
 # use in a CI environment, and leads to people reporting the node error rather
 # than the underlying error. One solution is to pass in a command line argument to node


### PR DESCRIPTION
For native building, we will now call `download_settings_controls.js` during the 'native setup' script.

For devapp serving, we will add a new script (`serve-prod`) allowing us to test production JS (which is bundled+minified) on the devapp.