### PR TITLE
🎆 Only do BLE matching on the phone for unprocessed BLE Scans

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js|jsx)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!((enketo-transformer/dist/enketo-transformer/web)|(jest-)?react-native(-.*)?|@react-native(-community)?)/)",
+    "node_modules/(?!((enketo-transformer/dist/enketo-transformer/web)|(jest-)?react-native(-.*)?|@react-native(-community)?|e-mission-common)/)"
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   moduleDirectories: ["node_modules", "src"],

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -139,7 +139,7 @@
     "cordova-custom-config": "^5.1.1",
     "cordova-plugin-ibeacon": "git+https://github.com/louisg1337/cordova-plugin-ibeacon.git",
     "core-js": "^2.5.7",
-    "e-mission-common": "git+https://github.com/JGreenlee/e-mission-common.git",
+    "e-mission-common": "git+https://github.com/JGreenlee/e-mission-common.git#0.4.4",
     "enketo-core": "^6.1.7",
     "enketo-transformer": "^4.0.0",
     "fast-xml-parser": "^4.2.2",

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -139,6 +139,7 @@
     "cordova-custom-config": "^5.1.1",
     "cordova-plugin-ibeacon": "git+https://github.com/louisg1337/cordova-plugin-ibeacon.git",
     "core-js": "^2.5.7",
+    "e-mission-common": "git+https://github.com/JGreenlee/e-mission-common.git",
     "enketo-core": "^6.1.7",
     "enketo-transformer": "^4.0.0",
     "fast-xml-parser": "^4.2.2",

--- a/package.serve.json
+++ b/package.serve.json
@@ -65,6 +65,7 @@
     "chartjs-adapter-luxon": "^1.3.1",
     "chartjs-plugin-annotation": "^3.0.1",
     "core-js": "^2.5.7",
+    "e-mission-common": "git+https://github.com/JGreenlee/e-mission-common.git",
     "enketo-core": "^6.1.7",
     "enketo-transformer": "^4.0.0",
     "fast-xml-parser": "^4.2.2",

--- a/package.serve.json
+++ b/package.serve.json
@@ -65,7 +65,7 @@
     "chartjs-adapter-luxon": "^1.3.1",
     "chartjs-plugin-annotation": "^3.0.1",
     "core-js": "^2.5.7",
-    "e-mission-common": "git+https://github.com/JGreenlee/e-mission-common.git",
+    "e-mission-common": "git+https://github.com/JGreenlee/e-mission-common.git#0.4.4",
     "enketo-core": "^6.1.7",
     "enketo-transformer": "^4.0.0",
     "fast-xml-parser": "^4.2.2",

--- a/www/__tests__/timelineHelper.test.ts
+++ b/www/__tests__/timelineHelper.test.ts
@@ -291,13 +291,14 @@ jest.mock('../js/services/unifiedDataLoader', () => ({
 }));
 
 it('works when there are no unprocessed trips...', async () => {
-  expect(readUnprocessedTrips(-1, -1, {} as any)).resolves.toEqual([]);
+  expect(readUnprocessedTrips(-1, -1, {} as any, {} as any)).resolves.toEqual([]);
 });
 
 it('works when there are one or more unprocessed trips...', async () => {
   const testValueOne = await readUnprocessedTrips(
     mockTLH.fakeStartTsOne,
     mockTLH.fakeEndTsOne,
+    {} as any,
     {} as any,
   );
   expect(testValueOne.length).toEqual(1);

--- a/www/js/diary/LabelTabContext.ts
+++ b/www/js/diary/LabelTabContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { TimelineEntry, TimestampRange, UserInputEntry } from '../types/diaryTypes';
+import { CompositeTrip, TimelineEntry, TimestampRange, UserInputEntry } from '../types/diaryTypes';
 import { LabelOption, LabelOptions, MultilabelKey } from '../types/labelTypes';
 import { EnketoUserInputEntry } from '../survey/enketo/enketoHelper';
 import { VehicleIdentity } from '../types/appConfigTypes';
@@ -35,7 +35,7 @@ type ContextProps = {
   userInputFor: (tlEntry: TimelineEntry) => UserInputMap | undefined;
   notesFor: (tlEntry: TimelineEntry) => UserInputEntry[] | undefined;
   labelFor: (tlEntry: TimelineEntry, labelType: MultilabelKey) => LabelOption | undefined;
-  confirmedModeFor: (tlEntry: TimelineEntry) => VehicleIdentity | LabelOption | undefined;
+  confirmedModeFor: (tlEntry: CompositeTrip) => VehicleIdentity | LabelOption | undefined;
   addUserInputToEntry: (oid: string, userInput: any, inputType: 'label' | 'note') => void;
   displayedEntries: TimelineEntry[] | null;
   filterInputs: LabelTabFilter[];

--- a/www/js/diary/diaryHelper.ts
+++ b/www/js/diary/diaryHelper.ts
@@ -192,6 +192,15 @@ export function getFormattedSectionProperties(trip: CompositeTrip, imperialConfi
   }));
 }
 
