### PR TITLE
Run Codecov Workflow only when PR is ready

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,34 @@
+name: code coverage
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  run-codecov:
+    if: github.event.pull_request.draft == false
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "21"
+
+      - name: Install dependencies
+        run: npm install jest
+
+      - name: Run Jest tests
+        run: npm run test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage/coverage-final.json
+          flags: unit
+          fail_ci_if_error: ${{ github.repository == 'e-mission/e-mission-phone' }}
+          

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -20,10 +20,13 @@ jobs:
           node-version: "21"
 
       - name: Install dependencies
+        shell: bash -l {0}
         run: npm install jest
 
       - name: Run Jest tests
-        run: npm run test
+        shell: bash -l {0}
+        run: |
+          npx jest
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,16 +12,10 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "21"
-
-      - name: Install dependencies
+      - name: Setup the serve environment
         shell: bash -l {0}
-        run: npm install jest
+        run: |
+          bash setup/setup_serve.sh
 
       - name: Run Jest tests
         shell: bash -l {0}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
       - name: Setup the serve environment
         shell: bash -l {0}
         run: |
@@ -20,6 +23,7 @@ jobs:
       - name: Run Jest tests
         shell: bash -l {0}
         run: |
+          source setup/activate_serve.sh
           npx jest
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/serve-install.yml
+++ b/.github/workflows/serve-install.yml
@@ -64,13 +64,6 @@ jobs:
       run: |
         npx jest
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./coverage/coverage-final.json
-        flags: unit
-        fail_ci_if_error: ${{ github.repository == 'e-mission/e-mission-phone' }}
-
 # TODO: figure out how to check that a server started correctly
 #    - name: Try starting it
 #      run: npx run serve

--- a/.github/workflows/serve-install.yml
+++ b/.github/workflows/serve-install.yml
@@ -59,11 +59,6 @@ jobs:
         echo "ionic version"
         npx ionic --version
 
-    - name: Run Jest tests
-      shell: bash -l {0}
-      run: |
-        npx jest
-
 # TODO: figure out how to check that a server started correctly
 #    - name: Try starting it
 #      run: npx run serve


### PR DESCRIPTION
### Why Change the Workflow?

Sending a coverage report to `Codecov` with GitHub Action without a token encounters a **rate limit** issue. For more details, please refer to the comments on issue #1085.

In the current flow, the `Codecov` workflow runs whenever we push code to PR. To address the rate limit issue, we have decided to run the workflow only when we are **ready for review**.

### When PR is **draft**
<img width="864" alt="Screenshot 2023-12-05 at 2 27 51 PM" src="https://github.com/e-mission/e-mission-phone/assets/47590587/3604a286-b51f-4e70-8cba-37b43ddcd326">
