### PR TITLE
Propagate cordova-custom-config failures through the iOS build 

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -68,15 +68,8 @@ jobs:
       - name: Build ios
         shell: bash -l {0}
         run: |
-          set -eo pipefail
           source setup/activate_native.sh
-          build_log=$(mktemp)
-          trap 'rm -f "$build_log"' EXIT
-          npx cordova build ios 2>&1 | tee "$build_log"
-          if grep -q "Error updating config for platform 'ios':" "$build_log"; then
-            echo "cordova-custom-config reported an iOS configuration error"
-            exit 1
-          fi
+          npx cordova build ios
 
       - name: Cleanup the cordova environment
         shell: bash -l {0}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -68,8 +68,15 @@ jobs:
       - name: Build ios
         shell: bash -l {0}
         run: |
+          set -eo pipefail
           source setup/activate_native.sh
-          npx cordova build ios
+          build_log=$(mktemp)
+          trap 'rm -f "$build_log"' EXIT
+          npx cordova build ios 2>&1 | tee "$build_log"
+          if grep -q "Error updating config for platform 'ios':" "$build_log"; then
+            echo "cordova-custom-config reported an iOS configuration error"
+            exit 1
+          fi
 
       - name: Cleanup the cordova environment
         shell: bash -l {0}

--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -10,6 +10,7 @@
     <content src="index.html" />
     <access origin="*" />
     <hook src="hooks/before_prepare/download_translation.js" type="before_prepare" />
+    <preference name="cordova-custom-config-stoponerror" value="true" />
     <preference name="InspectableWebview" value="true" />
     <preference name="webviewbounce" value="false" />
     <preference name="UIWebViewBounce" value="false" />


### PR DESCRIPTION
The iOS workflow was reporting success even when `cordova-custom-config` failed to update platform config during `cordova build ios`. The build step was succeeding because the plugin logged the error but did not fail the Cordova command.

- **Root cause**
  - `cordova-custom-config` defaults `cordova-custom-config-stoponerror` to `false`
  - on config update errors, the plugin logs and continues, so `npx cordova build ios` can still exit `0`

- **Change**
  - enable `cordova-custom-config-stoponerror` in `config.cordovabuild.xml`
  - remove workflow-local log parsing from `.github/workflows/ios-build.yml`
  - rely on the Cordova build command’s exit status to determine workflow success/failure

- **Effect**
  - any `cordova-custom-config` failure during prepare/build now propagates as a non-zero exit code
  - the iOS GitHub Action succeeds only when the build actually succeeds

```xml
<preference name="cordova-custom-config-stoponerror" value="true" />
```

This addresses https://github.com/e-mission/e-mission-docs/issues/1144#issuecomment-4825118679