### PR TITLE
💚 Enable babel transpiling of react-native as well

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,6 +26,14 @@ jobs:
           source setup/activate_serve.sh
           npm run test
 
+      - name: Upload exact version(s) of packages used
+        uses: actions/upload-artifact@v4
+        with:
+          name: versions-results
+          path: |
+            package-lock.json
+            ./coverage/coverage-final.json
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash -l {0}
         run: |
           source setup/activate_serve.sh
-          npx jest
+          npm run test
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-typescript', '@babel/preset-react'],
+  presets: ['@babel/preset-env', '@babel/preset-typescript', '@babel/preset-react', 'module:@react-native/babel-preset'],
   plugins: ['@babel/plugin-transform-flow-strip-types'],
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+coverage:
+  status:
+    project:
+      default: false  # disable the default status that measures entire project
 comment:                  
   layout: " diff, flags, files"
   behavior: default


### PR DESCRIPTION
This fixes the code coverage github action.

Without this change, we were getting the error

```
i FAIL  www/__tests__/DateSelect.test.tsx
  ● Test suite failed to run

    SyntaxError: /private/tmp/e-mission-phone/node_modules/react-native/Libraries/vendor/emitter/EventEmitter.js: Unexpected token, expected "]" (39:5)
```

The last successful run was from Oct 17.
The first failed run was from Oct 23.

We have not made any changes to the react-native components that we directly import since Sept 2024. However, we use a carat semver, so we will pull newly released minor versions. One of our dependencies bumped up the version of RN that they use, and released a new minor version, which broke this.

After fruitlessly searching around for a root cause (as documented in the PR comments), since we import a lot of components and it was laborious to check when each of them have been updated, I did a brute force search in GitHub for this error and found both the same issue
https://github.com/facebook/react-native/issues/48228 and a fix that worked
https://github.com/facebook/react-native/issues/48228#issuecomment-2547160218

I am surprised this has not been reported widely, but I guess it is fairly new! Thanks to @Basil-Code for the suggestion!