### PR TITLE
Include `sections` in `UnprocessedTrip`s

### DIFF
--- a/www/js/diary/timelineHelper.ts
+++ b/www/js/diary/timelineHelper.ts
@@ -15,6 +15,7 @@ import {
   CompositeTrip,
   UnprocessedTrip,
   SectionData,
+  CompositeTripLocation,
 } from '../types/diaryTypes';
 import { getLabelInputDetails, getLabelInputs } from '../survey/multilabel/confirmHelper';
 import { LabelOptions } from '../types/labelTypes';
@@ -216,10 +217,10 @@ const location2GeojsonPoint = (locationPoint: Point, featureType: string): Featu
  */
 function locations2GeojsonTrajectory(
   trip: CompositeTrip,
-  locationList: Array<Point>,
+  locationList: CompositeTripLocation[],
   trajectoryColor?: string,
-) {
-  let sectionsPoints;
+): Feature[] {
+  let sectionsPoints: CompositeTripLocation[][];
   if (!trip.sections) {
     // this is a unimodal trip so we put all the locations in one section
     sectionsPoints = [locationList];
@@ -242,6 +243,9 @@ function locations2GeojsonTrajectory(
         /* If a color was passed as arg, use it for the whole trajectory. Otherwise, use the
           color for the sensed mode of this section, and fall back to dark grey */
         color: trajectoryColor || getBaseModeByKey(section?.sensed_mode_str)?.color || '#333',
+      },
+      properties: {
+        feature_type: 'section_trajectory',
       },
     };
   });
@@ -341,7 +345,7 @@ function points2UnprocessedTrip(locationPoints: Array<BEMData<FilteredLocation>>
     } as Point,
     start_local_dt: dateTime2localdate(startTime, startPoint.metadata.time_zone),
     start_ts: startPoint.data.ts,
