### PR TITLE
Change timeout for React Component test from 5s to 15s

### DIFF
--- a/www/__tests__/LoadMoreButton.test.tsx
+++ b/www/__tests__/LoadMoreButton.test.tsx
@@ -11,13 +11,15 @@ describe('LoadMoreButton', () => {
     await waitFor(() => {
       expect(screen.getByTestId('load-button')).toBeTruthy();
     });
-  });
+  }, 15000);
 
-  it('calls onPressFn when clicked', () => {
+  it('calls onPressFn when clicked', async () => {
     const mockFn = jest.fn();
     const { getByTestId } = render(<LoadMoreButton onPressFn={mockFn}>{}</LoadMoreButton>);
     const loadButton = getByTestId('load-button');
     fireEvent.press(loadButton);
-    expect(mockFn).toHaveBeenCalled();
-  });
+    await waitFor(() => {
+      expect(mockFn).toHaveBeenCalled();
+    });
+  }, 15000);
 });


### PR DESCRIPTION
## Change timeout for React Component test from 5s to 15s

### Why the test fails on GitHub Actions Environment

The test fails with the message `Exceeded timeout of 5000 ms for a test` in the GitHub Actions environment. In Jest, the default test timeout is 5 seconds, which might be too short for React component testing. I guess this could happen in component tests where we trigger actions, render components, and check if the component exists or if the function gets called. 

### What is changed to fix this issue

During our regular meeting, we reached an agreement to extend the timeout from **5 seconds** to **15 seconds**.

We will further discuss how to handle this issue, especially considering that as we write more component tests, this issue may arise again.

For more details, refer to [Jest documentation](https://jestjs.io/docs/api#afterallfn-timeout).