### PR TITLE
🐛 fix errors on pipelineRange with null start_ts and end_ts

### DIFF
--- a/www/js/TimelineContext.ts
+++ b/www/js/TimelineContext.ts
@@ -176,8 +176,8 @@ export const useTimelineContext = (): ContextProps => {
 
   function loadDateRange(range: [string, string]) {
     logDebug('Timeline: loadDateRange with newDateRange = ' + range);
-    if (!pipelineRange) {
-      logWarn('No pipelineRange yet - early return from loadDateRange');
+    if (!pipelineRange?.start_ts) {
+      logWarn('No pipelineRange start_ts yet - early return from loadDateRange');
       return;
     }
     const pipelineStartDate = DateTime.fromSeconds(pipelineRange.start_ts).toISODate();
@@ -220,8 +220,10 @@ export const useTimelineContext = (): ContextProps => {
   }
 
   async function fetchTripsInRange(dateRange: [string, string]) {
-    if (!pipelineRange?.start_ts || !pipelineRange?.end_ts)
-      return logWarn('No pipelineRange yet - early return');
+    if (!pipelineRange?.start_ts || !pipelineRange?.end_ts) {
+      logDebug('No pipelineRange yet, returning empty lists');
+      return [[], []];
+    }
     logDebug('Timeline: fetchTripsInRange from ' + dateRange[0] + ' to ' + dateRange[1]);
 
     const [startTs, endTs] = isoDateRangeToTsRange(dateRange);

--- a/www/js/diary/list/TimelineScrollList.tsx
+++ b/www/js/diary/list/TimelineScrollList.tsx
@@ -57,7 +57,8 @@ const TimelineScrollList = ({ listEntries }: Props) => {
     </LoadMoreButton>
   );
 
-  const pipelineEndDate = pipelineRange && DateTime.fromSeconds(pipelineRange.end_ts).toISODate();
+  const pipelineEndDate =
+    pipelineRange?.end_ts && DateTime.fromSeconds(pipelineRange.end_ts).toISODate();
   const noTravelBanner = (
     <Banner visible={true} icon={({ size }) => <Icon source="alert-circle" size={size} />}>
       <View style={{ width: '100%' }}>


### PR DESCRIPTION
For a new user where the pipeline has not yet processed, pipelineRange will be `{ start_ts: null, end_ts: null }`. We should handle this appropriately:
-in TimelineScrollList, pipelineEndDate should be undefined instead of trying to call DateTime.fromSeconds with null
-loadDateRange should return early and do nothing
-The early return from fetchTripsInRange should return empty arrays, not void