### PR TITLE
Use imperial config test

### DIFF
--- a/www/__tests__/useImperialConfig.test.ts
+++ b/www/__tests__/useImperialConfig.test.ts
@@ -14,17 +14,24 @@ jest.mock('../js/useAppConfig', () => {
 describe('formatForDisplay', () => {
   it('should round to the nearest integer when value is >= 100', () => {
     expect(formatForDisplay(105)).toBe('105');
-    expect(formatForDisplay(119)).toBe('119');
+    expect(formatForDisplay(119.01)).toBe('119');
+    expect(formatForDisplay(119.91)).toBe('120');
   });
 
   it('should round to 3 significant digits when 1 <= value < 100', () => {
     expect(formatForDisplay(7.02)).toBe('7.02');
-    expect(formatForDisplay(11.3)).toBe('11.3');
+    expect(formatForDisplay(9.6262)).toBe('9.63');
+    expect(formatForDisplay(11.333)).toBe('11.3');
+    expect(formatForDisplay(99.99)).toBe('100');
   });
 
   it('should round to 2 decimal places when value < 1', () => {
-    expect(formatForDisplay(0.07)).toBe('0.07');
+    expect(formatForDisplay(0.07178)).toBe('0.07');
+    expect(formatForDisplay(0.08978)).toBe('0.09');
     expect(formatForDisplay(0.75)).toBe('0.75');
+    expect(formatForDisplay(0.001)).toBe('0');
+    expect(formatForDisplay(0.006)).toBe('0.01');
+    expect(formatForDisplay(0.00001)).toBe('0');
   });
 });
 

--- a/www/__tests__/useImperialConfig.test.ts
+++ b/www/__tests__/useImperialConfig.test.ts
@@ -1,0 +1,49 @@
+import { convertDistance, convertSpeed, formatForDisplay } from '../js/config/useImperialConfig';
+
+
+// This mock is required, or else the test will dive into the import chain of useAppConfig.ts and fail when it gets to the root
+jest.mock('../js/useAppConfig', () => {
+  return jest.fn(() => ({
+    appConfig: {
+      use_imperial: false
+    },
+    loading: false
+  }));
+});
+  
+describe('formatForDisplay', () => {
+  it('should round to the nearest integer when value is >= 100', () => {
+    expect(formatForDisplay(105)).toBe('105');
+    expect(formatForDisplay(119)).toBe('119');
+  });
+
+  it('should round to 3 significant digits when 1 <= value < 100', () => {
+    expect(formatForDisplay(7.02)).toBe('7.02');
+    expect(formatForDisplay(11.3)).toBe('11.3');
+  });
+
+  it('should round to 2 decimal places when value < 1', () => {
+    expect(formatForDisplay(0.07)).toBe('0.07');
+    expect(formatForDisplay(0.75)).toBe('0.75');
+  });
+});
+
+describe('convertDistance', () => {
+  it('should convert meters to kilometers by default', () => {
+    expect(convertDistance(1000, false)).toBe(1);
+  });
+
+  it('should convert meters to miles when imperial flag is true', () => {
+    expect(convertDistance(1609.34, true)).toBe(1); // Approximately 1 mile
+  });
+});
+
+describe('convertSpeed', () => {
+  it('should convert meters per second to kilometers per hour by default', () => {
+    expect(convertSpeed(10, false)).toBe(36);
+  });
+
+  it('should convert meters per second to miles per hour when imperial flag is true', () => {
+    expect(convertSpeed(6.7056, true)).toBe(15); // Approximately 15 mph
+  });
+});

--- a/www/__tests__/useImperialConfig.test.ts
+++ b/www/__tests__/useImperialConfig.test.ts
@@ -34,7 +34,7 @@ describe('convertDistance', () => {
   });
 
   it('should convert meters to miles when imperial flag is true', () => {
-    expect(convertDistance(1609.34, true)).toBe(1); // Approximately 1 mile
+    expect(convertDistance(1609.34, true)).toBeCloseTo(1); // Approximately 1 mile
   });
 });
 
@@ -44,6 +44,6 @@ describe('convertSpeed', () => {
   });
 
   it('should convert meters per second to miles per hour when imperial flag is true', () => {
-    expect(convertSpeed(6.7056, true)).toBe(15); // Approximately 15 mph
+    expect(convertSpeed(6.7056, true)).toBeCloseTo(15); // Approximately 15 mph
   });
 });

--- a/www/js/config/useImperialConfig.ts
+++ b/www/js/config/useImperialConfig.ts
@@ -24,13 +24,13 @@ export const formatForDisplay = (value: number): string => {
   return Intl.NumberFormat(i18next.language, opts).format(value);
 }
 
-const convertDistance = (distMeters: number, imperial: boolean): number => {
+export const convertDistance = (distMeters: number, imperial: boolean): number => {
   if (imperial)
     return (distMeters / 1000) * KM_TO_MILES;
   return distMeters / 1000;
 }
 
-const convertSpeed = (speedMetersPerSec: number, imperial: boolean): number => {
+export const convertSpeed = (speedMetersPerSec: number, imperial: boolean): number => {
   if (imperial)
     return speedMetersPerSec * MPS_TO_KMPH * KM_TO_MILES;
   return speedMetersPerSec * MPS_TO_KMPH;


### PR DESCRIPTION
useImperialConfig.ts
- Added exports to the functions, so that we can test them _(can't use `export function useImperialConfig()` as it gets caught in invalid React hooks with `useState`)_

useImperialConfig.test.ts
- Using mock of `useAppConfig` so that the testing doesn't terminate by following the chain of import statements within `useAppConfig`
- Added basic testing of the functions

**2 of the tests are failing, as they are not rounding properly**

1:

```
convertSpeed › should convert meters per second to miles per hour when imperial flag is true

    expect(received).toBe(expected) // Object.is equality

    Expected: 15
    Received: 14.99999535936
```

2:
```
convertDistance › should convert meters to miles when imperial flag is true

    expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 0.99999720514
```