### PR TITLE
🐛 Re-enable "Download JSON dump"

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -120,7 +120,7 @@
     "cordova-plugin-app-version": "0.1.14",
     "cordova-plugin-customurlscheme": "5.0.2",
     "cordova-plugin-device": "2.1.0",
-    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.8.9",
+    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.9.0",
     "cordova-plugin-em-opcodeauth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.7.2",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.7",
     "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.3.3",

--- a/setup/activate_native.sh
+++ b/setup/activate_native.sh
@@ -10,6 +10,9 @@ then
     echo "ANDROID_HOME and ANDROID_SDK_ROOT not set, android SDK not found"
 fi
 
+echo "Activating sdkman, and by default, gradle"
+source ~/.sdkman/bin/sdkman-init.sh
+
 echo "Ensuring that we use the most recent version of the command line tools"
 export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$PATH
 

--- a/setup/export_shared_dep_versions.sh
+++ b/setup/export_shared_dep_versions.sh
@@ -6,6 +6,7 @@ export NODE_VERSION=20.9.0
 # Looks like brew supports only major and minor, not patch version
 export RUBY_VERSION=3.0
 export COCOAPODS_VERSION=1.15.2
+export GRADLE_VERSION=8.10
 export OSX_EXP_VERSION=12
 
 export NVM_DIR="$HOME/.nvm"

--- a/setup/setup_android_native.sh
+++ b/setup/setup_android_native.sh
@@ -27,4 +27,19 @@ else
     echo "ANDROID_HOME = $ANDROID_HOME; ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
 fi
 
+echo "Setting up sdkman"
+curl -s "https://get.sdkman.io" | bash
+source ~/.sdkman/bin/sdkman-init.sh
+
+CURR_GRADLE_VER=`sdk current gradle | cut -d " " -f 4 | xargs`
+
+echo "CURR_GRADLE_VER = '$CURR_GRADLE_VER', expected $GRADLE_VERSION"
+
+if [[ $CURR_GRADLE_VER == $GRADLE_VERSION ]]; then
+    echo "Already have gradle version $GRADLE_VERSION"
+else
+    echo "Setting up gradle using SDKMan"
+    sdk install gradle $GRADLE_VERSION
+fi
+
 source setup/setup_shared_native.sh

--- a/www/js/services/controlHelper.ts
+++ b/www/js/services/controlHelper.ts
@@ -39,48 +39,38 @@ export function getMyDataHelpers(fileName: string, startTimeString: string, endT
   function localShareData() {
     return new Promise<void>((resolve, reject) => {
       window['resolveLocalFileSystemURL'](window['cordova'].file.cacheDirectory, (fs) => {
-        fs.filesystem.root.getFile(fileName, null, (fileEntry) => {
-          logDebug(`fileEntry ${fileEntry.nativeURL} is file? ${fileEntry.isFile.toString()}`);
-          fileEntry.file(
-            (file) => {
-              const reader = new FileReader();
-
-              reader.onloadend = () => {
-                const readResult = this.result as string;
-                logDebug(`Successfull file read with ${readResult.length} characters`);
-                const dataArray = JSON.parse(readResult);
-                logDebug(`Successfully read resultList of size ${dataArray.length}`);
-                let attachFile = fileEntry.nativeURL;
-                const shareObj = {
-                  files: [attachFile],
-                  message: i18next.t(
-                    'shareFile-service.send-data.body-data-consists-of-list-of-entries',
-                  ),
-                  subject: i18next.t('shareFile-service.send-data.subject-data-dump-from-to', {
-                    start: startTimeString,
-                    end: endTimeString,
-                  }),
-                };
-                window['plugins'].socialsharing.shareWithOptions(
-                  shareObj,
-                  (result) => {
-                    logDebug(`Share Completed? ${result.completed}`); // On Android, most likely returns false
-                    logDebug(`Shared to app:  ${result.app}`);
-                    resolve();
-                  },
-                  (msg) => {
-                    logDebug(`Sharing failed with message ${msg}`);
-                  },
-                );
-              };
-              reader.readAsText(file);
-            },
-            (error) => {
-              displayError(error, 'Error while downloading JSON dump');
-              reject(error);
-            },
-          );
-        });
+        fs.filesystem.root.getFile(
+          fileName,
+          null,
+          (fileEntry) => {
+            logDebug(`fileEntry ${fileEntry.nativeURL} is file? ${fileEntry.isFile.toString()}`);
+            const shareObj = {
+              files: [fileEntry.nativeURL],
+              message: i18next.t(
+                'shareFile-service.send-data.body-data-consists-of-list-of-entries',
+              ),
+              subject: i18next.t('shareFile-service.send-data.subject-data-dump-from-to', {
+                start: startTimeString,
+                end: endTimeString,
+              }),
+            };
+            window['plugins'].socialsharing.shareWithOptions(
+              shareObj,
+              (result) => {
+                logDebug(`Share Completed? ${result.completed}`); // On Android, most likely returns false
+                logDebug(`Shared to app:  ${result.app}`);
+                resolve();
+              },
+              (error) => {
+                displayError(error, `Sharing failed with message`);
+              },
+            );
+          },
+          (error) => {
+            displayError(error, 'Error while downloading JSON dump');
+            reject(error);
+          },
+        );
       });
     });
   }
@@ -117,7 +107,7 @@ export function getMyDataHelpers(fileName: string, startTimeString: string, endT
  * getMyData fetches timeline data for a given day, and then gives the user a prompt to share the data
  * @param timeStamp initial timestamp of the timeline to be fetched.
  */
-export function getMyData(timeStamp: Date) {
+export async function getMyData(timeStamp: Date) {
   // We are only retrieving data for a single day to avoid
   // running out of memory on the phone
   const endTime = DateTime.fromJSDate(timeStamp);
@@ -125,7 +115,8 @@ export function getMyData(timeStamp: Date) {
   const startTimeString = startTime.toFormat("yyyy'-'MM'-'dd");
   const endTimeString = endTime.toFormat("yyyy'-'MM'-'dd");
 
-  const dumpFile = startTimeString + '.' + endTimeString + '.timeline';
+  // let's rename this to .txt so that we can email it on iPhones
+  const dumpFile = startTimeString + '.' + endTimeString + '.timeline.txt';
   alert(`Going to retrieve data to ${dumpFile}`);
 
   const getDataMethods = getMyDataHelpers(dumpFile, startTimeString, endTimeString);


### PR DESCRIPTION
After the giant refactor, both "email log" and "download JSON dump" were broken. We fixed "email log" in
https://github.com/e-mission/e-mission-phone/pull/1160 but didn't fix "Download JSON dump then, because of lack of time.

This fixes the "Download JSON dump" as well by making it similar to implementation in "email log".

It was already fairly similar, but for some reason, was reading the data before sharing the file

```
             const reader = new FileReader();

             reader.onloadend = () => {
             const readResult = this.result as string;
             logDebug(`Successfull file read with ${readResult.length} characters`);
```

and "this" doesn't exist, resulting in an undefined error. Since the shareObj takes in a file name anyway, I just made this similar to the emailLog changes by passing in the filename directly.

Also, similar ot the "Email Log", added a `.txt` extension so that the file can be sent on iOS.

Testing done:
- Before this change: clicking on "Download JSON dump" did not do anything
- After this change: clicking on "Download JSON dump" launched the share menu

I haven't actually tried sharing yet because gmail is not configured on the emulator.