### PR TITLE
Bumped up version for battery optimization integration.

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -127,7 +127,7 @@
     "cordova-plugin-app-version": "0.1.14",
     "cordova-plugin-customurlscheme": "5.0.2",
     "cordova-plugin-device": "2.1.0",
-    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.7.9",
+    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.8.0",
     "cordova-plugin-em-opcodeauth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.7.2",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.6",
     "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.3.2",


### PR DESCRIPTION
Switched `"cordova-plugin-em-datacollection"` in `package.cordovabuild.json` from 1.7.9 to release 1.8.0 to incorporate new battery optimization plugin. 

Extension of this [pull request](https://github.com/e-mission/e-mission-data-collection/pull/209) which has the changes made to data collection. 