### PR TITLE
Use specific prettier version

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npx prettier --check www
+      - run: npx prettier@3.0.3 --check www
+      
       

--- a/setup/setup_ios_native.sh
+++ b/setup/setup_ios_native.sh
@@ -7,14 +7,32 @@ source setup/setup_shared.sh
 OSX_MAJOR_VERSION=`sw_vers | grep ProductVersion | cut -d ':' -f 2 | cut -d '.' -f 1`
 echo "Found OSX major version" $OSX_MAJOR_VERSION
 
+# The Homebrew pac-man is installed in different locations, depending on whether the processor
+# is an Intel or Apple Silicone chip.  Intel uses x86_64, Apple chips are amd64, so we can
+# check the chip type using these hardware platforms.
+CHIP_ARC=`uname -m`
+INTEL="x86_64"
+APPLE_SILICONE="arm64"
+WORKING_DIR=""
+
+if [ $CHIP_ARC == $INTEL ]; then
+    echo "Found "$INTEL" chip"
+    WORKING_DIR="/usr/local/"
+else 
+    if [ $CHIP_ARC == $APPLE_SILICONE ]; then
+        echo "Found "$APPLE_SILICONE" chip"
+        WORKING_DIR="/opt/homebrew/"
+    fi
+fi
+
 CURR_RUBY_VERSION=`ruby --version | cut -d ' ' -f 2 | cut -d '.' -f 1-2`
 echo "Found ruby version "$CURR_RUBY_VERSION
 
 if [ $CURR_RUBY_VERSION == $RUBY_VERSION ]; then
     echo "Found ruby version "$CURR_RUBY_VERSION" expected "$RUBY_VERSION" no need to upgrade"
 else
-    if [ -x /usr/local/bin/brew ]; then
-        echo "Found brew installation with version" `/usr/local/bin/brew --version`
+    if [ -x "${WORKING_DIR}/bin/brew" ]; then 
+        echo "Found brew installation with version" ` brew --version`
         echo "Installing ruby version to brew" $RUBY_VERSION
         brew install ruby@$RUBY_VERSION
     else
@@ -32,6 +50,6 @@ echo "Adding $RUBY_PATH to the path before the install"
 export PATH=$RUBY_PATH:$PATH
 
 echo "Installing cocoapods"
-/usr/local/opt/ruby@$RUBY_VERSION/bin/gem install --no-document --user-install cocoapods -v $COCOAPODS_VERSION
+${WORKING_DIR}/opt/ruby@$RUBY_VERSION/bin/gem install --no-document --user-install cocoapods -v $COCOAPODS_VERSION
 
 source setup/setup_shared_native.sh


### PR DESCRIPTION
### Background
`Prettier` failed on the [UI Migration Wrap-up PR](https://github.com/e-mission/e-mission-phone/pull/1106), and we discovered that it uses the latest Prettier version on GitHub Actions but version 3.0.3 in the project. Therefore, we have decided to stick with the specific version (3.0.3) to prevent this issue from occurring again.

<br />
<br />

<img width="691" alt="Screenshot 2023-12-12 at 8 05 29 PM" src="https://github.com/e-mission/e-mission-phone/assets/47590587/216147c3-b7d8-498f-9d40-207d2f120bd7">
