### PR TITLE
Point QR code scanner plugin to e-mission repo

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -151,7 +151,7 @@
     "leaflet": "^1.9.4",
     "luxon": "^3.3.0",
     "npm": "^9.6.3",
-    "phonegap-plugin-barcodescanner": "git+https://github.com/phonegap/phonegap-plugin-barcodescanner#v8.1.0",
+    "phonegap-plugin-barcodescanner": "git+https://github.com/louisg1337/phonegap-plugin-barcodescanner.git",
     "prop-types": "^15.8.1",
     "react": "~18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -151,7 +151,7 @@
     "leaflet": "^1.9.4",
     "luxon": "^3.3.0",
     "npm": "^9.6.3",
-    "phonegap-plugin-barcodescanner": "git+https://github.com/louisg1337/phonegap-plugin-barcodescanner.git",
+    "phonegap-plugin-barcodescanner": "git+https://github.com/e-mission/phonegap-plugin-barcodescanner.git",
     "prop-types": "^15.8.1",
     "react": "~18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -121,7 +121,7 @@
     "cordova-plugin-app-version": "0.1.14",
     "cordova-plugin-customurlscheme": "5.0.2",
     "cordova-plugin-device": "2.1.0",
-    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.8.7",
+    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.8.8",
     "cordova-plugin-em-opcodeauth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.7.2",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.6",
     "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.3.2",


### PR DESCRIPTION
Changes `package.cordovabuild.json` to point to e-mission's custom QR code scanner plugin which will fix weird iOS glitch found in issue below. The changes to the plugin can be found [here](https://github.com/phonegap/phonegap-plugin-barcodescanner/compare/master...louisg1337:phonegap-plugin-barcodescanner:master).