### PR TITLE
🐛 Fix Edit Collection Settings

### DIFF
--- a/www/js/control/ProfileSettings.jsx
+++ b/www/js/control/ProfileSettings.jsx
@@ -42,7 +42,7 @@ const ProfileSettings = () => {
     const StartPrefs = getAngularService('StartPrefs');
 
     //functions that come directly from an Angular service
-    const editCollectionConfig = () => setEditCollection(true);
+    const editCollectionConfig = () => setEditCollectionVis(true);
     const editSyncConfig = () => setEditSync(true);
 
     //states and variables used to control/create the settings


### PR DESCRIPTION
When I updated the name of this visibility state, I did not update its setter 🤦‍♀️ . This caused the popup to fail to launch. I have now tested in the emulator, and the popup does launch. See [5386a2d](https://github.com/e-mission/e-mission-phone/pull/1076/commits/5386a2dc651079f4e0e1139a57531d7b4cb76341) for the commit where I made this mistake