### PR TITLE
Support mode_studied being an array of multiple modes

### DIFF
--- a/www/js/survey/multilabel/confirmHelper.ts
+++ b/www/js/survey/multilabel/confirmHelper.ts
@@ -5,8 +5,9 @@ import { LabelOption, LabelOptions, MultilabelKey, InputDetails } from '../../ty
 import { CompositeTrip, InferredLabels, TimelineEntry } from '../../types/diaryTypes';
 import { UserInputMap } from '../../TimelineContext';
 import DEFAULT_LABEL_OPTIONS from 'e-mission-common/src/emcommon/resources/label-options.default.json';
+import AppConfig from '../../types/appConfigTypes';
 
-let appConfig;
+let appConfig: AppConfig;
 export let labelOptions: LabelOptions;
 export let inputDetails: InputDetails<MultilabelKey>;
 
@@ -51,7 +52,7 @@ export function getLabelInputDetails(appConfigParam?) {
   if (inputDetails) return inputDetails;
 
   if (!appConfig.intro.mode_studied) {
-    /* If there is no mode of interest, we don't need REPLACED_MODE.
+    /* If there are no modes of interest, we don't need REPLACED_MODE.
       So just return the base input details. */
     return baseLabelInputDetails;
   }
@@ -71,9 +72,13 @@ export function getLabelInputDetails(appConfigParam?) {
 export function labelInputDetailsForTrip(userInputForTrip, appConfigParam?) {
   if (appConfigParam) appConfig = appConfigParam;
   if (appConfig.intro.mode_studied) {
-    if (userInputForTrip?.['MODE']?.data?.label == appConfig.intro.mode_studied) {
-      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data?.label}, mode of study = ${appConfig.intro.mode_studied}.
-        Needs REPLACED_MODE`);
+    const modesStudied =
+      typeof appConfig.intro.mode_studied == 'string'
+        ? [appConfig.intro.mode_studied]
+        : appConfig.intro.mode_studied;
+    if (modesStudied.includes(userInputForTrip?.['MODE']?.data?.label)) {
+      logDebug(`Found trip labeled with ${userInputForTrip?.['MODE']?.data?.label}; 
+        modesStudied = ${modesStudied}. Needs REPLACED_MODE`);
       return getLabelInputDetails();
     } else {
       return baseLabelInputDetails;

--- a/www/js/types/appConfigTypes.ts
+++ b/www/js/types/appConfigTypes.ts
@@ -29,7 +29,7 @@ export type IntroConfig = {
   app_required: boolean;
   start_month: number;
   start_year: number;
-  mode_studied?: string;
+  mode_studied?: string | string[];
   program_admin_contact: string;
   deployment_partner_name: string;
   translated_text: {


### PR DESCRIPTION
mode_studied is currently a string, but we want to support multiple modes of interest. We can allow it to be `string | string[]` and handle both cases at runtime

Updated app config typing accordingly