### PR TITLE
💩 Turn off the background checks for fleet deployments

### DIFF
--- a/www/js/usePermissionStatus.ts
+++ b/www/js/usePermissionStatus.ts
@@ -446,9 +446,10 @@ const usePermissionStatus = () => {
       setupAndroidFitnessChecks();
       if (appConfig.tracking?.bluetooth_only) {
         setupAndroidBluetoothChecks();
+      } else {
+        setupAndroidBackgroundRestrictionChecks();
       }
       setupAndroidNotificationChecks();
-      setupAndroidBackgroundRestrictionChecks();
     } else if (window['device'].platform.toLowerCase() == 'ios') {
       setupIOSLocChecks();
       setupIOSFitnessChecks();

--- a/www/js/usePermissionStatus.ts
+++ b/www/js/usePermissionStatus.ts
@@ -407,7 +407,11 @@ const usePermissionStatus = () => {
       refresh: checkBatteryOpt,
     };
     let tempChecks = checkList;
-    tempChecks.push(unusedAppsUnrestrictedCheck, ignoreBatteryOptCheck);
+    if (appConfig.tracking?.bluetooth_only) {
+      tempChecks.push(ignoreBatteryOptCheck);
+    } else {
+      tempChecks.push(unusedAppsUnrestrictedCheck, ignoreBatteryOptCheck);
+    }
     setCheckList(tempChecks);
   }
 
@@ -446,10 +450,9 @@ const usePermissionStatus = () => {
       setupAndroidFitnessChecks();
       if (appConfig.tracking?.bluetooth_only) {
         setupAndroidBluetoothChecks();
-      } else {
-        setupAndroidBackgroundRestrictionChecks();
       }
       setupAndroidNotificationChecks();
+      setupAndroidBackgroundRestrictionChecks();
     } else if (window['device'].platform.toLowerCase() == 'ios') {
       setupIOSLocChecks();
       setupIOSFitnessChecks();


### PR DESCRIPTION
Since the fleet deployments are installed on work phones, and the background restriction is apparently grayed out on android work phones.
https://github.com/e-mission/e-mission-docs/issues/1070

This is a hack (hence the 💩 emoji) but it will allow us to make progress through the onboarding, get the logs and then resolve the issue the right way. Or if we can't figure out how to access it the right way, this can become a config option for deployments that plan to use work phones.

This should unblock
https://github.com/e-mission/e-mission-docs/issues/1070#issuecomment-2094354832