### PR TITLE
🧪 Switch Jest preset from jest-expo/web to jest-expo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'jest-expo/web',
+  preset: 'jest-expo',
   testEnvironment: "jsdom",
   testPathIgnorePatterns: [
     "/node_modules/",
@@ -12,7 +12,7 @@ module.exports = {
     "/platforms/",
     "/plugins/",
   ],
-  // Extend jest-expo/web's transformIgnorePatterns to handle additional ESM packages:
+  // Extend jest-expo's transformIgnorePatterns to handle additional ESM packages:
   // enketo, e-mission-common, and color-*.
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|enketo(-.*)?|(enketo-transformer/dist/enketo-transformer/web)|e-mission-common|color(-.*)?)",

--- a/src/__mocks__/setupJestEnv.js
+++ b/src/__mocks__/setupJestEnv.js
@@ -2,10 +2,22 @@
   Applies mocks to the global (window) object for use in tests.
   This is run before all of the tests are run, so these mocks are available in all tests.
 */
-import { mockNativeForWeb } from '../js/nativePlugins';
+const { TextDecoder, TextEncoder } = require('util');
+const { URL, URLSearchParams } = require('url');
+
+global.TextDecoder = TextDecoder;
+global.TextEncoder = TextEncoder;
+global.URL = URL;
+global.URLSearchParams = URLSearchParams;
+window.TextDecoder = TextDecoder;
+window.TextEncoder = TextEncoder;
+window.URL = URL;
+window.URLSearchParams = URLSearchParams;
+
+const { mockNativeForWeb } = require('../js/nativePlugins');
 
 // init i18next so phone_lang is set correctly during tests
-import initializedI18next from '../js/i18nextInit';
+const initializedI18next = require('../js/i18nextInit').default;
 window['i18next'] = initializedI18next;
 
 mockNativeForWeb();


### PR DESCRIPTION
Testing UI components, at least with RN Paper, appears more reliable with jest-expo instead of jest-expo/web preset. We'll switch back to that, but keep jsdom for browser/Cordova globals The only things we do have to shim are a couple URL/TextEncoder globals which are needed by opcode.test.ts