### PR TITLE
fix permissions popup on 'summary' page; refactor

### DIFF
--- a/www/js/App.tsx
+++ b/www/js/App.tsx
@@ -7,7 +7,7 @@ import MetricsTab from './metrics/MetricsTab';
 import ProfileSettings from './control/ProfileSettings';
 import useAppConfig from './useAppConfig';
 import OnboardingStack from './onboarding/OnboardingStack';
-import { OnboardingState, getPendingOnboardingState } from './onboarding/onboardingHelper';
+import { OnboardingRoute, OnboardingState, getPendingOnboardingState } from './onboarding/onboardingHelper';
 import { setServerConnSettings } from './config/serverConn';
 import AppStatusModal from './control/AppStatusModal';
 
@@ -76,7 +76,9 @@ const App = () => {
       :
         <OnboardingStack />
       }
-      {(pendingOnboardingState == null || pendingOnboardingState.route != 'welcome' && pendingOnboardingState.route != 'consent') &&
+      { /* if onboarding is done (state == null), or if is in progress but we are past the
+        consent page (route > CONSENT), the permissions popup can show if needed */ }
+      {(pendingOnboardingState == null || pendingOnboardingState.route > OnboardingRoute.CONSENT) &&
         <AppStatusModal permitVis={permissionsPopupVis} setPermitVis={setPermissionsPopupVis} />
       }
     </AppContext.Provider>

--- a/www/js/onboarding/OnboardingStack.tsx
+++ b/www/js/onboarding/OnboardingStack.tsx
@@ -6,30 +6,27 @@ import ConsentPage from "./ConsentPage";
 import SurveyPage from "./SurveyPage";
 import SaveQrPage from "./SaveQrPage";
 import SummaryPage from "./SummaryPage";
+import { OnboardingRoute } from "./onboardingHelper";
+import { displayErrorMsg } from "../plugin/logger";
 
-// true if loading/undetermined
-// 'welcome' if no config present
-// 'consent' if config present, but not consented
-// 'survey' if consented but intro not done
-// null if intro done
 const OnboardingStack = () => {
 
   const { pendingOnboardingState } = useContext(AppContext);
 
   console.debug('pendingOnboardingState in OnboardingStack', pendingOnboardingState);
 
-  if (pendingOnboardingState.route == 'welcome') {
+  if (pendingOnboardingState.route == OnboardingRoute.WELCOME) {
     return <WelcomePage />;
-  } else if (pendingOnboardingState.route == 'summary') {
+  } else if (pendingOnboardingState.route == OnboardingRoute.SUMMARY) {
     return <SummaryPage />;
-  } else if (pendingOnboardingState.route == 'consent') {
+  } else if (pendingOnboardingState.route == OnboardingRoute.CONSENT) {
     return <ConsentPage />;
-  } else if (pendingOnboardingState.route == 'save-qr') {
+  } else if (pendingOnboardingState.route == OnboardingRoute.SAVE_QR) {
     return <SaveQrPage />;
-  } else if (pendingOnboardingState.route == 'survey') {
+  } else if (pendingOnboardingState.route == OnboardingRoute.SURVEY) {
     return <SurveyPage />;
   } else {
-    return 'TODO'
+    displayErrorMsg('OnboardingStack: unknown route', pendingOnboardingState.route);
   }
 }
 


### PR DESCRIPTION
https://github.com/e-mission/e-mission-docs/issues/998 Adding the 'summary' page caused a regression in which the permissions popup could appear before the consent page, while the onboarding route is 'summary'. This is because when it was added, I forgot to add it to the conditional statement in App.tsx, line 79.

Semantically we want the routes to be named, but also ordered. So a cleaner way to handle these routes is to declare them as enum values instead of strings.

Behind the scense, TypeScript enums automatically get assigned an integer value (WELCOME=0, SUMMARY=1, etc). This way, to see if a route is past consent or not, we can use `<` and `>` comparisons instead of specifically listing out and checking against different string values.

So, this commit switches over to using `enum` for the onboarding state route and uses `>` in the conditional to ensure that the AppStatusModal can only show if we are past the consent page.

Also tidied up all the code comments around the onboarding states and routes.