+/**
+ * @param trip A composite trip object
+ * @return the primary section of the trip, i.e. the section with the greatest distance
+ */
+export function primarySectionForTrip(trip: CompositeTrip) {
+  if (!trip.sections?.length) return undefined;
+  return trip.sections.reduce((prev, curr) => (prev.distance > curr.distance ? prev : curr));
+}
+
 export function getLocalTimeString(dt?: LocalDt) {
   if (!dt) return;
   const dateTime = DateTime.fromObject({

--- a/www/js/types/diaryTypes.ts
+++ b/www/js/types/diaryTypes.ts
@@ -4,6 +4,7 @@
 
 import { BaseModeKey, MotionTypeKey } from '../diary/diaryHelper';
 import useDerivedProperties from '../diary/useDerivedProperties';
+import { VehicleIdentity } from './appConfigTypes';
 import { MultilabelKey } from './labelTypes';
 import { BEMData, LocalDt } from './serverData';
 import { FeatureCollection, Feature, Geometry, Point, Position } from 'geojson';
@@ -58,6 +59,8 @@ export type CompositeTripLocation = {
 export type UnprocessedTrip = {
   _id: ObjectId;
   additions: []; // unprocessed trips won't have any matched processed inputs, so this is always empty
+  ble_sensed_summary: SectionSummary;
+  cleaned_section_summary: SectionSummary;
   confidence_threshold: number;
   distance: number;
   duration: number;
@@ -67,6 +70,7 @@ export type UnprocessedTrip = {
   end_ts: number;
   expectation: { to_label: true }; // unprocessed trips are always expected to be labeled
   inferred_labels: []; // unprocessed trips won't have inferred labels
+  inferred_section_summary: SectionSummary;
   key: 'UNPROCESSED_trip';
   locations?: CompositeTripLocation[];
   origin_key: 'UNPROCESSED_trip';
@@ -85,6 +89,7 @@ export type UnprocessedTrip = {
 export type CompositeTrip = {
   _id: ObjectId;
   additions: UserInputEntry[];
+  ble_sensed_summary: SectionSummary;
   cleaned_section_summary: SectionSummary;
   cleaned_trip: ObjectId;
   confidence_threshold: number;
@@ -202,6 +207,7 @@ export type SectionData = {
   key: string;
   origin_key: string;
   trip_id: ObjectId;
+  ble_sensed_mode: VehicleIdentity;
   sensed_mode: number;
   source: string; // e.x., "SmoothedHighConfidenceMotion"
   start_ts: number; // Unix


### PR DESCRIPTION
### fill in new BLE fields & update types

`ble_sensed_mode` and `ble_sensed_summary` were added to sections and confirmed trips in https://github.com/e-mission/e-mission-server/pull/965.

We are going to need `ble_sensed_mode` to determine vehicle info.

The section summaries (`ble_sensed_summary`, `cleaned_section_summary` and `inferred_section_summary`) are not used in unprocessed trips currently, but I am adding them so there is less of a gap between composite trips and unprocessed trips

<hr>

### use only unprocessed BLE scans in label tab

Since we have matching on the server, processed sections will already have BLE sensed modes filled in. We no longer need to query for all BLE scans; only unprocessed ones (ie newer than pipeline end ts).
Then while we are constructing unprocessed trips, the list of unprocessed BLE scans will be used to determine BLE sensed modes.

We no longer need timelineBleMap and won't treat BLE scans like user inputs anymore. For 'confirmedMode', instead of using timelineBleMap, we will use the ble_sensed_mode of the primary section. New simple function in diaryHelper to deternmine the primary section.