### PR TITLE
🚑️ 🐛 Ensure that we do show the replaced mode when the `mode_of_inter…

### DIFF
--- a/www/__tests__/confirmHelper.test.ts
+++ b/www/__tests__/confirmHelper.test.ts
@@ -45,6 +45,16 @@ const fakeDefaultLabelOptions = {
     },
   },
 };
+const fakeInputs = {
+  MODE: [
+    { data: { label: 'walk', start_ts: 1245, end_ts: 5678}},
+    { data: { label: 'bike', start_ts: 1245, end_ts: 5678}},
+  ],
+  PURPOSE: [
+    { data: {label: 'home', start_ts: 1245, end_ts: 5678 }},
+    { data: {label: 'work', start_ts: 1245, end_ts: 5678 }}
+  ],
+};
 
 jest.mock('../js/services/commHelper', () => ({
   ...jest.requireActual('../js/services/commHelper'),
@@ -62,8 +72,8 @@ describe('confirmHelper', () => {
 
   it('returns base labelInputDetails for a labelUserInput which does not have mode of study', () => {
     const fakeLabelUserInput = {
-      MODE: fakeDefaultLabelOptions.MODE[1],
-      PURPOSE: fakeDefaultLabelOptions.PURPOSE[0],
+      MODE: fakeInputs.MODE[1],
+      PURPOSE: fakeInputs.PURPOSE[0],
     };
     const labelInputDetails = labelInputDetailsForTrip(
       fakeLabelUserInput,
@@ -74,8 +84,8 @@ describe('confirmHelper', () => {
 
   it('returns full labelInputDetails for a labelUserInput which has the mode of study', () => {
     const fakeLabelUserInput = {
-      MODE: fakeDefaultLabelOptions.MODE[0], // 'walk' is mode of study
-      PURPOSE: fakeDefaultLabelOptions.PURPOSE[0],
+      MODE: fakeInputs.MODE[0], // 'walk' is mode of study
+      PURPOSE: fakeInputs.PURPOSE[0],
     };
     const labelInputDetails = labelInputDetailsForTrip(
       fakeLabelUserInput,

--- a/www/__tests__/confirmHelper.test.ts
+++ b/www/__tests__/confirmHelper.test.ts
@@ -47,12 +47,12 @@ const fakeDefaultLabelOptions = {
 };
 const fakeInputs = {
   MODE: [
-    { data: { label: 'walk', start_ts: 1245, end_ts: 5678}},
-    { data: { label: 'bike', start_ts: 1245, end_ts: 5678}},
+    { data: { label: 'walk', start_ts: 1245, end_ts: 5678 } },
+    { data: { label: 'bike', start_ts: 1245, end_ts: 5678 } },
   ],
   PURPOSE: [
-    { data: {label: 'home', start_ts: 1245, end_ts: 5678 }},
-    { data: {label: 'work', start_ts: 1245, end_ts: 5678 }}
+    { data: { label: 'home', start_ts: 1245, end_ts: 5678 } },
+    { data: { label: 'work', start_ts: 1245, end_ts: 5678 } },
   ],
 };
 

--- a/www/js/survey/multilabel/confirmHelper.ts
+++ b/www/js/survey/multilabel/confirmHelper.ts
@@ -91,12 +91,12 @@ export function getLabelInputDetails(appConfigParam?) {
 export function labelInputDetailsForTrip(userInputForTrip, appConfigParam?) {
   if (appConfigParam) appConfig = appConfigParam;
   if (appConfig.intro.mode_studied) {
-    if (userInputForTrip?.['MODE']?.value == appConfig.intro.mode_studied) {
-      logDebug(`Found trip labeled with mode of study, ${appConfig.intro.mode_studied}. 
+    if (userInputForTrip?.['MODE']?.data.label == appConfig.intro.mode_studied) {
+      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data.label}, mode of study = ${appConfig.intro.mode_studied}.
         Needs REPLACED_MODE`);
       return getLabelInputDetails();
     } else {
-      logDebug(`Found trip not labeled with mode of study, ${appConfig.intro.mode_studied}. 
+      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data.label}, not labeled with mode of study = ${appConfig.intro.mode_studied}.
         Doesn't need REPLACED_MODE`);
       return baseLabelInputDetails;
     }

--- a/www/js/survey/multilabel/confirmHelper.ts
+++ b/www/js/survey/multilabel/confirmHelper.ts
@@ -91,12 +91,12 @@ export function getLabelInputDetails(appConfigParam?) {
 export function labelInputDetailsForTrip(userInputForTrip, appConfigParam?) {
   if (appConfigParam) appConfig = appConfigParam;
   if (appConfig.intro.mode_studied) {
-    if (userInputForTrip?.['MODE']?.data.label == appConfig.intro.mode_studied) {
-      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data.label}, mode of study = ${appConfig.intro.mode_studied}.
+    if (userInputForTrip?.['MODE']?.data?.label == appConfig.intro.mode_studied) {
+      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data?.label}, mode of study = ${appConfig.intro.mode_studied}.
         Needs REPLACED_MODE`);
       return getLabelInputDetails();
     } else {
-      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data.label}, not labeled with mode of study = ${appConfig.intro.mode_studied}.
+      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data?.label}, not labeled with mode of study = ${appConfig.intro.mode_studied}.
         Doesn't need REPLACED_MODE`);
       return baseLabelInputDetails;
     }


### PR DESCRIPTION
…est` matches

At some point, we changed the mode and purpose user inputs as objects that were stored to be full objects, with start and end timestamps, instead of just the labels. We changed all uses of the MODE and PURPOSE to match it, but apparently forgot to change this location, where the replaced mode button is conditionally displayed.

This is a quick change to make the usage here consistent with the rest of the code so that we can push this out ASAP.

@JGreenlee, please let me know if there is a more principled fix, it is late and I don't want to experiment any further.

Testing done:
Please see PR