### PR TITLE
💚 Fix malformed "build"and "sdk install" workflow yml files

### DIFF
--- a/.github/workflows/android-automated-sdk-install.yml
+++ b/.github/workflows/android-automated-sdk-install.yml
@@ -27,13 +27,12 @@ jobs:
     env:
       NEW_ANDROID_SDK_ROOT: /tmp/new-install/Android/sdk
 
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: upgrade bash
       run: |
         brew install bash
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
     # Runs a single command using the runners shell

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,65 +24,65 @@ jobs:
     # The type of runner that the job will run on
     runs-on: macos-14
 
-    - name: upgrade bash
-      run: |
-        brew install bash
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      - name: upgrade bash
+        run: |
+          brew install bash
+      
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Runs a single command using the runners shell
+      - name: Prints related environment variables so that we can know what to set 
+        run: env | egrep "JAVA|PATH|ANDROID"
 
-    # Runs a single command using the runners shell
-    - name: Prints related environment variables so that we can know what to set 
-      run: env | egrep "JAVA|PATH|ANDROID"
+      # Runs a single command using the runners shell
+      - name: Print the java and gradle versions
+        run: |
+          echo "Default java version"
+          java -version
+          echo "Setting to Java 11 instead"
+          export JAVA_HOME=$JAVA_HOME_17_arm64
+          java -version
+          echo "Checking gradle"
+          which gradle
+          gradle -version
 
-    # Runs a single command using the runners shell
-    - name: Print the java and gradle versions
-      run: |
-        echo "Default java version"
-        java -version
-        echo "Setting to Java 11 instead"
-        export JAVA_HOME=$JAVA_HOME_17_arm64
-        java -version
-        echo "Checking gradle"
-        which gradle
-        gradle -version
+      - name: Tries to figure out where android is installed
+        run: |
+          echo "Android listed at $ANDROID_SDK_ROOT"
+          ls -al /opt/
 
-    - name: Tries to figure out where android is installed
-      run: |
-        echo "Android listed at $ANDROID_SDK_ROOT"
-        ls -al /opt/
+      - name: Setup the cordova environment
+        shell: bash -l {0}
+        run: |
+          export JAVA_HOME=$JAVA_HOME_17_arm64
+          bash setup/setup_native.sh
 
-    - name: Setup the cordova environment
-      shell: bash -l {0}
-      run: |
-        export JAVA_HOME=$JAVA_HOME_17_arm64
-        bash setup/setup_native.sh
+      - name: Check tool versions
+        shell: bash -l {0}
+        run: |
+          export JAVA_HOME=$JAVA_HOME_17_arm64
+          source setup/activate_native.sh
+          echo "cordova version"
+          npx cordova -version
+          echo "ionic version"
+          npx ionic --version
+          which gradle
+          echo "gradle version"
+          gradle -version
 
-    - name: Check tool versions
-      shell: bash -l {0}
-      run: |
-        export JAVA_HOME=$JAVA_HOME_17_arm64
-        source setup/activate_native.sh
-        echo "cordova version"
-        npx cordova -version
-        echo "ionic version"
-        npx ionic --version
-        which gradle
-        echo "gradle version"
-        gradle -version
-
-    - name: Build android
-      shell: bash -l {0}
-      run: |
-        echo $PATH
-        which gradle
-        gradle -version
-        echo "Let's rerun the activation"
-        source setup/activate_native.sh
-        export JAVA_HOME=$JAVA_HOME_17_arm64
-        echo $PATH
-        which gradle
-        gradle --version
-        npx cordova build android
+      - name: Build android
+        shell: bash -l {0}
+        run: |
+          echo $PATH
+          which gradle
+          gradle -version
+          echo "Let's rerun the activation"
+          source setup/activate_native.sh
+          export JAVA_HOME=$JAVA_HOME_17_arm64
+          echo $PATH
+          which gradle
+          gradle --version
+          npx cordova build android

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -24,54 +24,53 @@ jobs:
     # The type of runner that the job will run on
     runs-on: macos-14
 
-    - name: upgrade bash
-      run: |
-        brew install bash
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      - name: upgrade bash
+        run: |
+          brew install bash
+    
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Runs a single command using the runners shell
+      - name: Print the xcode path
+        run: xcode-select --print-path
 
-    # Runs a single command using the runners shell
-    - name: Print the xcode path
-      run: xcode-select --print-path
+      - name: Print the xcode setup
+        run: xcodebuild -version -sdk
 
-    - name: Print the xcode setup
-      run: xcodebuild -version -sdk
+      - name: Print the brew and ruby versions
+        run: |
+          echo "brew version is "`brew --version`
+          echo "ruby version is" `ruby --version`
 
-    - name: Print the brew and ruby versions
-      run: |
-        echo "brew version is "`brew --version`
-        echo "ruby version is" `ruby --version`
+      - name: Print applications through dmg
+        run: ls /Applications
 
-    - name: Print applications through dmg
-      run: ls /Applications
+      - name: Print applications through brew
+        run: brew list --formula
 
-    - name: Print applications through brew
-      run: brew list --formula
+      - name: Setup the cordova environment
+        shell: bash -l {0}
+        run: |
+          bash setup/setup_native.sh
 
-    - name: Setup the cordova environment
-      shell: bash -l {0}
-      run: |
-        bash setup/setup_native.sh
+      - name: Check tool versions
+        shell: bash -l {0}
+        run: |
+          source setup/activate_native.sh
+          echo "cordova version"
+          npx cordova -version
+          echo "ionic version"
+          npx ionic --version
 
-    - name: Check tool versions
-      shell: bash -l {0}
-      run: |
-        source setup/activate_native.sh
-        echo "cordova version"
-        npx cordova -version
-        echo "ionic version"
-        npx ionic --version
+      - name: Build ios
+        shell: bash -l {0}
+        run: |
+          source setup/activate_native.sh
+          npx cordova build ios
 
-    - name: Build ios
-      shell: bash -l {0}
-      run: |
-        source setup/activate_native.sh
-        npx cordova build ios
-
-    - name: Cleanup the cordova environment
-      shell: bash -l {0}
-      run: bash setup/teardown_ios_native.sh
-
+      - name: Cleanup the cordova environment
+        shell: bash -l {0}
+        run: bash setup/teardown_ios_native.sh


### PR DESCRIPTION
In https://github.com/e-mission/e-mission-phone/pull/1238 we made changes that were supposed to fix the "build" and "sdk install" workflows by adding a step to upgrade bash. However, these files are malformed (not valid yaml syntax) and the workflows do not run. The build and sdk install workflows didn't even run for that commit/PR, which gave the false appearance of "all checks passing" and I think is the reason we didn't see this.

Fixed syntax