### PR TITLE
📝 Conditional Surveys depending on trip characteristics

### DIFF
--- a/www/js/survey/enketo/conditionalSurveys.ts
+++ b/www/js/survey/enketo/conditionalSurveys.ts
@@ -32,7 +32,7 @@ export function getSurveyForTimelineEntry(
   for (let surveyConfig of tripLabelConfig) {
     if (!surveyConfig.showsIf) return surveyConfig; // survey shows unconditionally
     const scope = {
-      tlEntry,
+      ...tlEntry,
       ...conditionalSurveyFunctions,
     };
     try {

--- a/www/js/survey/enketo/conditionalSurveys.ts
+++ b/www/js/survey/enketo/conditionalSurveys.ts
@@ -1,14 +1,21 @@
 import { displayError } from '../../plugin/logger';
 import { SurveyButtonConfig } from '../../types/appConfigTypes';
 import { TimelineEntry } from '../../types/diaryTypes';
+import { Position } from 'geojson';
 
 const conditionalSurveyFunctions = {
-  pointIsWithinBounds: (pt: [number, number], bounds: [[number, number], [number, number]]) => {
-    // pt is [lat, lon] and bounds is NW and SE corners as [[lat, lon], [lat, lon]]
-    // pt's lat must be south of, or less than, NW's lat; and north of, or greater than, SE's lat
+  /**
+  @description Returns true if the given point is within the given bounds.
+    Coordinates are in [longitude, latitude] order, since that is the GeoJSON spec.
+  @param pt point to check as [lon, lat]
+  @param bounds NW and SE corners as [[lon, lat], [lon, lat]] 
+  @returns true if pt is within bounds
+  */
+  pointIsWithinBounds: (pt: Position, bounds: Position[]) => {
     // pt's lon must be east of, or greater than, NW's lon; and west of, or less than, SE's lon
-    const latInRange = pt[0] < bounds[0][0] && pt[0] > bounds[1][0];
-    const lonInRange = pt[1] > bounds[0][1] && pt[1] < bounds[1][1];
+    const lonInRange = pt[0] > bounds[0][0] && pt[0] < bounds[1][0];
+    // pt's lat must be south of, or less than, NW's lat; and north of, or greater than, SE's lat
+    const latInRange = pt[1] < bounds[0][1] && pt[1] > bounds[1][1];
     return latInRange && lonInRange;
   },
 };

--- a/www/js/survey/enketo/conditionalSurveys.ts
+++ b/www/js/survey/enketo/conditionalSurveys.ts
@@ -18,7 +18,7 @@ const conditionalSurveyFunctions = {
  * @example scopedEval('console.log(foo)', { foo: 'bar' })
  */
 const scopedEval = (script: string, scope: { [k: string]: any }) =>
-  Function(...Object.keys(scope), script)(...Object.values(scope));
+  Function(...Object.keys(scope), `return ${script}`)(...Object.values(scope));
 
 // the first survey in the list that passes its condition will be returned
 export function getSurveyForTimelineEntry(

--- a/www/js/survey/enketo/conditionalSurveys.ts
+++ b/www/js/survey/enketo/conditionalSurveys.ts
@@ -1,0 +1,47 @@
+import { displayError } from '../../plugin/logger';
+import { SurveyButtonConfig } from '../../types/appConfigTypes';
+import { TimelineEntry } from '../../types/diaryTypes';
+
+const conditionalSurveyFunctions = {
+  pointIsWithinBounds: (pt: [number, number], bounds: [[number, number], [number, number]]) => {
+    // pt is [lat, lon] and bounds is NW and SE corners as [[lat, lon], [lat, lon]]
+    // pt's lat must be south of, or less than, NW's lat; and north of, or greater than, SE's lat
+    // pt's lon must be east of, or greater than, NW's lon; and west of, or less than, SE's lon
+    const latInRange = pt[0] < bounds[0][0] && pt[0] > bounds[1][0];
+    const lonInRange = pt[1] > bounds[0][1] && pt[1] < bounds[1][1];
+    return latInRange && lonInRange;
+  },
+};
+
+/**
+ * @description Executes a JS expression `script` in a restricted `scope`
+ * @example scopedEval('console.log(foo)', { foo: 'bar' })
+ */
+const scopedEval = (script: string, scope: { [k: string]: any }) =>
+  Function(...Object.keys(scope), script)(...Object.values(scope));
+
+// the first survey in the list that passes its condition will be returned
+export function getSurveyForTimelineEntry(
+  tripLabelConfig: SurveyButtonConfig | SurveyButtonConfig[],
+  tlEntry: TimelineEntry,
+) {
+  // if only one survey is given, just return it
+  if (!(tripLabelConfig instanceof Array)) return tripLabelConfig;
+  if (tripLabelConfig.length == 1) return tripLabelConfig[0];
+  // else we have an array of possible surveys, we need to find which one to use for this entry
+  for (let surveyConfig of tripLabelConfig) {
+    if (!surveyConfig.showsIf) return surveyConfig; // survey shows unconditionally
+    const scope = {
+      tlEntry,
+      ...conditionalSurveyFunctions,
+    };
+    try {
+      const evalResult = scopedEval(surveyConfig.showsIf, scope);
+      if (evalResult) return surveyConfig;
+    } catch (e) {
+      displayError(e, `Error evaluating survey condition "${surveyConfig.showsIf}"`);
+    }
+  }
+  // TODO if none of the surveys passed conditions?? should we return null, throw error, or return a default?
+  return null;
+}

--- a/www/js/types/appConfigTypes.ts
+++ b/www/js/types/appConfigTypes.ts
@@ -7,7 +7,7 @@ export type AppConfig = {
   survey_info: {
     'trip-labels': 'MULTILABEL' | 'ENKETO';
     surveys: EnketoSurveyConfig;
-    buttons?: any;
+    buttons?: SurveyButtonsConfig;
   };
   reminderSchemes?: ReminderSchemesConfig;
   [k: string]: any; // TODO fill in all the other fields
@@ -42,6 +42,19 @@ export type EnketoSurveyConfig = {
     compatibleWith: number;
     dataKey?: string;
   };
+};
+
+export type SurveyButtonConfig = {
+  surveyName: string;
+  'not-filled-in-label': {
+    [lang: string]: string;
+  };
+  showsIf: string; // a JS expression that evaluates to a boolean
+};
+export type SurveyButtonsConfig = {
+  [k in 'trip-label' | 'trip-notes' | 'place-label' | 'place-notes']:
+    | SurveyButtonConfig
+    | SurveyButtonConfig[];
 };
 
 export type ReminderSchemesConfig = {


### PR DESCRIPTION
We plan to support a conditional approach to surveys: depending on characteristics of the trip / timelineEntry, it may prompt for one survey or another. This involves rearranging UserInputButton so that the survey name is not hardcoded as "TripConfirmSurvey". Instead, survey names and button labels will be pulled from the config. Each survey that could show conditionally has a `showsIf` field, which is evaluated at runtime in conditionalSurveys.ts. The first survey whose condition matches is the one that is used for that timelineEntry.

This is a draft, and I don't expect it to work as-is, but it should serve as an outline to the planned approach