### PR TITLE
🐛 Reset promised config on UI resume after inactive period

### DIFF
--- a/www/__tests__/enketoHelper.test.ts
+++ b/www/__tests__/enketoHelper.test.ts
@@ -8,7 +8,7 @@ import {
   EnketoUserInputEntry,
 } from '../js/survey/enketo/enketoHelper';
 import { mockBEMUserCache } from '../__mocks__/cordovaMocks';
-import { getConfig, _test_resetPromisedConfig } from '../../www/js/config/dynamicConfig';
+import { getConfig, resetPromisedConfig } from '../../www/js/config/dynamicConfig';
 import fakeConfig from '../__mocks__/fakeConfig.json';
 
 import initializedI18next from '../js/i18nextInit';
@@ -22,7 +22,7 @@ global.URL = require('url').URL;
 global.Blob = require('node:buffer').Blob;
 
 beforeEach(() => {
-  _test_resetPromisedConfig();
+  resetPromisedConfig();
 });
 
 it('gets the survey config', async () => {

--- a/www/js/AppRoot.tsx
+++ b/www/js/AppRoot.tsx
@@ -16,6 +16,7 @@ import React, { useEffect } from 'react';
 import App from './App';
 import useAppState from './useAppState';
 import { logDebug } from './plugin/logger';
+import { resetPromisedConfig } from './config/dynamicConfig';
 
 const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -26,6 +27,11 @@ const AppRoot = () => {
     onActive: (msNotActive) => {
       if (msNotActive >= BACKGROUND_TIMEOUT_MS) {
         logDebug(`App resumed after ${msNotActive} ms, reloading app`);
+        // reset the cached dynamic config to ensure we retrieve the config on resume,
+        // which could have been updated in the background by the native code
+        // TODO a better long-term strategy is to not cache the config at the module level,
+        // only keep it in React state
+        resetPromisedConfig();
         setReloadMs(Date.now());
       }
     },

--- a/www/js/config/dynamicConfig.ts
+++ b/www/js/config/dynamicConfig.ts
@@ -19,8 +19,7 @@ export let _promisedConfig: Promise<DeploymentConfig | null> | undefined;
 export let configChanged = false;
 export const setConfigChanged = (b) => (configChanged = b);
 
-// used to test multiple configs, not used outside of test
-export const _test_resetPromisedConfig = () => {
+export const resetPromisedConfig = () => {
   _promisedConfig = undefined;
 };
 


### PR DESCRIPTION
#### 🐛 Reset promised config on UI resume after inactive period

> As noted in the comment, we cache the promise of the config retrieval at the module-level (dynamicConfig.ts module), which doesn't get reset when we reload the App component. If the config is upgraded in the background via native code, we wouldn't pick this up until the next full UI initialization, which is when the app is restarted or the UI is killed by the system (no guarantees on when/ how often that happens). So for config updates to be truly automatic and be visible in the UI as well, we need to manually reset it here. As noted, it would be cleaner to only keep this in React state going forward rather than a module-level variable