### PR TITLE
Fix blank screen issue when scrolling on trip list

### DIFF
--- a/www/js/components/LeafletView.tsx
+++ b/www/js/components/LeafletView.tsx
@@ -7,6 +7,15 @@ import { GeoJSONData, GeoJSONStyledFeature } from '../types/diaryTypes';
 const mapSet = new Set<any>();
 const cachedLeafletMap = new Map();
 
+// open the URL in the system browser & prevent any other effects of the click event
+window['launchURL'] = (url, event) => {
+  window['cordova'].InAppBrowser.open(url, '_system');
+  event.stopPropagation();
+  return false;
+};
+const osmURL = 'http://www.openstreetmap.org/copyright';
+const leafletURL = 'https://leafletjs.com';
+
 export function invalidateMaps() {
   mapSet.forEach((map) => map.invalidateSize());
 }
@@ -26,8 +35,11 @@ const LeafletView = ({ geojson, opts, downscaleTiles, ...otherProps }: Props) =>
   const [isMapReady, setIsMapReady] = useState(false);
 
   function initMap(map: LeafletMap) {
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    map.attributionControl?.setPrefix(
+      `<a href="#" onClick="launchURL('${leafletURL}', event)">Leaflet</a>`,
+    );
+    const tileLayer = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: `&copy; <a href="#" onClick="launchURL('${osmURL}', event)">OpenStreetMap</a>`,
       opacity: 1,
       detectRetina: !downscaleTiles,
     }).addTo(map);

--- a/www/js/components/LeafletView.tsx
+++ b/www/js/components/LeafletView.tsx
@@ -12,7 +12,7 @@ export function invalidateMaps() {
   mapSet.forEach((map) => map.invalidateSize());
 }
 
