### PR TITLE
📍 use reverse-geocoded place names in composite trips

### DIFF
--- a/www/__tests__/useAddressNames.test.ts
+++ b/www/__tests__/useAddressNames.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import useAddressNames from '../js/diary/useAddressNames';
+import { CompositeTrip, ConfirmedPlace } from '../js/types/diaryTypes';
+
+global.fetch = (url) =>
+  new Promise((rs, rj) => {
+    if (url.endsWith('lat=39.740322&lon=-105.168467')) {
+      // prettier-ignore
+      rs({json: () => Promise.resolve({"place_id":385177537,"licence":"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright","osm_type":"way","osm_id":69546971,"lat":"39.740274150000005","lon":"-105.16842343310245","display_name":"East Entrance Gate, Denver West Parkway, Applewood, Jefferson County, Colorado, 80410, United States","address":{"building":"East Entrance Gate","road":"Denver West Parkway","village":"Applewood","county":"Jefferson County","state":"Colorado","ISO3166-2-lvl4":"US-CO","postcode":"80410","country":"United States","country_code":"us"},"boundingbox":["39.7402185","39.7403381","-105.1684959","-105.1683483"]})});
+    } else if (url.endsWith('lat=39.744749&lon=-105.150327')) {
+      // prettier-ignore
+      rs({json: () => Promise.resolve({"place_id":216339398,"licence":"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright","osm_type":"way","osm_id":359442199,"lat":"39.7447133","lon":"-105.14973971883751","display_name":"1840, Alkire Court, Golden, Jefferson County, Colorado, 80401, United States","address":{"house_number":"1840","road":"Alkire Court","city":"Golden","county":"Jefferson County","state":"Colorado","ISO3166-2-lvl4":"US-CO","postcode":"80401","country":"United States","country_code":"us"},"boundingbox":["39.744683","39.7447438","-105.1497927","-105.1496867"]})});
+    }
+  }) as any;
+
+describe('useAddressNames', () => {
+  it('should return location name for a confirmed place', async () => {
+    const place = {
+      key: 'analysis/confirmed_place',
+      display_name: 'Third Street, City',
+    } as any as ConfirmedPlace;
+    const { result } = renderHook(() => useAddressNames(place));
+    await waitFor(() => {
+      const [locName] = result.current;
+      expect(locName).toBe('Third Street, City');
+    });
+  });
+
+  it('should return start and end location names for a composite trip', async () => {
+    const trip = {
+      key: 'analysis/composite_trip',
+      start_confirmed_place: { display_name: 'First Street, City' },
+      end_confirmed_place: { display_name: 'Second Street, City' },
+    } as any as CompositeTrip;
+
+    const { result } = renderHook(() => useAddressNames(trip));
+    await waitFor(() => {
+      const [startLocName, endLocName] = result.current;
+      expect(startLocName).toBe('First Street, City');
+      expect(endLocName).toBe('Second Street, City');
+    });
+  });
+
+  it('should fetch start and end location names for an unprocessed trip', async () => {
+    const trip = {
+      key: 'analysis/composite_trip',
+      start_loc: { coordinates: [-105.168467, 39.740322] },
+      end_loc: { coordinates: [-105.150327, 39.744749] },
+    } as any as CompositeTrip;
+
+    const { result } = renderHook(() => useAddressNames(trip));
+    await waitFor(() => {
+      const [startLocName, endLocName] = result.current;
+      expect(startLocName).toBe('Denver West Parkway, Jefferson County');
+      expect(endLocName).toBe('Alkire Court, Golden');
+    });
+  });
+});

--- a/www/js/diary/LabelTab.tsx
+++ b/www/js/diary/LabelTab.tsx
@@ -11,7 +11,6 @@ import { createStackNavigator } from '@react-navigation/stack';
 import LabelScreenDetails from './details/LabelDetailsScreen';
 import { NavigationContainer } from '@react-navigation/native';
 import { updateAllUnprocessedInputs } from './timelineHelper';
-import { fillLocationNamesOfTrip } from './addressNamesHelper';
 import { logDebug } from '../plugin/logger';
 import { configuredFilters as multilabelConfiguredFilters } from '../survey/multilabel/infinite_scroll_filters';
 import { configuredFilters as enketoConfiguredFilters } from '../survey/enketo/infinite_scroll_filters';
@@ -52,15 +51,6 @@ const LabelTab = () => {
       setFilterInputs(filtersWithState);
     }
   }, [appConfig]);
