### PR TITLE
🚑 Fix Processed Trip Survey Responses Not Matching

### DIFF
--- a/www/js/survey/inputMatcher.ts
+++ b/www/js/survey/inputMatcher.ts
@@ -2,7 +2,7 @@ import { logDebug, displayErrorMsg } from '../plugin/logger';
 import { DateTime } from 'luxon';
 import { CompositeTrip, ConfirmedPlace, TimelineEntry, UserInputEntry } from '../types/diaryTypes';
 import { keysForLabelInputs, unprocessedLabels, unprocessedNotes } from '../diary/timelineHelper';
-import { getLabelInputDetails, inputType2retKey } from './multilabel/confirmHelper';
+import { getLabelInputDetails, inputType2retKey, removeManualPrefix } from './multilabel/confirmHelper';
 import { TimelineLabelMap, TimelineNotesMap } from '../diary/LabelTabContext';
 import { MultilabelKey } from '../types/labelTypes';
 import { EnketoUserInputEntry } from './enketo/enketoHelper';
@@ -281,7 +281,8 @@ export function mapInputsToTimelineEntries(
         timelineLabelMap[tlEntry._id.$oid] = { SURVEY: userInputForTrip };
       } else {
         let processedSurveyResponse;
-        for (const key of keysForLabelInputs(appConfig)) {
+        for (const dataKey of keysForLabelInputs(appConfig)) {
+          const key = removeManualPrefix(dataKey);
           if (tlEntry.user_input?.[key]) {
             processedSurveyResponse = tlEntry.user_input[key];
             break;

--- a/www/js/survey/inputMatcher.ts
+++ b/www/js/survey/inputMatcher.ts
@@ -2,7 +2,11 @@ import { logDebug, displayErrorMsg } from '../plugin/logger';
 import { DateTime } from 'luxon';
 import { CompositeTrip, ConfirmedPlace, TimelineEntry, UserInputEntry } from '../types/diaryTypes';
 import { keysForLabelInputs, unprocessedLabels, unprocessedNotes } from '../diary/timelineHelper';
-import { getLabelInputDetails, inputType2retKey, removeManualPrefix } from './multilabel/confirmHelper';
+import {
+  getLabelInputDetails,
+  inputType2retKey,
+  removeManualPrefix,
+} from './multilabel/confirmHelper';
 import { TimelineLabelMap, TimelineNotesMap } from '../diary/LabelTabContext';
 import { MultilabelKey } from '../types/labelTypes';
 import { EnketoUserInputEntry } from './enketo/enketoHelper';

--- a/www/js/survey/inputMatcher.ts
+++ b/www/js/survey/inputMatcher.ts
@@ -298,7 +298,7 @@ export function mapInputsToTimelineEntries(
       // MULTILABEL configuration: use the label inputs from the labelOptions to determine which
       // keys to look for in the unprocessedInputs
       const labelsForTrip: { [k: string]: UserInputEntry | undefined } = {};
-      Object.keys(getLabelInputDetails()).forEach((label: MultilabelKey) => {
+      Object.keys(getLabelInputDetails(appConfig)).forEach((label: MultilabelKey) => {
         // Check unprocessed labels first since they are more recent
         const userInputForTrip = getUserInputForTimelineEntry(
           tlEntry,

--- a/www/js/survey/multilabel/confirmHelper.ts
+++ b/www/js/survey/multilabel/confirmHelper.ts
@@ -137,8 +137,11 @@ export const getFakeEntry = (otherValue): Partial<LabelOption> | undefined => {
 export const labelKeyToRichMode = (labelKey: string) =>
   labelOptionByValue(labelKey, 'MODE')?.text || labelKeyToReadable(labelKey);
 
-/* manual/mode_confirm becomes mode_confirm */
-export const inputType2retKey = (inputType) => getLabelInputDetails()[inputType].key.split('/')[1];
+/** @description e.g. manual/mode_confirm becomes mode_confirm */
+export const removeManualPrefix = (key: string) => key.split('/')[1];
+/** @description e.g. 'MODE' gets looked up, its key is 'manual/mode_confirm'. Returns without prefix as 'mode_confirm' */
+export const inputType2retKey = (inputType: string) =>
+  removeManualPrefix(getLabelInputDetails()[inputType].key);
 
 export function verifiabilityForTrip(trip: CompositeTrip, userInputForTrip?: UserInputMap) {
   let allConfirmed = true;


### PR DESCRIPTION
Processed responses for user input surveys were not being matched because they were being looked up under "manual/trip_user_input", while it should have just been "trip_user_input". This is because we were only invoking a function to trim off "manual/" for MULTILABEL user input matching, and it was neglected for ENKETO.

Revise the functions in confirmHelper (keeping 2 versions, `removeManualPrefix` which just trims the key, and `inputType2retKey` which looks up the key and then trims), and use `removeManualPrefix` in inputMatcher appropriately

Some day we can unify the data model (https://github.com/e-mission/e-mission-docs/issues/1045) and not keep 2 versions of so many things