-const LeafletView = ({ geojson, opts, ...otherProps }) => {
+const LeafletView = ({ geojson, opts, downscaleTiles, ...otherProps }: Props) => {
   const mapElRef = useRef<HTMLDivElement | null>(null);
   const leafletMapRef = useRef<LeafletMap | null>(null);
   const geoJsonIdRef = useRef(null);
@@ -25,7 +25,7 @@ const LeafletView = ({ geojson, opts, ...otherProps }) => {
     L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       opacity: 1,
-      detectRetina: true,
+      detectRetina: !downscaleTiles,
     }).addTo(map);
     const gj = L.geoJson(geojson.data, {
       pointToLayer: pointToLayer,

--- a/www/js/components/LeafletView.tsx
+++ b/www/js/components/LeafletView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View } from 'react-native';
+import { View, ViewProps } from 'react-native';
 import { useTheme } from 'react-native-paper';
 import L, { Map as LeafletMap } from 'leaflet';
-import { GeoJSONStyledFeature } from '../types/diaryTypes';
+import { GeoJSONData, GeoJSONStyledFeature } from '../types/diaryTypes';
 import parse from 'html-react-parser';
 
 const mapSet = new Set<any>();
@@ -12,10 +12,15 @@ export function invalidateMaps() {
   mapSet.forEach((map) => map.invalidateSize());
 }
 
+type Props = ViewProps & {
+  geojson: GeoJSONData;
+  opts?: L.MapOptions;
+  downscaleTiles?: boolean;
+};
 const LeafletView = ({ geojson, opts, downscaleTiles, ...otherProps }: Props) => {
   const mapElRef = useRef<HTMLDivElement | null>(null);
   const leafletMapRef = useRef<LeafletMap | null>(null);
-  const geoJsonIdRef = useRef(null);
+  const geoJsonIdRef = useRef<string | null>(null);
   const { colors } = useTheme();
   // non-alphanumeric characters are not safe for element IDs
   const mapElId = `map-${geojson.data.id.replace(/[^a-zA-Z0-9]/g, '')}`;

--- a/www/js/components/useLeafletCache.ts
+++ b/www/js/components/useLeafletCache.ts
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+export default function useLeafletCache() {
+  const [cachedMaps, setCachedMaps] = useState(new Map());
+
+  return {
+    has: (key: string) => cachedMaps.has(key),
+    get: (key: string) => cachedMaps.get(key),
+    set: (key: string, value: any) => setCachedMaps((prev) => new Map(prev.set(key, value))),
+  };
+}

--- a/www/js/diary/cards/TripCard.tsx
+++ b/www/js/diary/cards/TripCard.tsx
@@ -26,8 +26,8 @@ import { useGeojsonForTrip } from '../timelineHelper';
 import { CompositeTrip } from '../../types/diaryTypes';
 import { EnketoUserInputEntry } from '../../survey/enketo/enketoHelper';
 
-type Props = { trip: CompositeTrip };
-const TripCard = ({ trip }: Props) => {
+type Props = { trip: CompositeTrip; isFirstInList?: boolean };
+const TripCard = ({ trip, isFirstInList }: Props) => {
   const { t } = useTranslation();
   const { width: windowWidth } = useWindowDimensions();
   const appConfig = useAppConfig();
@@ -54,7 +54,7 @@ const TripCard = ({ trip }: Props) => {
     navigation.navigate('label.details', { tripId, flavoredTheme });
   }
 
-  const mapOpts = { zoomControl: false, dragging: false };
+  const mapOpts = { attributionControl: isFirstInList, zoomControl: false, dragging: false };
   const showAddNoteButton = appConfig?.survey_info?.buttons?.['trip-notes'];
   const mapStyle = showAddNoteButton ? s.shortenedMap : s.fullHeightMap;
   return (

--- a/www/js/diary/cards/TripCard.tsx
+++ b/www/js/diary/cards/TripCard.tsx
@@ -113,14 +113,16 @@ const TripCard = ({ trip }: Props) => {
         </View>
         <View style={{ flex: 1, paddingBottom: showAddNoteButton ? 8 : 0 }}>
           {/* left panel */}
-          <LeafletView
-            geojson={tripGeojson}
-            opts={mapOpts}
-            downscaleTiles={true}
-            /* the map should be at least as tall as it is wide
+          {tripGeojson && (
+            <LeafletView
+              geojson={tripGeojson}
+              opts={mapOpts}
+              downscaleTiles={true}
+              /* the map should be at least as tall as it is wide
                           so it doesn't look squished */
-            style={[{ minHeight: windowWidth / 2 }, mapStyle]}
-          />
+              style={[{ minHeight: windowWidth / 2 }, mapStyle]}
+            />
+          )}
           <ModesIndicator trip={trip} detectedModes={detectedModes} />
           {showAddNoteButton && (
             <View style={cardStyles.notesButton}>

--- a/www/js/diary/cards/TripCard.tsx
+++ b/www/js/diary/cards/TripCard.tsx
@@ -118,6 +118,7 @@ const TripCard = ({ trip, isFirstInList }: Props) => {
               geojson={tripGeojson}
               opts={mapOpts}
               downscaleTiles={true}
+              cacheHtml={true}
               /* the map should be at least as tall as it is wide
                           so it doesn't look squished */
               style={[{ minHeight: windowWidth / 2 }, mapStyle]}

--- a/www/js/diary/cards/TripCard.tsx
+++ b/www/js/diary/cards/TripCard.tsx
@@ -116,6 +116,7 @@ const TripCard = ({ trip }: Props) => {
           <LeafletView
             geojson={tripGeojson}
             opts={mapOpts}
+            downscaleTiles={true}
             /* the map should be at least as tall as it is wide
                           so it doesn't look squished */
             style={[{ minHeight: windowWidth / 2 }, mapStyle]}

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -9,9 +9,9 @@ import LoadMoreButton from './LoadMoreButton';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../../components/Icon';
 
-const renderCard = ({ item: listEntry }) => {
+const renderCard = ({ item: listEntry, index }) => {
   if (listEntry.origin_key.includes('trip')) {
-    return <TripCard trip={listEntry} />;
+    return <TripCard trip={listEntry} isFirstInList={index == 0} />;
   } else if (listEntry.origin_key.includes('place')) {
     return <PlaceCard place={listEntry} />;
   } else if (listEntry.origin_key.includes('untracked')) {

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -110,7 +110,6 @@ const TimelineScrollList = ({
             is the least intrusive way I've found to trigger a layout change.
           It basically just jiggles the element so it doesn't blank out. */
         onContentSizeChange={() => {
-          console.debug('TimelineScrollList onContentSizeChange');
           const list = document.getElementById('timelineScrollList');
           list?.style.setProperty('margin-right', '1px');
           setTimeout(() => {

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -97,6 +97,25 @@ const TimelineScrollList = ({
         }
         ListFooterComponent={isLoading == 'prepend' ? smallSpinner : footer}
         ItemSeparatorComponent={separator}
+        /* Percent of viewport that must be covered for a partially occluded item to count as "viewable", 0-100.
+        a single pixel in the viewport makes the item viewable */
+        viewabilityConfig={{
+          viewAreaCoveragePercentThreshold: 0,
+          itemVisiblePercentThreshold: 0,
+          waitForInteraction: false,
+        }}
+        // 'getItemType' prop is used when FlashList has different types of cell components and these are vastly different
+        getItemType={(item) => {
+          if (item.origin_key.includes('trip')) {
+            return 'trip';
+          } else if (item.origin_key.includes('place')) {
+            return 'place';
+          } else if (item.origin_key.includes('untracked')) {
+            return 'untracked';
+          } else {
+            return 'unknown';
+          }
+        }}
       />
     );
   } else {

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { FlashList } from '@shopify/flash-list';
 import TripCard from '../cards/TripCard';
 import PlaceCard from '../cards/PlaceCard';
 import UntrackedTimeCard from '../cards/UntrackedTimeCard';
-import { View } from 'react-native';
+import { View, FlatList } from 'react-native';
 import { ActivityIndicator, Banner, Text } from 'react-native-paper';
 import LoadMoreButton from './LoadMoreButton';
 import { useTranslation } from 'react-i18next';
@@ -40,6 +39,7 @@ const TimelineScrollList = ({
   isLoading,
 }: Props) => {
   const { t } = useTranslation();
+  const listRef = React.useRef<FlatList | null>(null);
 
   // The way that FlashList inverts the scroll view means we have to reverse the order of items too
   const reversedListEntries = listEntries ? [...listEntries].reverse() : [];
@@ -82,11 +82,11 @@ const TimelineScrollList = ({
   } else if (listEntries) {
     /* Condition: we've successfully loaded and set `listEntries`, so show the list */
     return (
-      <FlashList
-        inverted
+      <FlatList
+        ref={listRef}
+        nativeID="timelineScrollList"
         data={reversedListEntries}
         renderItem={renderCard}
-        estimatedItemSize={240}
         keyExtractor={(item) => item._id.$oid}
         /* TODO: We can capture onScroll events like this, so we should be able to automatically
             load more trips when the user is approaching the bottom or top of the list.
@@ -97,24 +97,25 @@ const TimelineScrollList = ({
         }
         ListFooterComponent={isLoading == 'prepend' ? smallSpinner : footer}
         ItemSeparatorComponent={separator}
-        /* Percent of viewport that must be covered for a partially occluded item to count as "viewable", 0-100.
-        a single pixel in the viewport makes the item viewable */
-        viewabilityConfig={{
-          viewAreaCoveragePercentThreshold: 0,
-          itemVisiblePercentThreshold: 0,
-          waitForInteraction: false,
-        }}
-        // 'getItemType' prop is used when FlashList has different types of cell components and these are vastly different
-        getItemType={(item) => {
-          if (item.origin_key.includes('trip')) {
-            return 'trip';
-          } else if (item.origin_key.includes('place')) {
-            return 'place';
-          } else if (item.origin_key.includes('untracked')) {
-            return 'untracked';
-          } else {
-            return 'unknown';
-          }
+        /* use column-reverse so that the list is 'inverted', meaning it should start
+            scrolling from the bottom, and the bottom-most item should be first in the DOM tree
+          This method is used instead of the `inverted` property of FlatList, because `inverted`
+            uses CSS transforms to flip the entire list and then flip each list item back, which
+            is a performance hit and causes scrolling to be choppy, especially on old iPhones. */
+        style={{ flexDirection: 'column-reverse' }}
+        contentContainerStyle={{ flexDirection: 'column-reverse' }}
+        /* Workaround for iOS Safari bug where a 'column-reverse' element containing scroll content
+            shows up blank until it's scrolled or its layout changes.
+          Adding a temporary 1px margin-right, and then removing it on the next event loop,
+            is the least intrusive way I've found to trigger a layout change.
+          It basically just jiggles the element so it doesn't blank out. */
+        onContentSizeChange={() => {
+          console.debug('TimelineScrollList onContentSizeChange');
+          const list = document.getElementById('timelineScrollList');
+          list?.style.setProperty('margin-right', '1px');
+          setTimeout(() => {
+            list?.style.setProperty('margin-right', '0');
+          });
         }}
       />
     );


### PR DESCRIPTION
### Issue
A blank screen appears when scrolling on the trip list.
https://github.com/e-mission/e-mission-phone/assets/47590587/6949486f-0237-42e8-99e4-83efacd05348

<br />

### Flashlist performance optimization
Upon reviewing the FlashList issue pages, I attempted to find solutions, but none seemed to address the problem effectively. 
Here are the details:
[Issue 1](https://github.com/Shopify/flash-list/issues/838)
[Issue 2](https://github.com/Shopify/flash-list/issues/796)
[Issue 3](https://github.com/Shopify/flash-list/issues/607)
[Issue 4](https://github.com/Shopify/flash-list/issues/868)

<br />

Next, I consulted the [documentation](https://shopify.github.io/flash-list/docs/fundamentals/performant-components) shared by Jack regarding FlashList performance optimization:

#### getItemType ✅ 
This prop is useful when FlashList has different types of cell components that are vastly different. 
#### estimatedItemSize
we are already using this prop.
#### memo
Since there is no repeated calculation in our case, using memo won't fix this issue.

<br />

### Flashlist configuration 
Additionally, there are configurations for determining whether items are viewable. I tried these configurations:

#### viewAreaCoveragePercentThreshold ✅ 
Percent of viewport that must be covered for a partially occluded item to count as "viewable", 0-100. Fully visible items are always considered viewable. A value of 0 means that a single pixel in the viewport makes the item viewable, and a value of 100 means that an item must be either entirely visible or cover the entire viewport to count as viewable.

#### itemVisiblePercentThreshold ✅ 
Similar to viewAreaCoveragePercentThreshold, but considers the percent of the item that is visible, rather than the fraction of the viewable area it covers.

#### waitForInteraction ✅ 
If it is `true`, nothing is considered viewable until the user scrolls or recordInteraction is called after render.

[Referacne](https://shopify.github.io/flash-list/docs/usage#viewabilityconfig)

<br />

### Leaflet rendring 
When rendering without Leaflet, the blank screen issue did not occur. 
https://github.com/e-mission/e-mission-phone/assets/47590587/159c21ff-696d-43e3-b391-0694b8a880b1

<br />

When rendering a Leaflet map without any additional calculations (= calling the initMap function), the performance improved but a blank screen still appears.
https://github.com/e-mission/e-mission-phone/assets/47590587/a435cf63-1ac7-4f69-99e1-c6bf1284cb9f

