### PR TITLE
Add 'collectCoverageForm' configuration to track all files for Jest coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
           flags: unit
           fail_ci_if_error: ${{ github.repository == 'e-mission/e-mission-phone' }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -27,7 +27,7 @@ jobs:
           npx jest
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage/coverage-final.json
           flags: unit

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,4 +18,9 @@ module.exports = {
   moduleDirectories: ["node_modules", "src"],
   globals: {"__DEV__": false},
   collectCoverage: true,
+  collectCoverageFrom: [
+    "www/js/**/*.{ts,tsx,js,jsx}",
+    "!www/js/**/index.{ts,tsx,js,jsx}",
+    "!www/js/types/**/*.{ts,tsx,js,jsx}",
+  ],
 };


### PR DESCRIPTION
### Related Issue
https://github.com/e-mission/e-mission-docs/issues/1064

### Overview
We have been ignoring files not included in the test folder when calculating coverage. To improve this, I added the `collectCoverageFrom` configuration.

For more information, please refer to this document: https://jestjs.io/docs/configuration#collectcoveragefrom-array

### Code coverage report after adding `collectCoverageFrom`
![Screenshot 2024-04-08 at 1 05 31 PM](https://github.com/e-mission/e-mission-phone/assets/47590587/6c54db41-2f73-4b92-aff8-15f3cf813553)

