### PR TITLE
⬆️  Support xcode 26

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -22,7 +22,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-15
+    runs-on: macos-26
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -22,7 +22,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-14
+    runs-on: macos-15
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
All builds submitted to the app store after Apr 2026 must be built by xcode 26+
This is consistent with https://github.com/e-mission/e-mission-docs/issues/1144#issuecomment-4824716695

<img width="1098" height="483" alt="Image" src="https://github.com/user-attachments/assets/13133580-4b31-4230-a0c4-7f2de9cf35c9" />