### PR TITLE
🐛 Fix timeline range issues

### DIFF
--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -122,7 +122,7 @@
     "cordova-plugin-app-version": "0.1.14",
     "cordova-plugin-customurlscheme": "5.0.2",
     "cordova-plugin-device": "2.1.0",
-    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.9.2",
+    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.9.3",
     "cordova-plugin-em-opcodeauth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.7.2",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.7",
     "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.3.3",

--- a/www/js/TimelineContext.ts
+++ b/www/js/TimelineContext.ts
@@ -179,8 +179,8 @@ export const useTimelineContext = (): ContextProps => {
 
   function loadDateRange(range: [string, string]) {
     logDebug('Timeline: loadDateRange with newDateRange = ' + range);
-    if (!pipelineRange) {
-      logWarn('No pipelineRange yet - early return from loadDateRange');
+    if (!pipelineRange?.start_ts) {
+      logWarn('No pipelineRange start_ts yet - early return from loadDateRange');
       return;
     }
     const pipelineStartDate = DateTime.fromSeconds(pipelineRange.start_ts).toISODate();
@@ -223,8 +223,10 @@ export const useTimelineContext = (): ContextProps => {
   }
 
   async function fetchTripsInRange(dateRange: [string, string]) {
-    if (!pipelineRange?.start_ts || !pipelineRange?.end_ts)
-      return logWarn('No pipelineRange yet - early return');
+    if (!pipelineRange?.start_ts || !pipelineRange?.end_ts) {
+      logDebug('No pipelineRange yet, returning empty lists');
+      return [[], []];
+    }
     logDebug('Timeline: fetchTripsInRange from ' + dateRange[0] + ' to ' + dateRange[1]);
 
     const [startTs, endTs] = isoDateRangeToTsRange(dateRange);

--- a/www/js/TimelineContext.ts
+++ b/www/js/TimelineContext.ts
@@ -25,9 +25,12 @@ import useAppStateChange from './useAppStateChange';
 import { isoDateRangeToTsRange, isoDateWithOffset } from './datetimeUtil';
 import { base_modes } from 'e-mission-common';
 
-const TODAY_DATE = DateTime.now().toISODate();
+const getTodayDate = () => DateTime.now().toISODate();
 // initial date range is the past week: [TODAY - 6 days, TODAY]
-const INITIAL_DATE_RANGE: [string, string] = [isoDateWithOffset(TODAY_DATE, -6), TODAY_DATE];
+const getPastWeekDateRange = (): [string, string] => {
+  const todayDate = getTodayDate();
+  return [isoDateWithOffset(todayDate, -6), todayDate];
+};
 
 type ContextProps = {
   labelOptions: LabelOptions | null;
@@ -60,7 +63,7 @@ export const useTimelineContext = (): ContextProps => {
   // date range (inclusive) that has been loaded into the UI [YYYY-MM-DD, YYYY-MM-DD]
   const [queriedDateRange, setQueriedDateRange] = useState<[string, string] | null>(null);
   // date range (inclusive) chosen by datepicker [YYYY-MM-DD, YYYY-MM-DD]
-  const [dateRange, setDateRange] = useState<[string, string]>(INITIAL_DATE_RANGE);
+  const [dateRange, setDateRange] = useState<[string, string]>(getPastWeekDateRange);
   // map of timeline entries (trips, places, untracked time), ids to objects
   const [timelineMap, setTimelineMap] = useState<TimelineMap | null>(null);
   const [timelineIsLoading, setTimelineIsLoading] = useState<string | false>('replace');
@@ -184,7 +187,7 @@ export const useTimelineContext = (): ContextProps => {
     // clamp range to ensure it is within [pipelineStartDate, TODAY_DATE]
     const clampedDateRange: [string, string] = [
       new Date(range[0]) < new Date(pipelineStartDate) ? pipelineStartDate : range[0],
-      new Date(range[1]) > new Date(TODAY_DATE) ? TODAY_DATE : range[1],
+      new Date(range[1]) > new Date(getTodayDate()) ? getTodayDate() : range[1],
     ];
     if (clampedDateRange[0] != dateRange?.[0] || clampedDateRange[1] != dateRange?.[1]) {
       logDebug('Timeline: loadDateRange setting new date range = ' + clampedDateRange);
@@ -257,7 +260,7 @@ export const useTimelineContext = (): ContextProps => {
     try {
       logDebug('timelineContext: refreshTimeline');
       setTimelineIsLoading('replace');
-      setDateRange(INITIAL_DATE_RANGE);
+      setDateRange(getPastWeekDateRange());
       setQueriedDateRange(null);
       setTimelineMap(null);
       setRefreshTime(new Date());

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -57,7 +57,8 @@ const TimelineScrollList = ({ listEntries }: Props) => {
     </LoadMoreButton>
   );
 
-  const pipelineEndDate = pipelineRange && DateTime.fromSeconds(pipelineRange.end_ts).toISODate();
+  const pipelineEndDate =
+    pipelineRange?.end_ts && DateTime.fromSeconds(pipelineRange.end_ts).toISODate();
   const noTravelBanner = (
     <Banner visible={true} icon={({ size }) => <Icon source="alert-circle" size={size} />}>
       <View style={{ width: '100%' }}>


### PR DESCRIPTION
### on timeline refresh, recompute "past week" date range

Within one app session, the constants TODAY_DATE and INITIAL_DATE_RANGE do not change. On app resume, we call refreshTimeline which sets dateRange to INITIAL_DATE_RANGE. But this is a problem if the app stays running for multiple days because INITIAL_DATE_RANGE is old.

Instead we need to recompute the date range, using an up-to-date "today" date. Thus, TODAY_DATE and INITIAL_DATE_RANGE are replaced with functions: getTodayDate and getPastWeekDateRange.

<hr>

### fix errors on pipelineRange with null start_ts and end_ts

For a new user where the pipeline has not yet processed, pipelineRange will be `{ start_ts: null, end_ts: null }`.
We should handle this appropriately:
-in TimelineScrollList, pipelineEndDate should be undefined instead of trying to call DateTime.fromSeconds with null
-loadDateRange should return early and do nothing
-The early return from fetchTripsInRange should return empty arrays, not void

<hr>

### fix re-prompting of notifications permission after denied