### PR TITLE
Integrate unified base mode color and helper function

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -137,7 +137,7 @@
     "cordova-custom-config": "^5.1.1",
     "cordova-plugin-ibeacon": "git+https://github.com/louisg1337/cordova-plugin-ibeacon.git",
     "core-js": "^2.5.7",
-    "e-mission-common": "github:JGreenlee/e-mission-common#semver:0.5.1",
+    "e-mission-common": "github:JGreenlee/e-mission-common#semver:0.5.4",
     "enketo-core": "^6.1.7",
     "enketo-transformer": "^4.0.0",
     "fast-xml-parser": "^4.2.2",

--- a/package.serve.json
+++ b/package.serve.json
@@ -65,7 +65,7 @@
     "chartjs-adapter-luxon": "^1.3.1",
     "chartjs-plugin-annotation": "^3.0.1",
     "core-js": "^2.5.7",
-    "e-mission-common": "github:JGreenlee/e-mission-common#semver:0.5.1",
+    "e-mission-common": "github:JGreenlee/e-mission-common#semver:0.5.4",
     "enketo-core": "^6.1.7",
     "enketo-transformer": "^4.0.0",
     "fast-xml-parser": "^4.2.2",

--- a/www/__tests__/diaryHelper.test.ts
+++ b/www/__tests__/diaryHelper.test.ts
@@ -4,9 +4,10 @@ import {
   getFormattedDateAbbr,
   getFormattedTimeRange,
   getDetectedModes,
-  getBaseModeByKey,
   modeColors,
 } from '../js/diary/diaryHelper';
+
+import { base_mode_colors } from 'e-mission-common';
 
 import initializedI18next from '../js/i18nextInit';
 window['i18next'] = initializedI18next;
