### PR TITLE
Remove moped

### DIFF
--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -158,7 +158,6 @@
         "hybrid_shared_ride": "Hybrid Shared Ride",
         "e_car_drove_alone": "E-Car Drove Alone",
         "e_car_shared_ride": "E-Car Shared Ride",
-        "moped": "Moped",
         "taxi": "Taxi / Uber / Lyft",
         "bus": "Bus",
         "train": "Train",

--- a/www/json/label-options.json.sample
+++ b/www/json/label-options.json.sample
@@ -11,7 +11,6 @@
     {"value":"hybrid_shared_ride", "baseMode":"CAR", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.0635},
     {"value":"e_car_drove_alone", "baseMode":"E_CAR", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.08216},
     {"value":"e_car_shared_ride", "baseMode":"E_CAR", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.04108},
-    {"value":"moped", "baseMode":"MOPED", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.05555},
     {"value":"taxi", "baseMode":"TAXI", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.30741},
     {"value":"bus", "baseMode":"BUS", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.20727},
     {"value":"train", "baseMode":"TRAIN", "met_equivalent":"IN_VEHICLE", "kgCo2PerKm": 0.12256},


### PR DESCRIPTION
Removed moped from `en.json` and the default `label-options.json.sample` files

In response to @shankari and @Abby-Wheelis in https://github.com/e-mission/e-mission-docs/issues/1013#issuecomment-1787627109