### PR TITLE
📍 Use the server-side geocoded addresses for place names

### DIFF
--- a/www/js/types/diaryTypes.ts
+++ b/www/js/types/diaryTypes.ts
@@ -2,6 +2,7 @@
  and user input objects.
  As much as possible, these types parallel the types used in the server code. */
 
+import { NominatimResponse } from '../diary/addressNamesHelper';
 import { BaseModeKey, MotionTypeKey } from '../diary/diaryHelper';
 import useDerivedProperties from '../diary/useDerivedProperties';
 import { VehicleIdentity } from './appConfigTypes';
@@ -32,8 +33,13 @@ export type ConfirmedPlace = {
   exit_fmt_time: string; // ISO string e.g. 2023-10-31T12:00:00.000-04:00
   exit_local_dt: LocalDt;
   exit_ts: number; // Unix timestamp
+
+  // one of these depending on what we decide to keep on the server
+  geocoded_address?: NominatimResponse['address'];
+  reverse_geocode?: NominatimResponse;
+
   key: string;
-  location: Geometry;
+  location: Point;
   origin_key: string;
   raw_places: ObjectId[];
   source: string;
@@ -96,7 +102,7 @@ export type CompositeTrip = {
   confirmed_trip: ObjectId;
   distance: number;
   duration: number;
-  end_confirmed_place: BEMData<ConfirmedPlace>;
+  end_confirmed_place: ConfirmedPlace;
   end_fmt_time: string;
   end_loc: Point;
   end_local_dt: LocalDt;
@@ -113,7 +119,7 @@ export type CompositeTrip = {
   raw_trip: ObjectId;
   sections: SectionData[];
   source: string;
-  start_confirmed_place: BEMData<ConfirmedPlace>;
+  start_confirmed_place: ConfirmedPlace;
   start_fmt_time: string;
   start_loc: Point;
   start_local_dt: LocalDt;


### PR DESCRIPTION
Since the server now fills in geocoded_address (we may later change this to reverse_geocode), we will only need to perform a client-side nominatim request for unprocessed trips. If either field is present, we'll use that; otherwise schedule a request like before.

Updated types:

-Since the CompositeTrip type definition is based on the return type of Timeline.readAllCompositeTrips, which is after "unpacking", `start_confirmed_place` and `end_confirmed_place` are simply `ConfirmedPlace`, not `BEMData<ConfirmedPlace>`
-ConfirmedPlace.location is a `Point`, (having `coordinates`) not just a generic `Geometry`
-added `geocoded_address` and `reverse_geocode`, both optional since it depends on https://github.com/e-mission/e-mission-server/pull/973