@@ -38,17 +39,17 @@ it('returns a human readable time range', () => {
 });
 
 it('returns a Base Mode for a given key', () => {
-  expect(getBaseModeByKey('WALKING')).toEqual({
+  expect(base_mode_colors.get_base_mode_by_key('WALKING')).toEqual({
     name: 'WALKING',
     icon: 'walk',
     color: modeColors.blue,
   });
-  expect(getBaseModeByKey('MotionTypes.WALKING')).toEqual({
+  expect(base_mode_colors.get_base_mode_by_key('MotionTypes.WALKING')).toEqual({
     name: 'WALKING',
     icon: 'walk',
     color: modeColors.blue,
   });
-  expect(getBaseModeByKey('I made this type up')).toEqual({
+  expect(base_mode_colors.get_base_mode_by_key('I made this type up')).toEqual({
     name: 'UNKNOWN',
     icon: 'help',
     color: modeColors.grey,

--- a/www/__tests__/diaryHelper.test.ts
+++ b/www/__tests__/diaryHelper.test.ts
@@ -4,7 +4,6 @@ import {
   getFormattedDateAbbr,
   getFormattedTimeRange,
   getDetectedModes,
-  modeColors,
 } from '../js/diary/diaryHelper';
 
 import { base_modes } from 'e-mission-common';
@@ -39,20 +38,17 @@ it('returns a human readable time range', () => {
 });
 
 it('returns a Base Mode for a given key', () => {
-  expect(base_modes.get_base_mode_by_key('WALKING')).toEqual({
-    name: 'WALKING',
+  expect(base_modes.get_base_mode_by_key('WALKING')).toMatchObject({
     icon: 'walk',
-    color: modeColors.blue,
+    color: base_modes.mode_colors['blue'],
   });
-  expect(base_modes.get_base_mode_by_key('MotionTypes.WALKING')).toEqual({
-    name: 'WALKING',
+  expect(base_modes.get_base_mode_by_key('MotionTypes.WALKING')).toMatchObject({
     icon: 'walk',
-    color: modeColors.blue,
+    color: base_modes.mode_colors['blue'],
   });
-  expect(base_modes.get_base_mode_by_key('I made this type up')).toEqual({
-    name: 'UNKNOWN',
+  expect(base_modes.get_base_mode_by_key('I made this type up')).toMatchObject({
     icon: 'help',
-    color: modeColors.grey,
+    color: base_modes.mode_colors['grey'],
   });
 });
 
@@ -88,11 +84,13 @@ let myFakeTrip2 = {
 };
 
 let myFakeDetectedModes = [
-  { mode: 'BICYCLING', icon: 'bike', color: modeColors.green, pct: 89 },
-  { mode: 'WALKING', icon: 'walk', color: modeColors.blue, pct: 11 },
+  { mode: 'BICYCLING', icon: 'bike', color: base_modes.mode_colors['green'], pct: 89 },
+  { mode: 'WALKING', icon: 'walk', color: base_modes.mode_colors['blue'], pct: 11 },
 ];
 
-let myFakeDetectedModes2 = [{ mode: 'BICYCLING', icon: 'bike', color: modeColors.green, pct: 100 }];
+let myFakeDetectedModes2 = [
+  { mode: 'BICYCLING', icon: 'bike', color: base_modes.mode_colors['green'], pct: 100 },
+];
 
 it('returns the detected modes, with percentages, for a trip', () => {
   expect(getDetectedModes(myFakeTrip)).toEqual(myFakeDetectedModes);

--- a/www/__tests__/diaryHelper.test.ts
+++ b/www/__tests__/diaryHelper.test.ts
@@ -7,7 +7,7 @@ import {
   modeColors,
 } from '../js/diary/diaryHelper';
 
-import { base_mode_colors } from 'e-mission-common';
+import { base_modes } from 'e-mission-common';
 
 import initializedI18next from '../js/i18nextInit';
 window['i18next'] = initializedI18next;
@@ -39,17 +39,17 @@ it('returns a human readable time range', () => {
 });
 
 it('returns a Base Mode for a given key', () => {
-  expect(base_mode_colors.get_base_mode_by_key('WALKING')).toEqual({
+  expect(base_modes.get_base_mode_by_key('WALKING')).toEqual({
     name: 'WALKING',
     icon: 'walk',
     color: modeColors.blue,
   });
-  expect(base_mode_colors.get_base_mode_by_key('MotionTypes.WALKING')).toEqual({
+  expect(base_modes.get_base_mode_by_key('MotionTypes.WALKING')).toEqual({
     name: 'WALKING',
     icon: 'walk',
     color: modeColors.blue,
   });
-  expect(base_mode_colors.get_base_mode_by_key('I made this type up')).toEqual({
+  expect(base_modes.get_base_mode_by_key('I made this type up')).toEqual({
     name: 'UNKNOWN',
     icon: 'help',
     color: modeColors.grey,

--- a/www/js/components/charting.ts
+++ b/www/js/components/charting.ts
@@ -1,5 +1,4 @@
 import color from 'color';
-import { getBaseModeByKey } from '../diary/diaryHelper';
 import { readableLabelToKey } from '../survey/multilabel/confirmHelper';
 import { logDebug } from '../plugin/logger';
 

--- a/www/js/diary/cards/ModesIndicator.tsx
+++ b/www/js/diary/cards/ModesIndicator.tsx
@@ -6,7 +6,7 @@ import { logDebug } from '../../plugin/logger';
 import { getBaseModeByValue } from '../diaryHelper';
 import { Text, Icon, useTheme } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
-import { base_mode_colors } from 'e-mission-common';
+import { base_modes } from 'e-mission-common';
 
 const ModesIndicator = ({ trip, detectedModes }) => {
   const { t } = useTranslation();
@@ -19,7 +19,7 @@ const ModesIndicator = ({ trip, detectedModes }) => {
   let modeViews;
   const confirmedModeForTrip = confirmedModeFor(trip);
   if (labelOptions && confirmedModeForTrip?.value) {
-    const baseMode = base_mode_colors.get_base_mode_by_key(confirmedModeForTrip.baseMode);
+    const baseMode = base_modes.get_base_mode_by_key(confirmedModeForTrip.baseMode);
     indicatorBorderColor = baseMode.color;
     logDebug(`TripCard: got baseMode = ${JSON.stringify(baseMode)}`);
     modeViews = (

--- a/www/js/diary/cards/ModesIndicator.tsx
+++ b/www/js/diary/cards/ModesIndicator.tsx
@@ -3,9 +3,10 @@ import { View, StyleSheet } from 'react-native';
 import color from 'color';
 import TimelineContext from '../../TimelineContext';
 import { logDebug } from '../../plugin/logger';
-import { getBaseModeByKey, getBaseModeByValue } from '../diaryHelper';
+import { getBaseModeByValue } from '../diaryHelper';
 import { Text, Icon, useTheme } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
+import { base_mode_colors } from 'e-mission-common';
 
 const ModesIndicator = ({ trip, detectedModes }) => {
   const { t } = useTranslation();
@@ -18,7 +19,7 @@ const ModesIndicator = ({ trip, detectedModes }) => {
   let modeViews;
   const confirmedModeForTrip = confirmedModeFor(trip);
   if (labelOptions && confirmedModeForTrip?.value) {
-    const baseMode = getBaseModeByKey(confirmedModeForTrip.baseMode);
+    const baseMode = base_mode_colors.get_base_mode_by_key(confirmedModeForTrip.baseMode);
     indicatorBorderColor = baseMode.color;
     logDebug(`TripCard: got baseMode = ${JSON.stringify(baseMode)}`);
     modeViews = (

--- a/www/js/diary/cards/ModesIndicator.tsx
+++ b/www/js/diary/cards/ModesIndicator.tsx
@@ -3,7 +3,6 @@ import { View, StyleSheet } from 'react-native';
 import color from 'color';
 import TimelineContext from '../../TimelineContext';
 import { logDebug } from '../../plugin/logger';
-import { getBaseModeByValue } from '../diaryHelper';
 import { Text, Icon, useTheme } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { base_modes } from 'e-mission-common';

--- a/www/js/diary/details/TripSectionsDescriptives.tsx
+++ b/www/js/diary/details/TripSectionsDescriptives.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Icon, Text, useTheme } from 'react-native-paper';
 import useDerivedProperties from '../useDerivedProperties';
-import { getBaseModeByValue } from '../diaryHelper';
 import TimelineContext from '../../TimelineContext';
 import { base_modes } from 'e-mission-common';
 

--- a/www/js/diary/details/TripSectionsDescriptives.tsx
+++ b/www/js/diary/details/TripSectionsDescriptives.tsx
@@ -4,7 +4,7 @@ import { Icon, Text, useTheme } from 'react-native-paper';
 import useDerivedProperties from '../useDerivedProperties';
 import { getBaseModeByValue } from '../diaryHelper';
 import TimelineContext from '../../TimelineContext';
-import { base_mode_colors } from 'e-mission-common';
+import { base_modes } from 'e-mission-common';
 
 const TripSectionsDescriptives = ({ trip, showConfirmedMode = false }) => {
   const { labelOptions, labelFor, confirmedModeFor } = useContext(TimelineContext);
@@ -25,9 +25,9 @@ const TripSectionsDescriptives = ({ trip, showConfirmedMode = false }) => {
   if ((showConfirmedMode && confirmedModeForTrip) || !trip.sections?.length) {
     let baseMode;
     if (showConfirmedMode && labelOptions && confirmedModeForTrip) {
-      baseMode = base_mode_colors.get_base_mode_by_key(confirmedModeForTrip.baseMode);
+      baseMode = base_modes.get_base_mode_by_key(confirmedModeForTrip.baseMode);
     } else {
-      baseMode = base_mode_colors.get_base_mode_by_key('UNPROCESSED');
+      baseMode = base_modes.get_base_mode_by_key('UNPROCESSED');
     }
     sections = [
       {

--- a/www/js/diary/details/TripSectionsDescriptives.tsx
+++ b/www/js/diary/details/TripSectionsDescriptives.tsx
@@ -2,8 +2,9 @@ import React, { useContext } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Icon, Text, useTheme } from 'react-native-paper';
 import useDerivedProperties from '../useDerivedProperties';
-import { getBaseModeByKey, getBaseModeByValue } from '../diaryHelper';
+import { getBaseModeByValue } from '../diaryHelper';
 import TimelineContext from '../../TimelineContext';
+import { base_mode_colors } from 'e-mission-common';
 
 const TripSectionsDescriptives = ({ trip, showConfirmedMode = false }) => {
   const { labelOptions, labelFor, confirmedModeFor } = useContext(TimelineContext);
@@ -24,9 +25,9 @@ const TripSectionsDescriptives = ({ trip, showConfirmedMode = false }) => {
   if ((showConfirmedMode && confirmedModeForTrip) || !trip.sections?.length) {
     let baseMode;
     if (showConfirmedMode && labelOptions && confirmedModeForTrip) {
-      baseMode = getBaseModeByKey(confirmedModeForTrip.baseMode);
+      baseMode = base_mode_colors.get_base_mode_by_key(confirmedModeForTrip.baseMode);
     } else {
-      baseMode = getBaseModeByKey('UNPROCESSED');
+      baseMode = base_mode_colors.get_base_mode_by_key('UNPROCESSED');
     }
     sections = [
       {

--- a/www/js/diary/diaryHelper.ts
+++ b/www/js/diary/diaryHelper.ts
@@ -27,11 +27,6 @@ export type MotionTypeKey =
   | 'STOPPED_WHILE_IN_VEHICLE'
   | 'AIR_OR_HSR';
 
-export function getBaseModeByValue(value: string, labelOptions: LabelOptions) {
-  const modeOption = labelOptions?.MODE?.find((opt) => opt.value == value);
-  return base_modes.get_base_mode_by_key(modeOption?.baseMode || 'OTHER');
-}
-
 export function getBaseModeByText(text: string, labelOptions: LabelOptions) {
   const modeOption = labelOptions?.MODE?.find((opt) => opt.text == text);
   return base_modes.get_base_mode_by_key(modeOption?.baseMode || 'OTHER');

--- a/www/js/diary/diaryHelper.ts
+++ b/www/js/diary/diaryHelper.ts
@@ -9,9 +9,9 @@ import { LocalDt } from '../types/serverData';
 import humanizeDuration from 'humanize-duration';
 import { AppConfig } from '../types/appConfigTypes';
 import { ImperialConfig } from '../config/useImperialConfig';
-import { base_mode_colors } from 'e-mission-common';
+import { base_modes } from 'e-mission-common';
 
-export const modeColors = base_mode_colors.mode_colors;
+export const modeColors = base_modes.mode_colors;
 
 // parallels the server-side MotionTypes enum: https://github.com/e-mission/e-mission-server/blob/94e7478e627fa8c171323662f951c611c0993031/emission/core/wrapper/motionactivity.py#L12
 export type MotionTypeKey =
@@ -27,16 +27,16 @@ export type MotionTypeKey =
   | 'STOPPED_WHILE_IN_VEHICLE'
   | 'AIR_OR_HSR';
 
-const BaseModes = base_mode_colors.BASE_MODES;
+const BaseModes = base_modes.BASE_MODES;
 
 export function getBaseModeByValue(value: string, labelOptions: LabelOptions) {
   const modeOption = labelOptions?.MODE?.find((opt) => opt.value == value);
-  return base_mode_colors.get_base_mode_by_key(modeOption?.baseMode || 'OTHER');
+  return base_modes.get_base_mode_by_key(modeOption?.baseMode || 'OTHER');
 }
 
 export function getBaseModeByText(text: string, labelOptions: LabelOptions) {
   const modeOption = labelOptions?.MODE?.find((opt) => opt.text == text);
-  return base_mode_colors.get_base_mode_by_key(modeOption?.baseMode || 'OTHER');
+  return base_modes.get_base_mode_by_key(modeOption?.baseMode || 'OTHER');
 }
 
 /**
@@ -122,8 +122,8 @@ export function getDetectedModes(trip: CompositeTrip) {
     .sort(([modeA, distA]: [string, number], [modeB, distB]: [string, number]) => distB - distA) // sort by distance (highest first)
     .map(([mode, dist]: [MotionTypeKey, number]) => ({
       mode,
-      icon: base_mode_colors.get_base_mode_by_key(mode)?.icon,
-      color: base_mode_colors.get_base_mode_by_key(mode)?.color || 'black',
+      icon: base_modes.get_base_mode_by_key(mode)?.icon,
+      color: base_modes.get_base_mode_by_key(mode)?.color || 'black',
       pct: Math.round((dist / trip.distance) * 100) || '<1', // if rounds to 0%, show <1%
     }));
 }
@@ -134,8 +134,8 @@ export function getFormattedSectionProperties(trip: CompositeTrip, imperialConfi
     duration: getFormattedTimeRange(s.start_fmt_time, s.end_fmt_time),
     distance: imperialConfig.getFormattedDistance(s.distance),
     distanceSuffix: imperialConfig.distanceSuffix,
-    icon: base_mode_colors.get_base_mode_by_key(s.sensed_mode_str)?.icon,
-    color: base_mode_colors.get_base_mode_by_key(s.sensed_mode_str)?.color || '#333',
+    icon: base_modes.get_base_mode_by_key(s.sensed_mode_str)?.icon,
+    color: base_modes.get_base_mode_by_key(s.sensed_mode_str)?.color || '#333',
   }));
 }
 

--- a/www/js/diary/diaryHelper.ts
+++ b/www/js/diary/diaryHelper.ts
@@ -11,7 +11,7 @@ import { AppConfig } from '../types/appConfigTypes';
 import { ImperialConfig } from '../config/useImperialConfig';
 import { base_modes } from 'e-mission-common';
 
-export const modeColors = base_modes.mode_colors;
+export type BaseModeKey = string; // TODO figure out how to get keyof typeof base_modes.BASE_MODES
 
 // parallels the server-side MotionTypes enum: https://github.com/e-mission/e-mission-server/blob/94e7478e627fa8c171323662f951c611c0993031/emission/core/wrapper/motionactivity.py#L12
 export type MotionTypeKey =
@@ -26,8 +26,6 @@ export type MotionTypeKey =
   | 'NONE'
   | 'STOPPED_WHILE_IN_VEHICLE'
   | 'AIR_OR_HSR';
-
-const BaseModes = base_modes.BASE_MODES;
 
 export function getBaseModeByValue(value: string, labelOptions: LabelOptions) {
   const modeOption = labelOptions?.MODE?.find((opt) => opt.value == value);

--- a/www/js/diary/timelineHelper.ts
+++ b/www/js/diary/timelineHelper.ts
@@ -28,7 +28,7 @@ import {
 } from '../survey/enketo/enketoHelper';
 import { AppConfig } from '../types/appConfigTypes';
 import { Point, Feature } from 'geojson';
-import { ble_matching, base_mode_colors } from 'e-mission-common';
+import { ble_matching, base_modes } from 'e-mission-common';
 
 const cachedGeojsons: Map<string, GeoJSONData> = new Map();
 
@@ -43,7 +43,7 @@ export function useGeojsonForTrip(trip: CompositeTrip, baseMode?: string) {
   }
 
   const trajectoryColor =
-    (baseMode && base_mode_colors.get_base_mode_by_key(baseMode)?.color) || undefined;
+    (baseMode && base_modes.get_base_mode_by_key(baseMode)?.color) || undefined;
 
   logDebug("Reading trip's " + trip.locations.length + ' location points at ' + new Date());
   const features = [
@@ -269,7 +269,7 @@ function locations2GeojsonTrajectory(
           color for the sensed mode of this section, and fall back to dark grey */
         color:
           trajectoryColor ||
-          base_mode_colors.get_base_mode_by_key(section?.sensed_mode_str)?.color ||
+          base_modes.get_base_mode_by_key(section?.sensed_mode_str)?.color ||
           '#333',
       },
       properties: {

--- a/www/js/diary/timelineHelper.ts
+++ b/www/js/diary/timelineHelper.ts
@@ -1,5 +1,4 @@
 import { displayError, displayErrorMsg, logDebug } from '../plugin/logger';
-import { getBaseModeByValue } from './diaryHelper';
 import { getUnifiedDataForInterval } from '../services/unifiedDataLoader';
 import { getRawEntries } from '../services/commHelper';
 import { ServerResponse, BEMData } from '../types/serverData';

--- a/www/js/diary/timelineHelper.ts
+++ b/www/js/diary/timelineHelper.ts
@@ -42,7 +42,8 @@ export function useGeojsonForTrip(trip: CompositeTrip, baseMode?: string) {
     return cachedGeojsons.get(gjKey);
   }
 
-  const trajectoryColor = (baseMode && base_mode_colors.get_base_mode_by_key(baseMode)?.color) || undefined;
+  const trajectoryColor =
+    (baseMode && base_mode_colors.get_base_mode_by_key(baseMode)?.color) || undefined;
 
   logDebug("Reading trip's " + trip.locations.length + ' location points at ' + new Date());
   const features = [
@@ -266,7 +267,10 @@ function locations2GeojsonTrajectory(
       style: {
         /* If a color was passed as arg, use it for the whole trajectory. Otherwise, use the
           color for the sensed mode of this section, and fall back to dark grey */
-        color: trajectoryColor || base_mode_colors.get_base_mode_by_key(section?.sensed_mode_str)?.color || '#333',
+        color:
+          trajectoryColor ||
+          base_mode_colors.get_base_mode_by_key(section?.sensed_mode_str)?.color ||
+          '#333',
       },
       properties: {
         feature_type: 'section_trajectory',

--- a/www/js/diary/timelineHelper.ts
+++ b/www/js/diary/timelineHelper.ts
@@ -1,5 +1,5 @@
 import { displayError, displayErrorMsg, logDebug } from '../plugin/logger';
-import { getBaseModeByKey, getBaseModeByValue } from './diaryHelper';
+import { getBaseModeByValue } from './diaryHelper';
 import { getUnifiedDataForInterval } from '../services/unifiedDataLoader';
 import { getRawEntries } from '../services/commHelper';
 import { ServerResponse, BEMData } from '../types/serverData';
@@ -28,7 +28,7 @@ import {
 } from '../survey/enketo/enketoHelper';
 import { AppConfig } from '../types/appConfigTypes';
 import { Point, Feature } from 'geojson';
-import { ble_matching } from 'e-mission-common';
+import { ble_matching, base_mode_colors } from 'e-mission-common';
 
 const cachedGeojsons: Map<string, GeoJSONData> = new Map();
 
@@ -42,7 +42,7 @@ export function useGeojsonForTrip(trip: CompositeTrip, baseMode?: string) {
     return cachedGeojsons.get(gjKey);
   }
 
-  const trajectoryColor = (baseMode && getBaseModeByKey(baseMode)?.color) || undefined;
+  const trajectoryColor = (baseMode && base_mode_colors.get_base_mode_by_key(baseMode)?.color) || undefined;
 
   logDebug("Reading trip's " + trip.locations.length + ' location points at ' + new Date());
   const features = [
@@ -266,7 +266,7 @@ function locations2GeojsonTrajectory(
       style: {
         /* If a color was passed as arg, use it for the whole trajectory. Otherwise, use the
           color for the sensed mode of this section, and fall back to dark grey */
-        color: trajectoryColor || getBaseModeByKey(section?.sensed_mode_str)?.color || '#333',
+        color: trajectoryColor || base_mode_colors.get_base_mode_by_key(section?.sensed_mode_str)?.color || '#333',
       },
       properties: {
         feature_type: 'section_trajectory',

--- a/www/js/metrics/MetricsCard.tsx
+++ b/www/js/metrics/MetricsCard.tsx
@@ -15,7 +15,7 @@ import {
 import ToggleSwitch from '../components/ToggleSwitch';
 import { cardStyles } from './MetricsTab';
 import { labelKeyToRichMode, labelOptions } from '../survey/multilabel/confirmHelper';
-import { getBaseModeByText, modeColors } from '../diary/diaryHelper';
+import { getBaseModeByText } from '../diary/diaryHelper';
 import { useTranslation } from 'react-i18next';
 import { GroupingField, MetricName } from '../types/appConfigTypes';
 import { useImperialConfig } from '../config/useImperialConfig';

--- a/www/js/metrics/MetricsCard.tsx
+++ b/www/js/metrics/MetricsCard.tsx
@@ -15,10 +15,11 @@ import {
 import ToggleSwitch from '../components/ToggleSwitch';
 import { cardStyles } from './MetricsTab';
 import { labelKeyToRichMode, labelOptions } from '../survey/multilabel/confirmHelper';
-import { getBaseModeByKey, getBaseModeByText, modeColors } from '../diary/diaryHelper';
+import { getBaseModeByText, modeColors } from '../diary/diaryHelper';
 import { useTranslation } from 'react-i18next';
 import { GroupingField, MetricName } from '../types/appConfigTypes';
 import { useImperialConfig } from '../config/useImperialConfig';
+import { base_mode_colors } from 'e-mission-common';
 
 type Props = {
   metricName: MetricName;
@@ -115,7 +116,7 @@ const MetricsCard = ({
   // All other modes are colored according to their base mode
   const getColorForLabel = (label: string) => {
     if (label == 'Unlabeled') {
-      const unknownModeColor = getBaseModeByKey('UNKNOWN').color;
+      const unknownModeColor = base_mode_colors.get_base_mode_by_key('UNKNOWN').color;
       return colorLib(unknownModeColor).alpha(0.15).rgb().string();
     }
     return getBaseModeByText(label, labelOptions).color;

--- a/www/js/metrics/MetricsCard.tsx
+++ b/www/js/metrics/MetricsCard.tsx
@@ -19,7 +19,7 @@ import { getBaseModeByText, modeColors } from '../diary/diaryHelper';
 import { useTranslation } from 'react-i18next';
 import { GroupingField, MetricName } from '../types/appConfigTypes';
 import { useImperialConfig } from '../config/useImperialConfig';
-import { base_mode_colors } from 'e-mission-common';
+import { base_modes } from 'e-mission-common';
 
 type Props = {
   metricName: MetricName;
@@ -116,7 +116,7 @@ const MetricsCard = ({
   // All other modes are colored according to their base mode
   const getColorForLabel = (label: string) => {
     if (label == 'Unlabeled') {
-      const unknownModeColor = base_mode_colors.get_base_mode_by_key('UNKNOWN').color;
+      const unknownModeColor = base_modes.get_base_mode_by_key('UNKNOWN').color;
       return colorLib(unknownModeColor).alpha(0.15).rgb().string();
     }
     return getBaseModeByText(label, labelOptions).color;


### PR DESCRIPTION
Integrated `e-mission-common` [PR](https://github.com/JGreenlee/e-mission-common/pull/1) which unifies the base mode colors and a helper function. Went through the code base and swapped all instances of `getBaseModeByKey()` with `base_mode_colors.get_base_mode_by_key()`. I also converted `modeColors` and `BaseModes` in `diaryHelper.ts` to now use our unified functions.  In `diaryHelper.ts` I also had to add in types for one of the functions as I was getting a typescript "type unknown of distA/distB" error. I guess when I removed `getBaseModeByKey()`, the type inference couldn't figure out that they were numbers so it was throwing that error.

**Testing Done**

I went through each component that I converted `getBaseModeByKey()` for `base_mode_colors.get_base_mode_by_key()` and tested it out to make sure it still worked properly.