### PR TITLE
Register all ChartJS elements as workaround

### DIFF
--- a/www/js/components/Chart.tsx
+++ b/www/js/components/Chart.tsx
@@ -2,23 +2,12 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { View } from 'react-native';
 import { useTheme } from 'react-native-paper';
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, TimeScale, ChartData, ChartType, ScriptableContext, PointElement, LineElement } from 'chart.js';
+import { Chart as ChartJS, registerables } from 'chart.js';
 import { Chart as ChartJSChart } from 'react-chartjs-2';
 import Annotation, { AnnotationOptions, LabelPosition } from 'chartjs-plugin-annotation';
 import { dedupColors, getChartHeight, darkenOrLighten } from './charting';
 
-ChartJS.register(
-  CategoryScale,
-  LinearScale,
-  TimeScale,
-  BarElement,
-  PointElement,
-  LineElement,
-  Title,
-  Tooltip,
-  Legend,
-  Annotation,
-);
+ChartJS.register(...registerables, Annotation);
 
 type XYPair = { x: number|string, y: number|string };
 type ChartDataset = {


### PR DESCRIPTION
Described in https://github.com/e-mission/e-mission-docs/issues/986#issuecomment-1738074971, we have a production-specific error where the needed ChartJS elements are not recognized as being registered. Likely an incompatibility between ChartJS and Webpack.

As a workaround, we will register all of the `registerables`. Unfortunately, we will no longer benefit from tree-shaking with this approach.