### PR TITLE
fix timeline initial date range regression

### DIFF
--- a/www/js/diary/list/DateSelect.tsx
+++ b/www/js/diary/list/DateSelect.tsx
@@ -31,7 +31,7 @@ const DateSelect = ({ mode, onChoose, ...rest }: Props) => {
   const { colors } = useTheme();
   const [open, setOpen] = React.useState(false);
   const minMaxDates = useMemo(() => {
-    if (!pipelineRange) return { startDate: new Date(), endDate: new Date() };
+    if (!pipelineRange?.start_ts) return { startDate: new Date(), endDate: new Date() };
     return {
       startDate: new Date(pipelineRange?.start_ts * 1000), // start of pipeline
       endDate: new Date(), // today

--- a/www/js/metrics/MetricsTab.tsx
+++ b/www/js/metrics/MetricsTab.tsx
@@ -111,7 +111,7 @@ const MetricsTab = () => {
   const [aggMetricsIsLoading, setAggMetricsIsLoading] = useState(false);
 
   const readyToLoad = useMemo(() => {
-    if (!appConfig) return false;
+    if (!appConfig || !dateRange) return false;
     const dateRangeDays = isoDatesDifference(...dateRange);
     if (dateRangeDays < N_DAYS_TO_LOAD) {
       logDebug('MetricsTab: not enough days loaded, trying to load more');
@@ -132,7 +132,7 @@ const MetricsTab = () => {
   }, [readyToLoad, appConfig, timelineIsLoading, timelineMap, timelineLabelMap]);
 
   useEffect(() => {
-    if (!readyToLoad || !appConfig) return;
+    if (!readyToLoad || !appConfig || !dateRange) return;
     logDebug('MetricsTab: ready to fetch aggMetrics');
     setAggMetricsIsLoading(true);
     fetchAggMetrics(metricList, dateRange, appConfig).then((response) => {


### PR DESCRIPTION
When refactoring into TimelineContext, there was a regression regarding the date range that is initially loaded. https://github.com/e-mission/e-mission-phone/pull/1142#issuecomment-2141345034

It used to load 7 days before the pipelineEnd up to today. After the change, it would load 7 days before today up to today. If the user has travel everyday this ends up being equivalent. But if there isn't recent travel, this becomes a problem.

So in TimelineContext, the initial dateRange needs to depend on pipelineRange. instead of giving an initial value upfront, we'll let dateRange be null until pipelineRange is set, at which point we'll also set dateRange. This means we have to consider some extra cases where dateRange can be null.