### PR TITLE
Moved raw_data_use backwards compat hack

### DIFF
--- a/www/js/control/ProfileSettings.tsx
+++ b/www/js/control/ProfileSettings.tsx
@@ -131,15 +131,6 @@ const ProfileSettings = () => {
   function whenReady(newAppConfig: AppConfig) {
     const tempUiConfig = newAppConfig;
 
-    // backwards compat hack to fill in the raw_data_use for programs that don't have it
-    const default_raw_data_use = {
-      en: `to monitor the ${tempUiConfig.intro.program_or_study}, send personalized surveys or provide recommendations to participants`,
-      es: `para monitorear el ${tempUiConfig.intro.program_or_study}, enviar encuestas personalizadas o proporcionar recomendaciones a los participantes`,
-    };
-    Object.entries(tempUiConfig.intro.translated_text).forEach(([lang, val]) => {
-      val.raw_data_use = val.raw_data_use || default_raw_data_use[lang];
-    });
-
     // Backwards compat hack to fill in the `app_required` based on the
     // old-style "program_or_study"
     // remove this at the end of 2023 when all programs have been migrated over

--- a/www/js/onboarding/PrivacyPolicy.tsx
+++ b/www/js/onboarding/PrivacyPolicy.tsx
@@ -36,6 +36,17 @@ const PrivacyPolicy = () => {
     );
   }
 
+  // backwards compat hack to fill in the raw_data_use for programs that don't have it
+  if (appConfig?.intro) {
+    const default_raw_data_use = {
+      en: `monitor the ${appConfig?.intro?.program_or_study}, send personalized surveys or provide recommendations to participants`,
+      es: `monitorear el ${appConfig?.intro?.program_or_study}, enviar encuestas personalizadas o proporcionar recomendaciones a los participantes`,
+    };
+    Object.entries(appConfig?.intro?.translated_text).forEach(([lang, val]: [string, any]) => {
+      val.raw_data_use = val.raw_data_use || default_raw_data_use[lang];
+    });
+  }
+
   const templateText = useMemo(() => getTemplateText(appConfig, i18n.language), [appConfig]);
 
   return (


### PR DESCRIPTION
Moved backwards compat hack to fill in the raw_data_use for programs that don't have it to PrivacyPolicy.tsx, from ProfileSettings.tsx so that the privacy policy is updated for the login screen, and it carries over to the Profile settings screen.

| @Abby-Wheelis pointed out with the `washingtoncommons` program that their privacy policy had a textual error: | And @Abby-Wheelis phone on `nrel-commute` had this textual error: |
|---|---|
| ![MicrosoftTeams-image](https://github.com/e-mission/e-mission-phone/assets/61334340/86009b51-d544-44d2-a0ff-8cbc1346e47f) | ![MicrosoftTeams-image (1)](https://github.com/e-mission/e-mission-phone/assets/61334340/e7105442-0fee-45fa-8592-795e0ee576e1) |

They were both a result of a config not having the `raw_data_use` field filled in.

We had a backwards compat hack for programs without `raw_data_use`, but it was only in `ProfileSettings.tsx`, so now I removed it from there and placed it in PrivacyPolicy.tsx so that it checks for `raw_data_use` and gets filled in anytime the PrivacyPolicy is rendered.

Also, to fix the double "to to," I just removed the "to" and "para [ES]" from the backwards compat hack.