### PR TITLE
🌐 i18n: fix merge translations if structure differs

### DIFF
--- a/www/js/i18nextInit.ts
+++ b/www/js/i18nextInit.ts
@@ -22,14 +22,14 @@ const mergeInTranslations = (lang, fallbackLang) => {
       if (__DEV__) {
         if (typeof value === 'string') {
           lang[key] = `🌐${value}`
-        } else if (typeof value === 'object') {
+        } else if (typeof value === 'object' && typeof lang[key] === 'object') {
           lang[key] = {};
           mergeInTranslations(lang[key], value);
         }
       } else {
         lang[key] = value;
       }
-    } else if (typeof value === 'object') {
+    } else if (typeof value === 'object' && typeof lang[key] === 'object') {
       mergeInTranslations(lang[key], fallbackLang[key])
     }
   });


### PR DESCRIPTION
If the structure is different between `lang` and `fallbackLang` such that a key is an object in `fallbackLang` and a string in `lang`, we experience an error when we attempt to assign a property on the string. This change will skip filling in if the key is not an object in *both* `lang` and `fallbackLang`, thus preventing the error.