### PR TITLE
💚 ⬆️  Upgrade the pinned version of the runner to 14-large

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -53,13 +53,13 @@ jobs:
     - name: Setup the cordova environment
       shell: bash -l {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_arm64
         bash setup/setup_android_native.sh
 
     - name: Check tool versions
       shell: bash -l {0}
       run: |
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_arm64
         source setup/activate_native.sh
         echo "cordova version"
         npx cordova -version
@@ -77,7 +77,7 @@ jobs:
         gradle -version
         echo "Let's rerun the activation"
         source setup/activate_native.sh
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_arm64
         echo $PATH
         which gradle
         gradle --version

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,7 +22,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-13
+    runs-on: macos-14-large
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,7 +22,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-14-large
+    runs-on: macos-14
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -39,7 +39,7 @@ jobs:
         echo "Default java version"
         java -version
         echo "Setting to Java 11 instead"
-        export JAVA_HOME=$JAVA_HOME_11_X64
+        export JAVA_HOME=$JAVA_HOME_17_arm64
         java -version
         echo "Checking gradle"
         which gradle


### PR DESCRIPTION
This should still have the correct environment variable because `14-large` runs x64 https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md

`macos-14` now runs amd, and we have to figure out how to run it. Maybe we can run both as part of a schedule instead of on every pull request