### PR TITLE
💚 👷 Remove the check for patcher

### DIFF
--- a/.github/workflows/android-automated-sdk-install.yml
+++ b/.github/workflows/android-automated-sdk-install.yml
@@ -6,10 +6,12 @@ on:
   push:
     paths:
       - 'setup/prereq_android_sdk_install.sh'
+      - 'setup/android_sdk_packages'
       - '.github/workflows/android-automated-sdk-install.yml'
   pull_request:
     paths:
       - 'setup/prereq_android_sdk_install.sh'
+      - 'setup/android_sdk_packages'
       - '.github/workflows/android-automated-sdk-install.yml'
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -64,7 +66,6 @@ jobs:
         ls -al $ANDROID_SDK_ROOT
         if [ ! -d $ANDROID_SDK_ROOT/emulator ]; then exit 1; fi
         if [ ! -d $ANDROID_SDK_ROOT/build-tools ]; then exit 1; fi
-        if [ ! -d $ANDROID_SDK_ROOT/patcher ]; then exit 1; fi
         if [ ! -d $ANDROID_SDK_ROOT/extras ]; then exit 1; fi
         if [ ! -d $ANDROID_SDK_ROOT/platforms ]; then exit 1; fi
         if [ ! -d $ANDROID_SDK_ROOT/platform-tools ]; then exit 1; fi


### PR DESCRIPTION
We removed patcher in 41ff1a772756470fc4114ac555b543271180e4be so we should not expect to see it in the file structure any more

This should fix the failing build

```
+ ls -al /tmp/new-install/Android/sdk
+ '[' '!' -d /tmp/new-install/Android/sdk/emulator ']'
+ '[' '!' -d /tmp/new-install/Android/sdk/build-tools ']'
+ '[' '!' -d /tmp/new-install/Android/sdk/patcher ']'
+ exit 1
```

Also, run CI on changes to the SDK package list (i.e. `setup/android_sdk_packages`) so that such errors are caught in the PR stage in the future