### PR TITLE
[Bug Fix] Leaflet gets broken after updating labels 

### DIFF
--- a/www/js/components/LeafletView.tsx
+++ b/www/js/components/LeafletView.tsx
@@ -153,7 +153,9 @@ const LeafletView = ({ geojson, opts, downscaleTiles, cacheHtml, ...otherProps }
         dangerouslySetInnerHTML={
           /* this is not 'dangerous' here because the content is not user-generated;
           it's just an HTML string that we cached from a previous render */
-          cacheHtml && leafletCache?.has(mapElId) ? { __html: leafletCache.get(mapElId) } : undefined
+          cacheHtml && leafletCache?.has(mapElId)
+            ? { __html: leafletCache.get(mapElId) }
+            : undefined
         }
       />
     </View>

--- a/www/js/components/LeafletView.tsx
+++ b/www/js/components/LeafletView.tsx
@@ -80,7 +80,6 @@ const LeafletView = ({ geojson, opts, downscaleTiles, cacheHtml, ...otherProps }
         // After a Leaflet map is rendered, cache the map to reduce the cost for creating a map
         const mapHTMLElements = document.getElementById(mapElId);
         leafletCache.set(mapElId, mapHTMLElements?.innerHTML);
-        leafletMapRef.current?.remove();
       });
     }
   }, [geojson, cacheHtml]);
@@ -154,7 +153,7 @@ const LeafletView = ({ geojson, opts, downscaleTiles, cacheHtml, ...otherProps }
         dangerouslySetInnerHTML={
           /* this is not 'dangerous' here because the content is not user-generated;
           it's just an HTML string that we cached from a previous render */
-          cacheHtml && leafletCache.has(mapElId) ? { __html: leafletCache.get(mapElId) } : undefined
+          cacheHtml && leafletCache?.has(mapElId) ? { __html: leafletCache.get(mapElId) } : undefined
         }
       />
     </View>


### PR DESCRIPTION
### Overview
After optimizing the Leaflet map, a bug appears when updating labels.
We cache the map after rendering a Leaflet map and reset the `leafletMapRef`. However, when the map information changes, we need to re-render the map using `initMap`. Currently, this doesn't happen because we reset `leafletMapRef`, causing it to fail the conditional check.

### Before
<img width="300" alt="Screenshot 2024-03-19 at 1 02 43 PM" src="https://github.com/e-mission/e-mission-phone/assets/47590587/346b189f-9014-44b5-894d-521c1f5a65ad">


### After
https://github.com/e-mission/e-mission-phone/assets/47590587/ae58c3c6-6f83-4b8b-bfb5-42ba07b425a9

