### PR TITLE
🐛 Backwards Compat Fix for New Onboarding

### DIFF
--- a/www/js/config/dynamicConfig.ts
+++ b/www/js/config/dynamicConfig.ts
@@ -231,7 +231,7 @@ export function getConfig() {
   if (storedConfig) return Promise.resolve(storedConfig);
   const KVStore = getAngularService('KVStore');
   return KVStore.get(CONFIG_PHONE_UI_KVSTORE).then((config) => {
-    if (config) {
+    if (config && Object.keys(config).length) {
       storedConfig = config;
       return config;
     }

--- a/www/js/onboarding/onboardingHelper.ts
+++ b/www/js/onboarding/onboardingHelper.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { getAngularService } from "../angular-react-helper";
-import { getConfig } from "../config/dynamicConfig";
+import { getConfig, resetDataAndRefresh } from "../config/dynamicConfig";
 
 export const INTRO_DONE_KEY = 'intro_done';
 
@@ -28,6 +28,13 @@ export const setRegisterUserDone = (b) => registerUserDone = b;
 export function getPendingOnboardingState(): Promise<OnboardingState> {
   return Promise.all([getConfig(), readConsented(), readIntroDone()]).then(([config, isConsented, isIntroDone]) => {
     let route: OnboardingRoute;
+
+    // backwards compat - prev. versions might have config cleared but still have intro_done set
+    if (!config && (isIntroDone || isConsented)) {
+      resetDataAndRefresh(); // if there's no config, we need to reset everything
+      return null;
+    }
+    
     if (isIntroDone) {
       route = OnboardingRoute.DONE;
     } else if (!config) {


### PR DESCRIPTION
The old "Logout" functionality cleared the UI config but not other storage keys, such as those for marking consented and marking intro done.
A backwards-compat check is needed: if the UI config is blank but intro done or consented are marked true, we need to clear everything.