### PR TITLE
✓ Updated "Verify Inference" Checkmark

### DIFF
--- a/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
+++ b/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
@@ -101,7 +101,7 @@ const MultilabelButtonGroup = ({ trip, buttonsInline=false }) => {
         })}
       </View>
       {trip.verifiability === 'can-verify' && (
-        <View style={{marginTop:'1rem'}}>
+        <View style={{marginTop: 16}}>
           <IconButton icon='check-bold' mode='outlined' size={18} onPress={verifyTrip}
                        style={{width: 24, height: 24, margin: 3, backgroundColor: colors.secondaryContainer}}/>
         </View>

--- a/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
+++ b/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
@@ -103,7 +103,8 @@ const MultilabelButtonGroup = ({ trip, buttonsInline=false }) => {
       {trip.verifiability === 'can-verify' && (
         <View style={{marginTop: 16}}>
           <IconButton icon='check-bold' mode='outlined' size={18} onPress={verifyTrip}
-                       style={{width: 24, height: 24, margin: 3, backgroundColor: colors.secondaryContainer}}/>
+                      containerColor={colors.secondaryContainer}
+                      style={{width: 24, height: 24, margin: 3, borderColor: colors.secondary}} />
         </View>
       )}
     </View>

--- a/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
+++ b/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
@@ -100,10 +100,10 @@ const MultilabelButtonGroup = ({ trip, buttonsInline=false }) => {
           )
         })}
       </View>
-      <View>
-        <IconButton icon='check-bold' mode='outlined' size={16} onPress={verifyTrip}
+      <View style={{marginTop:'1rem'}}>
+        <IconButton icon='check-bold' mode='outlined' size={18} onPress={verifyTrip}
                     disabled={trip.verifiability != 'can-verify'}
-                    style={{width: 20, height: 20, margin: 3}}/>
+                    style={{width: 24, height: 24, margin: 3}}/>
       </View>
     </View>
     <Modal visible={modalVisibleFor != null} transparent={true} onDismiss={() => dismiss()}>

--- a/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
+++ b/www/js/survey/multilabel/MultiLabelButtonGroup.tsx
@@ -100,11 +100,12 @@ const MultilabelButtonGroup = ({ trip, buttonsInline=false }) => {
           )
         })}
       </View>
-      <View style={{marginTop:'1rem'}}>
-        <IconButton icon='check-bold' mode='outlined' size={18} onPress={verifyTrip}
-                    disabled={trip.verifiability != 'can-verify'}
-                    style={{width: 24, height: 24, margin: 3}}/>
-      </View>
+      {trip.verifiability === 'can-verify' && (
+        <View style={{marginTop:'1rem'}}>
+          <IconButton icon='check-bold' mode='outlined' size={18} onPress={verifyTrip}
+                       style={{width: 24, height: 24, margin: 3, backgroundColor: colors.secondaryContainer}}/>
+        </View>
+      )}
     </View>
     <Modal visible={modalVisibleFor != null} transparent={true} onDismiss={() => dismiss()}>
       <Dialog visible={modalVisibleFor != null} onDismiss={() => dismiss()}>


### PR DESCRIPTION
Work discussed in  [Issue 979](https://github.com/e-mission/e-mission-docs/issues/979) !
- The "verify trip" button now only only appears if both Mode and Purpose have verifiable inferences
- The button has been changed for clarity (centered, larger icon, color matches the verification color)