-
-  useEffect(() => {
-    if (!timelineMap) return;
-    const timelineEntries = Array.from(timelineMap.values());
-    if (!timelineEntries?.length) return;
-    timelineEntries.reverse().forEach((entry) => {
-      if (isTrip(entry)) fillLocationNamesOfTrip(entry);
-    });
-  }, [timelineMap]);
 
   useEffect(() => {
     if (!timelineMap || !timelineLabelMap || !filterInputs) return;

--- a/www/js/diary/cards/PlaceCard.tsx
+++ b/www/js/diary/cards/PlaceCard.tsx
@@ -14,7 +14,7 @@ import AddNoteButton from '../../survey/enketo/AddNoteButton';
 import AddedNotesList from '../../survey/enketo/AddedNotesList';
 import { getTheme } from '../../appTheme';
 import { DiaryCard, cardStyles } from './DiaryCard';
-import { useAddressNames } from '../addressNamesHelper';
+import useAddressNames from '../useAddressNames';
 import useDerivedProperties from '../useDerivedProperties';
 import StartEndLocations from '../components/StartEndLocations';
 import TimelineContext from '../../TimelineContext';

--- a/www/js/diary/cards/TripCard.tsx
+++ b/www/js/diary/cards/TripCard.tsx
@@ -17,7 +17,7 @@ import AddedNotesList from '../../survey/enketo/AddedNotesList';
 import { getTheme } from '../../appTheme';
 import { DiaryCard, cardStyles } from './DiaryCard';
 import { useNavigation } from '@react-navigation/native';
-import { useAddressNames } from '../addressNamesHelper';
+import useAddressNames from '../useAddressNames';
 import TimelineContext from '../../TimelineContext';
 import useDerivedProperties from '../useDerivedProperties';
 import StartEndLocations from '../components/StartEndLocations';

--- a/www/js/diary/cards/UntrackedTimeCard.tsx
+++ b/www/js/diary/cards/UntrackedTimeCard.tsx
@@ -13,7 +13,7 @@ import { Text } from 'react-native-paper';
 import { getTheme } from '../../appTheme';
 import { useTranslation } from 'react-i18next';
 import { DiaryCard, cardStyles } from './DiaryCard';
-import { useAddressNames } from '../addressNamesHelper';
+import useAddressNames from '../useAddressNames';
 import useDerivedProperties from '../useDerivedProperties';
 import StartEndLocations from '../components/StartEndLocations';
 

--- a/www/js/diary/details/LabelDetailsScreen.tsx
+++ b/www/js/diary/details/LabelDetailsScreen.tsx
@@ -18,7 +18,7 @@ import LeafletView from '../../components/LeafletView';
 import { useTranslation } from 'react-i18next';
 import MultilabelButtonGroup from '../../survey/multilabel/MultiLabelButtonGroup';
 import UserInputButton from '../../survey/enketo/UserInputButton';
-import { useAddressNames } from '../addressNamesHelper';
+import useAddressNames from '../useAddressNames';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import useDerivedProperties from '../useDerivedProperties';
 import StartEndLocations from '../components/StartEndLocations';

--- a/www/js/diary/useAddressNames.ts
+++ b/www/js/diary/useAddressNames.ts
@@ -110,7 +110,7 @@ function usePlaceAddressName(place: ConfirmedPlace) {
   return [placeName];
 }
 
-export function useAddressNames(tlEntry: TimelineEntry): string[] {
+export default function useAddressNames(tlEntry: TimelineEntry): string[] {
   if (isTrip(tlEntry)) {
     return useTripAddressNames(tlEntry);
   } else {

--- a/www/js/services/commHelper.ts
+++ b/www/js/services/commHelper.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import { displayError, logDebug } from '../plugin/logger';
 import { ServerConnConfig } from 'nrel-openpath-deploy-configs';
 import { TimestampRange } from '../types/diaryTypes';
+import { ServerResponse } from '../types/serverData';
 
 const log = (str, r) => {
   logDebug(str);
@@ -38,7 +39,7 @@ export function getRawEntries(
   time_key = 'metadata.write_ts',
   max_entries = undefined,
   trunc_method = 'sample',
-) {
+): Promise<ServerResponse<any>> {
   let prefix = `getRawEntries, args: ${JSON.stringify(Object.values(arguments))};\n\n`;
   return new Promise<any>((rs, rj) => {
     const msgFiller = (message) => {

--- a/www/js/types/apiTypes.ts
+++ b/www/js/types/apiTypes.ts
@@ -1,0 +1,24 @@
+export type NominatimResponse = {
+  address: {
+    road?: string;
+    pedestrian?: string;
+    suburb?: string;
+    neighbourhood?: string;
+    hamlet?: string;
+    city?: string;
+    town?: string;
+    county?: string;
+    state?: string;
+    postcode?: string;
+    country?: string;
+    country_code?: string;
+  };
+  osm_id: string;
+  osm_type: string;
+  place_id: string;
+  licence: string;
+  lat: string;
+  lon: string;
+  boundingbox: string[];
+  display_name: string;
+};

--- a/www/js/types/diaryTypes.ts
+++ b/www/js/types/diaryTypes.ts
@@ -6,8 +6,9 @@ import { BaseModeKey, MotionTypeKey } from '../diary/diaryHelper';
 import useDerivedProperties from '../diary/useDerivedProperties';
 import { VehicleIdentity } from 'nrel-openpath-deploy-configs';
 import { MultilabelKey } from './labelTypes';
-import { BEMData, LocalDt } from './serverData';
+import { LocalDt } from './serverData';
 import { FeatureCollection, Feature, Geometry, Point, Position } from 'geojson';
+import { NominatimResponse } from './apiTypes';
 
 type ObjectId = { $oid: string };
 
@@ -24,6 +25,7 @@ export type ConfirmedPlace = {
   _id: ObjectId;
   additions: UserInputEntry[];
   cleaned_place: ObjectId;
+  display_name: string; // e.g. "Main St, San Francisco"
   duration: number;
   ending_trip: ObjectId;
   enter_fmt_time: string; // ISO string e.g. 2023-10-31T12:00:00.000-04:00
@@ -32,10 +34,11 @@ export type ConfirmedPlace = {
   exit_fmt_time: string; // ISO string e.g. 2023-10-31T12:00:00.000-04:00
   exit_local_dt: LocalDt;
   exit_ts: number; // Unix timestamp
-  key: string;
-  location: Geometry;
-  origin_key: string;
+  key: 'analysis/confirmed_place';
+  location: Point;
+  origin_key: 'analysis/confirmed_place';
   raw_places: ObjectId[];
+  reverse_geocode: NominatimResponse;
   source: string;
   user_input: UserInput;
   starting_trip: ObjectId;
@@ -84,8 +87,7 @@ export type UnprocessedTrip = {
   user_input: {}; // unprocessed trips won't have any matched processed inputs, so this is always empty
 };
 
-/* These are the properties received from the server (basically matches Python code)
-  This should match what Timeline.readAllCompositeTrips returns (an array of these objects) */
+/* These are the properties received from the server after unpacking */
 export type CompositeTrip = {
   _id: ObjectId;
   additions: UserInputEntry[];
@@ -96,7 +98,7 @@ export type CompositeTrip = {
   confirmed_trip: ObjectId;
   distance: number;
   duration: number;
-  end_confirmed_place: BEMData<ConfirmedPlace>;
+  end_confirmed_place: ConfirmedPlace;
   end_fmt_time: string;
   end_loc: Point;
   end_local_dt: LocalDt;
@@ -107,13 +109,13 @@ export type CompositeTrip = {
   inferred_labels: InferredLabels;
   inferred_section_summary: SectionSummary;
   inferred_trip: ObjectId;
-  key: string;
+  key: 'analysis/composite_trip';
   locations: CompositeTripLocation[];
-  origin_key: string;
+  origin_key: 'analysis/confirmed_trip' | 'analysis/confirmed_untracked';
   raw_trip: ObjectId;
   sections: SectionData[];
   source: string;
-  start_confirmed_place: BEMData<ConfirmedPlace>;
+  start_confirmed_place: ConfirmedPlace;
   start_fmt_time: string;
   start_loc: Point;
   start_local_dt: LocalDt;

--- a/www/js/types/diaryTypes.ts
+++ b/www/js/types/diaryTypes.ts
@@ -130,8 +130,7 @@ export type TimelineEntry = ConfirmedPlace | CompositeTrip;
 
 /* Type guard to disambiguate timeline entries as either trips or places
   If it has a 'start_ts' and 'end_ts', it's a trip. Else, it's a place. */
-export const isTrip = (entry: TimelineEntry): entry is CompositeTrip =>
-  entry.hasOwnProperty('start_ts') && entry.hasOwnProperty('end_ts');
+export const isTrip = (entry: TimelineEntry): entry is CompositeTrip => entry.key.endsWith('trip');
 
 export type TimestampRange = { start_ts: number; end_ts: number };
 


### PR DESCRIPTION
#### update CompositeTrip and ConfirmPlace types

- Add specific string values for 'key' and 'origin_key' properties – makes it easier to diambiguate types in TS code
- added NominatimResponse type in apiTypes.ts
ConfirmedPlace: add reverse geocode props, fix location type
- getRawEntries return type is a ServerResponse
- Clarified that the CompositeTrip type is AFTER unpacking in timelineHelper. Applied types in timelineHelper; refactored to make clearer

#### use reverse-geocoded place names in composite trips

We used to only perform the nominatim queries on the client side, but we added it to the analysis pipeline a while ago. This means processed trips will already have the start and end places' display_name filled in, and it's only for unprocessed trips that we'll need to perform those queries on the client side.
Given this, we can simplify addressNamesHelper considerably. We can just handle the localStorage lookup and/or fetch (if needed) within the useAddressNames hooks rather than the previous approach (which was to explicitly queue all the nominatim requests from LabelTab.tsx and observe as they got put into localStorage)

- extracted GEOCODING_API_URL to separate variable

#### add tests for useAddressNames

since the useAddressNames hook is the only export now, let's make it the default export and rename addressNamesHelper -> useAddressNames
Then let's add tests with a couple fake trips/places to make sure it works whether display_name is filled in or not