### PR TITLE
🩹 fix crash on updatePrefReminderTime

### DIFF
--- a/www/js/control/ProfileSettings.tsx
+++ b/www/js/control/ProfileSettings.tsx
@@ -297,10 +297,10 @@ const ProfileSettings = () => {
     if (!uiConfig?.reminderSchemes)
       return logWarn('In updatePrefReminderTime, no reminderSchemes yet, skipping');
     if (storeNewVal) {
-      const m = DateTime.fromISO(newTime);
+      const dt = DateTime.fromJSDate(newTime);
       // store in HH:mm
       setReminderPrefs(
-        { reminder_time_of_day: m.toFormat('HH:mm') },
+        { reminder_time_of_day: dt.toFormat('HH:mm') },
         uiConfig.reminderSchemes,
         isScheduling,
         setIsScheduling,

--- a/www/js/splash/notifScheduler.ts
+++ b/www/js/splash/notifScheduler.ts
@@ -24,7 +24,11 @@ const calcNotifTimes = (scheme, dayZeroDate, timeOfDay): DateTime[] => {
         .plus({ days: d })
         .toFormat('yyyy-MM-dd');
       const notifTime = DateTime.fromFormat(date + ' ' + timeOfDay, 'yyyy-MM-dd HH:mm');
-      notifTimes.push(notifTime);
+      if (notifTime.isValid) {
+        notifTimes.push(notifTime);
+      } else {
+        displayErrorMsg('Cannot schedule notifs with invalid time of day: ' + timeOfDay);
+      }
     }
   }
   return notifTimes;


### PR DESCRIPTION
If user updates the "Time of Day for Reminders", it will store as "Invalid DateTime" and cause a crash.
<img src=https://github.com/e-mission/e-mission-phone/assets/15843932/4ba73c29-089a-4dbb-93e0-d51bee7981bd width=330>

> `newTime` here is not an ISO string; it is a JavaScript Date object. Attempting to parse it as an ISO string results in "Invalid DateTime" being stored to the user prefs and a crash on the Profile screen

This fix ensures that the selected time will be stored, and "Invalid DateTime" will not get stored.

But if any user had already encountered this, and "Invalid DateTime" was already stored to their profile, they would still not be able to access the Profile screen without it crashing.

So the second change makes sure `notifScheduler` only attempts to schedule notifications if the datetime is valid.
If not valid, user will see this popup:

<img src=https://github.com/e-mission/e-mission-phone/assets/15843932/47bffc56-2526-4c92-aef9-b60499957987 width=330>

After dismissing the popup, they can change their "Time of Day for Reminders" and it will set correctly this time