### PR TITLE
Fix the automated sdk install build

### DIFF
--- a/.github/workflows/android-automated-sdk-install.yml
+++ b/.github/workflows/android-automated-sdk-install.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         export JAVA_HOME=$JAVA_HOME_17_X64
         export ANDROID_SDK_ROOT=$NEW_ANDROID_SDK_ROOT
-        bash setup/setup_android_native.sh
+        bash setup/setup_native.sh
 
     - name: Ensure that the path is correct and the project can be activated
       shell: bash -l {0}


### PR DESCRIPTION
In https://github.com/e-mission/e-mission-phone/pull/1180 we unified the setup scripts so that we don't have separate android and iOS setup. This is because the plugins include both, so installing the plugins will fail unless the dependencies are installed, which, in turn, depends on having cocoapods installed

6dd71f18321c77cfaf3f67ba19911b4bc282396d fixed all the other github action scripts, but left this one out since it wasn't triggered