### PR TITLE
Remove html files from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,9 @@ www/dist
 www/manual_lib
 www/json
 
+# Ignore all HTML files:
+**/*.html
+
 # This is the pattern to check only www directory
 # Ignore all
 /*

--- a/www/index.html
+++ b/www/index.html
@@ -1,22 +1,18 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no, width=device-width, viewport-fit=cover" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self' data: gap: https://ssl.gstatic.com https://api.ionicjs.com https://pro-deploy.ionicjs.com https://nominatim.openstreetmap.org https://raw.githubusercontent.com emission: 'unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' https://tile.openstreetmap.org 'unsafe-inline' data: 'unsafe-eval'" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no, width=device-width, viewport-fit=cover">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com https://api.ionicjs.com https://pro-deploy.ionicjs.com https://nominatim.openstreetmap.org https://raw.githubusercontent.com emission: 'unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' https://tile.openstreetmap.org 'unsafe-inline' data: 'unsafe-eval'">
     <title></title>
-
+ 
     <!-- cordova script (this will be a 404 in the browser) -->
     <script type="text/javascript" src="cordova.js"></script>
   </head>
-
+ 
   <body ng-app="emission">
     <!-- <ion-nav-view></ion-nav-view> -->
-    <div id="appRoot" class="fill-container" style="width: 100vw; height: 100vh"></div>
+    <div id="appRoot" class="fill-container" style="width: 100vw; height: 100vh;"></div>
   </body>
   <script src="dist/bundle.js"></script>
 </html>


### PR DESCRIPTION
#### I found that `prettier` sometimes formats `html` files improperly.

I found that the `appzip` API failed after the HTML formatting changed, and the reason was that `prettier` changed the HTML file improperly.

Here is a screenshot:
![Screenshot](https://github.com/e-mission/e-mission-phone/assets/47590587/f4f5452e-5bab-46a0-87eb-5302f640d2af) 

For these reasons, I reverted the HTML file and made `prettier` ignore all `HTML` files.

You can find the related issue here: [https://github.com/prettier/prettier-vscode/issues/646](https://github.com/prettier/prettier-vscode/issues/646)