### PR TITLE
🔥 Remove the aws tap before upgrading bash

### DIFF
--- a/.github/workflows/android-automated-sdk-install.yml
+++ b/.github/workflows/android-automated-sdk-install.yml
@@ -32,6 +32,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: upgrade bash
       run: |
+        brew untap aws/tap || true
+        brew trust azure/bicep
         brew install bash
     - uses: actions/checkout@v2
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: upgrade bash
         run: |
+          brew untap aws/tap || true
+          brew trust azure/bicep
           brew install bash
       
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: upgrade bash
         run: |
+          brew untap aws/tap || true
+          brew trust azure/bicep
           brew install bash
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
This was added in https://github.com/e-mission/e-mission-phone/pull/1238 Homebrew now enforces tap trust, and without this change,brew install bash generates a warning about an untrusted tap.

```
Warning: The following taps are not trusted:
  aws/tap
  azure/bicep
```

The install succeeds

```
==> Installing bash dependency: ncurses
==> Pouring ncurses--6.6.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/ncurses/6.6: 4,086 files, 10.6MB
==> Pouring bash--5.3.12.arm64_sonoma.bottle.tar.gz
==> Caveats
DEFAULT_LOADABLE_BUILTINS_PATH: /opt/homebrew/lib/bash:/usr/local/lib/bash:/usr/lib/bash:/opt/local/lib/bash:/usr/pkg/lib/bash:/opt/pkg/lib/bash:.
==> Summary
🍺  /opt/homebrew/Cellar/bash/5.3.12: 172 files, 13.8MB
==> Caveats
==> bash
DEFAULT_LOADABLE_BUILTINS_PATH: /opt/homebrew/lib/bash:/usr/local/lib/bash:/usr/lib/bash:/opt/local/lib/bash:/usr/pkg/lib/bash:/opt/pkg/lib/bash:.
```

But copilot gets consistently tripped up by this, thinks it is the cause of the failure and does not scan ahead to find the actual failure, making it useless to find and fix compile errors downstream.

Fixing this to use copilot again.