### PR TITLE
Bumped cocoapods version

### DIFF
--- a/setup/export_shared_dep_versions.sh
+++ b/setup/export_shared_dep_versions.sh
@@ -6,7 +6,7 @@ export NPM_VERSION=9.3.1
 # ideally, this would be the same version as the CI
 # Looks like brew supports only major and minor, not patch version
 export RUBY_VERSION=3.0
-export COCOAPODS_VERSION=1.11.3
+export COCOAPODS_VERSION=1.12.1
 export GRADLE_VERSION=7.6
 export OSX_EXP_VERSION=12
 


### PR DESCRIPTION
**Testing Done**
Ran `bash setup/setup_ios_native.sh` and it 1) installed the new version of cocoapods and 2) finished with no errors