-  };
+  } as const;
 
   // section: baseProps + some properties that are unique to the section
   const singleSection: SectionData = {

--- a/www/js/types/diaryTypes.ts
+++ b/www/js/types/diaryTypes.ts
@@ -5,7 +5,7 @@
 import { BaseModeKey, MotionTypeKey } from '../diary/diaryHelper';
 import { MultilabelKey } from './labelTypes';
 import { BEMData, LocalDt } from './serverData';
-import { FeatureCollection, Feature, Geometry, Point } from 'geojson';
+import { FeatureCollection, Feature, Geometry, Point, Position } from 'geojson';
 
 type ObjectId = { $oid: string };
 
@@ -45,9 +45,9 @@ export type TripTransition = {
   ts: number;
 };
 
-type CompTripLocations = {
+export type CompositeTripLocation = {
   loc: {
-    coordinates: number[]; // e.g. [1, 2.3]
+    coordinates: Position; // [lon, lat]
   };
   speed: number;
   ts: number;
@@ -56,7 +56,7 @@ type CompTripLocations = {
 //  Used for return type of readUnprocessedTrips
 export type UnprocessedTrip = {
   _id: ObjectId;
-  additions: UserInputEntry[];
+  additions: []; // unprocessed trips won't have any matched processed inputs, so this is always empty
   confidence_threshold: number;
   distance: number;
   duration: number;
@@ -64,19 +64,19 @@ export type UnprocessedTrip = {
   end_loc: Point;
   end_local_dt: LocalDt;
   end_ts: number;
-  expectation: any; // TODO "{to_label: boolean}"
-  inferred_labels: any[]; // TODO
-  key: string;
-  locations?: CompTripLocations[];
-  origin_key: string; // e.x., UNPROCESSED_trip
+  expectation: { to_label: true }; // unprocessed trips are always expected to be labeled
+  inferred_labels: []; // unprocessed trips won't have inferred labels
+  key: 'UNPROCESSED_trip';
+  locations?: CompositeTripLocation[];
+  origin_key: 'UNPROCESSED_trip';
   sections: SectionData[];
-  source: string;
+  source: 'unprocessed';
   start_fmt_time: string;
   start_local_dt: LocalDt;
   start_ts: number;
   start_loc: Point;
   starting_trip?: any;
-  user_input: UserInput;
+  user_input: {}; // unprocessed trips won't have any matched processed inputs, so this is always empty
 };
 
 /* These are the properties received from the server (basically matches Python code)
@@ -96,13 +96,13 @@ export type CompositeTrip = {
   end_local_dt: LocalDt;
   end_place: ObjectId;
   end_ts: number;
-  expectation: any; // TODO "{to_label: boolean}"
+  expectation: { to_label: boolean };
   expected_trip: ObjectId;
   inferred_labels: InferredLabels;
   inferred_section_summary: SectionSummary;
   inferred_trip: ObjectId;
   key: string;
-  locations: any[]; // TODO
+  locations: CompositeTripLocation[];
   origin_key: string;
   raw_trip: ObjectId;
   sections: SectionData[];

--- a/www/js/types/diaryTypes.ts
+++ b/www/js/types/diaryTypes.ts
@@ -45,11 +45,6 @@ export type TripTransition = {
   ts: number;
 };
 
-export type LocationCoord = {
-  type: string; // e.x., "Point"
-  coordinates: [number, number];
-};
-
 type CompTripLocations = {
   loc: {
     coordinates: number[]; // e.g. [1, 2.3]
@@ -68,12 +63,15 @@ export type UnprocessedTrip = {
   end_fmt_time: string;
   end_loc: Point;
   end_local_dt: LocalDt;
+  end_ts: number;
   expectation: any; // TODO "{to_label: boolean}"
   inferred_labels: any[]; // TODO
   key: string;
   locations?: CompTripLocations[];
   origin_key: string; // e.x., UNPROCESSED_trip
+  sections: SectionData[];
   source: string;
+  start_fmt_time: string;
   start_local_dt: LocalDt;
   start_ts: number;
   start_loc: Point;
@@ -107,7 +105,7 @@ export type CompositeTrip = {
   locations: any[]; // TODO
   origin_key: string;
   raw_trip: ObjectId;
-  sections: any[]; // TODO
+  sections: SectionData[];
   source: string;
   start_confirmed_place: BEMData<ConfirmedPlace>;
   start_fmt_time: string;
@@ -188,23 +186,25 @@ export type Location = {
   latitude: number;
   fmt_time: string; // ISO
   mode: number;
-  loc: LocationCoord;
+  loc: Point;
   ts: number; // Unix
   altitude: number;
   distance: number;
 };
 
-// used in readAllCompositeTrips
 export type SectionData = {
+  _id: ObjectId;
   end_ts: number; // Unix time, e.x. 1696352498.804
-  end_loc: LocationCoord;
+  end_loc: Point;
   start_fmt_time: string; // ISO time
   end_fmt_time: string;
+  key: string;
+  origin_key: string;
   trip_id: ObjectId;
   sensed_mode: number;
   source: string; // e.x., "SmoothedHighConfidenceMotion"
   start_ts: number; // Unix
-  start_loc: LocationCoord;
+  start_loc: Point;
   cleaned_section: ObjectId;
   start_local_dt: LocalDt;
   end_local_dt: LocalDt;
@@ -213,7 +213,7 @@ export type SectionData = {
   distance: number;
 };
 
-// used in timelineHelper's `transitionTrip2TripObj`
+// used in timelineHelper's `transitionTrip2UnprocessedTrip`
 export type FilteredLocation = {
   accuracy: number;
   altitude: number;


### PR DESCRIPTION
> To be consistent with processed trips, and so we can use them in the same way, unprocessed trips should have the 'sections' property.
> 
> Unprocessed trips / 'draft' trips are assumed to be unimodal, so we can fairly easily reconstruct a section spanning the entirety of the trip and include that as the only section.

In doing this, I did a bunch of refactoring and expanded the type definitions we have for unprocessed trips, composite trips, and adjacent types.