### PR TITLE
⬆️  Upgrade the plugin to support cordova 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "cordova-android": "14.0.1",
     "cordova-browser": "^7.0.0",
     "cordova-clipboard": "^1.3.0",
-    "cordova-custom-config": "^5.1.1",
+    "cordova-custom-config": "^5.1.2",
     "cordova-ios": "8.1.0",
     "cordova-plugin-advanced-http": "3.3.1",
     "cordova-plugin-androidx-adapter": "1.1.3",


### PR DESCRIPTION
Cordova 8 changes the directory structure for the generated code, which breaks the `cordova-custom-config`.
https://github.com/e-mission/e-mission-docs/issues/1144#issuecomment-4824420397

As seen also in the failed action for
https://github.com/e-mission/e-mission-phone/pull/1267

This was added at the same time as
`cordova-plugin-bluetooth-classic-serial-port` (in https://github.com/e-mission/e-mission-phone/commit/157cfdefe110578014a203bc420b94ef40b54b52), which we still use, so we need to retain it
https://github.com/e-mission/e-mission-docs/issues/1144#issuecomment-4825167004

Fortunately, this was fixed in the plugin
https://github.com/dpa99c/cordova-custom-config/commit/3ad897ded4d72bb817c8a7dc38a93a6b09d92f79

Bumping up the version so we can pick up the change. This should cause the build to become green again