### PR TITLE
💪 Increase checks for scanned QR code

### DIFF
--- a/www/js/components/QrCode.tsx
+++ b/www/js/components/QrCode.tsx
@@ -35,6 +35,11 @@ export function shareQR(message) {
 }
 
 const QrCode = ({ value, ...rest }) => {
+  let hasLink = value.toString().includes("//");
+  if(!hasLink) {
+    value =  "nrelopenpath://login_token?token=" + value;
+  }
+  
   return <QRCode className="qr-code" value={value} style={[{ width: '100%', height: '100%' }, rest.style] as any} {...rest} />;
 };
 

--- a/www/js/components/QrCode.tsx
+++ b/www/js/components/QrCode.tsx
@@ -37,7 +37,7 @@ export function shareQR(message) {
 const QrCode = ({ value, ...rest }) => {
   let hasLink = value.toString().includes("//");
   if(!hasLink) {
-    value =  "nrelopenpath://login_token?token=" + value;
+    value =  "emission://login_token?token=" + value;
   }
   
   return <QRCode className="qr-code" value={value} style={[{ width: '100%', height: '100%' }, rest.style] as any} {...rest} />;

--- a/www/js/onboarding/WelcomePage.tsx
+++ b/www/js/onboarding/WelcomePage.tsx
@@ -20,12 +20,25 @@ const WelcomePage = () => {
   const [infoPopupVis, setInfoPopupVis] = useState(false);
   const [existingToken, setExistingToken] = useState('');
 
+  const checkURL = function (result) {
+    let notCancelled = result.cancelled == false;
+    let isQR = result.format == "QR_CODE";
+    let hasPrefix = false;
+    if (__DEV__) {
+      hasPrefix = result.text.startsWith("emission");
+    } else {
+      hasPrefix = result.text.startsWith("nrelopenpath");
+    }
+    let hasToken = result.text.includes("login_token?token");
+
+    return notCancelled && isQR && hasPrefix && hasToken;
+  }  
+
   const scanCode = function() {
-    window.cordova.plugins.barcodeScanner.scan(
+    window['cordova'].plugins.barcodeScanner.scan(
       function (result) {
         console.debug("scanned code", result);
-          if (result.format == "QR_CODE" && 
-              result.cancelled == false) {
+          if (checkURL(result)) {
                 let text = result.text.split("=")[1];
                 console.log("found code", text);
               loginWithToken(text);

--- a/www/js/onboarding/WelcomePage.tsx
+++ b/www/js/onboarding/WelcomePage.tsx
@@ -23,7 +23,7 @@ const WelcomePage = () => {
   const checkURL = function (result) {
     let notCancelled = result.cancelled == false;
     let isQR = result.format == "QR_CODE";
-    let hasPrefix = result.text.split(":")[0] == "nrelopenpath" || result.text.split(":")[0] == "emission";
+    let hasPrefix = result.text.split(":")[0] == "emission";
     let hasToken = result.text.includes("login_token?token");
 
     logDebug("QR code " + result.text + " checks: cancel, format, prefix, params " + notCancelled + isQR + hasPrefix + hasToken);

--- a/www/js/onboarding/WelcomePage.tsx
+++ b/www/js/onboarding/WelcomePage.tsx
@@ -5,7 +5,7 @@ import { Button, Dialog, Divider, IconButton, Surface, Text, TextInput, Touchabl
 import color from 'color';
 import { initByUser } from '../config/dynamicConfig';
 import { AppContext } from '../App';
-import { displayError } from "../plugin/logger";
+import { displayError, logDebug } from "../plugin/logger";
 import { onboardingStyles } from './OnboardingStack';
 import { Icon } from '../components/Icon';
 
@@ -23,13 +23,10 @@ const WelcomePage = () => {
   const checkURL = function (result) {
     let notCancelled = result.cancelled == false;
     let isQR = result.format == "QR_CODE";
-    let hasPrefix = false;
-    if (__DEV__) {
-      hasPrefix = result.text.startsWith("emission");
-    } else {
-      hasPrefix = result.text.startsWith("nrelopenpath");
-    }
+    let hasPrefix = result.text.split(":")[0] == "nrelopenpath" || result.text.split(":")[0] == "emission";
     let hasToken = result.text.includes("login_token?token");
+
+    logDebug("QR code " + result.text + " checks: cancel, format, prefix, params " + notCancelled + isQR + hasPrefix + hasToken);
 
     return notCancelled && isQR && hasPrefix && hasToken;
   }  


### PR DESCRIPTION
In order to ensure that only valid users are created, we need to make sure that the qr codes that are scanned: are QR codes, have not been canceled, start with the appropriate prefix (either emission or nrelopenpath), and include a token parameter. 

This way, after we scan into the app, we are sure that the user has scanned the right thing and will have a valid opcode. Later in the login process, we check the opcode for validity. 

I still need to test this with a physical phone before it can be merged, which I plan to do tonight. 