### PR TITLE
⬆️  Upgrade the android SDK tools to the latest versions

### DIFF
--- a/.github/workflows/android-automated-sdk-install.yml
+++ b/.github/workflows/android-automated-sdk-install.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install to a new SDK root
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         echo "New SDK root $ANDROID_SDK_ROOT"
         printf "Y\nY\nY\nY\nY\n" | bash setup/prereq_android_sdk_install.sh
@@ -48,7 +48,7 @@ jobs:
     - name: Verify that all packages are as expected
       shell: bash -l {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_X64
         echo "Comparing $ANDROID_SDK_ROOT and $NEW_ANDROID_SDK_ROOT"
         $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --list_installed > /tmp/existing_packages
         $NEW_ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --list_installed > /tmp/new_packages
@@ -58,7 +58,7 @@ jobs:
     - name: Verify that directory structure is consistent
       shell: bash -l -x {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         echo "New SDK root $ANDROID_SDK_ROOT"
         ls -al $ANDROID_SDK_ROOT
@@ -73,7 +73,7 @@ jobs:
     - name: Ensure that the path is correct and installed programs are runnable
       shell: bash -l {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         echo "New SDK root $ANDROID_SDK_ROOT"
         echo "About to run the emulator at $ANDROID_SDK_ROOT/emulator/emulator"
@@ -84,14 +84,14 @@ jobs:
     - name: Setup the cordova environment
       shell: bash -l {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         bash setup/setup_android_native.sh
 
     - name: Ensure that the path is correct and the project can be activated
       shell: bash -l {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
         echo "New SDK root $ANDROID_SDK_ROOT"
         source setup/activate_native.sh

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Pre-requisites
     - or this [supposedly easier to use repo](https://github.com/xcpretty/xcode-install)
     - **NOTE**: the basic xcode install on Catalina was messed up for me due to a prior installation of command line tools. [These workarounds helped](https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md).
 - git
-- Java 11. Tested with [OpenJDK 11 (Temurin) using AdoptOpenJDK](https://adoptopenjdk.net/releases.html).
+- Java 17. Tested with [OpenJDK 17 (Temurin) using Adoptium](https://adoptium.net).
 - android SDK; install manually or use setup script below. Note that you only need to run this once **per computer**.
     ```
     $ bash setup/prereq_android_sdk_install.sh

--- a/setup/android_sdk_packages
+++ b/setup/android_sdk_packages
@@ -1,15 +1,16 @@
 build-tools;31.0.0                                    
 build-tools;32.0.0                                    
 build-tools;33.0.2                                    
+build-tools;34.0.0
 emulator                                              
 extras;google;google_play_services                    
-extras;intel;Hardware_Accelerated_Execution_Manager   
 patcher;v4                                            
 platform-tools                                        
 platforms;android-30                                  
 platforms;android-31                                  
 platforms;android-32                                  
 platforms;android-33                                  
+platforms;android-34
 system-images;android-22;google_apis;x86_64           
 system-images;android-23;google_apis;x86_64           
 system-images;android-24;google_apis_playstore;x86    
@@ -24,3 +25,5 @@ system-images;android-32;google_apis;x86_64
 system-images;android-32;google_apis_playstore;x86_64 
 system-images;android-33;google_apis;x86_64 
 system-images;android-33;google_apis_playstore;x86_64 
+system-images;android-34;google_apis;x86_64
+system-images;android-34;google_apis_playstore;x86_64

--- a/setup/prereq_android_sdk_install.sh
+++ b/setup/prereq_android_sdk_install.sh
@@ -1,4 +1,4 @@
-TOOLS_VERSION=9477386
+TOOLS_VERSION=10406996
 TOOLS_ZIP_FILENAME=commandlinetools-mac-${TOOLS_VERSION}_latest.zip
 
 echo "Installing command line tools from $TOOLS_ZIP_FILENAME"


### PR DESCRIPTION
This addresses updating the SDK tools to the latest versions: https://github.com/e-mission/e-mission-docs/issues/934#issuecomment-1685090087

And removing the obsolete HAXM package:
https://github.com/e-mission/e-mission-docs/issues/958#issuecomment-1712314266

It also updates the README to indicate the required java version after the upgrade https://github.com/e-mission/e-mission-phone/pull/1016#issuecomment-1685132683 https://github.com/e-mission/e-mission-phone/pull/1016#issuecomment-1685133940

Testing done:

After upgrading to the most recent version of OpenJDK (17)

```
$ java --version
openjdk 17.0.8.1 2023-08-24
OpenJDK Runtime Environment Temurin-17.0.8.1+1 (build 17.0.8.1+1)
OpenJDK 64-Bit Server VM Temurin-17.0.8.1+1 (build 17.0.8.1+1, mixed mode, sharing)
```

Android SDK install succeeds

```
$ bash setup/prereq_android_sdk_install.sh

---------------------------------------
Accept? (y/N): Y
[=======================================] 100% Unzipping... android-12/zipalign

END: Done with android SDK download, exiting script
```

And an android build in an existing checked-out repo succeeds

```
$ npm run build-dev-android
BUILD SUCCESSFUL in 33s
52 actionable tasks: 12 executed, 40 up-to-date
Built the following apk(s):
	.../platforms/android/app/build/outputs/apk/debug/app-debug.apk

```

Albeit with several deprecated APIs

```
w: /Users/kshankar/in-house/openpath-phone/platforms/android/app/src/main/java/com/adobe/phonegap/push/FCMService.kt: (169, 17): 'get(String!): Any?' is deprecated. Deprecated in Java
w: /Users/kshankar/in-house/openpath-phone/platforms/android/app/src/main/java/com/adobe/phonegap/push/FCMService.kt: (316, 20): 'get(String!): Any?' is deprecated. Deprecated in Java
w: /Users/kshankar/in-house/openpath-phone/platforms/android/app/src/main/java/com/adobe/phonegap/push/FCMService.kt: (627, 33): 'constructor Builder(Context)' is deprecated. Deprecated in Java
w: /Users/kshankar/in-house/openpath-phone/platforms/android/app/src/main/java/com/adobe/phonegap/push/FCMService.kt: (1190, 37): 'fromHtml(String!): Spanned!' is deprecated. Deprecated in Java
w: /Users/kshankar/in-house/openpath-phone/platforms/android/app/src/main/java/com/adobe/phonegap/push/PushPlugin.kt: (97, 25): 'get(String!): Any?' is deprecated. Deprecated in Java
```