### PR TITLE
🐛 Fix logic to only render timeline when 'label' tab is active, rename

### DIFF
--- a/src/js/Main.tsx
+++ b/src/js/Main.tsx
@@ -79,9 +79,10 @@ const Main = () => {
   );
 
   useEffect(() => {
-    const { setShouldUpdateTimeline } = timelineContext;
+    const { setShouldRenderTimeline } = timelineContext;
     // update TimelineScrollList component only when the active tab is 'label' to fix leaflet map issue
-    setShouldUpdateTimeline(!index);
+    const isLabelTab = routes[index].key == 'label';
+    setShouldRenderTimeline(isLabelTab);
   }, [index]);
 
   return (

--- a/src/js/TimelineContext.ts
+++ b/src/js/TimelineContext.ts
@@ -47,8 +47,8 @@ type ContextProps = {
   loadMoreDays: (when: 'past' | 'future', nDays: number) => boolean | void;
   loadDateRange: (d: [string, string]) => boolean | void;
   refreshTimeline: () => void;
-  shouldUpdateTimeline: Boolean;
-  setShouldUpdateTimeline: React.Dispatch<React.SetStateAction<boolean>>;
+  shouldRenderTimeline: Boolean;
+  setShouldRenderTimeline: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const useTimelineContext = (): ContextProps => {
@@ -69,8 +69,8 @@ export const useTimelineContext = (): ContextProps => {
   const [timelineNotesMap, setTimelineNotesMap] = useState<TimelineNotesMap | null>(null);
   const [refreshTime, setRefreshTime] = useState<Date | null>(null);
   // Leaflet map encounters an error when prerendered, so we need to render the TimelineScrollList component when the active tab is 'label'
-  // 'shouldUpdateTimeline' gets updated based on the current tab index, and we can use it to determine whether to render the timeline or not
-  const [shouldUpdateTimeline, setShouldUpdateTimeline] = useState(true);
+  // 'shouldRenderTimeline' gets updated based on the current tab index, and we can use it to determine whether to render the timeline or not
+  const [shouldRenderTimeline, setShouldRenderTimeline] = useState(true);
 
   // initialization, once the appConfig is loaded
   useEffect(() => {
@@ -345,8 +345,8 @@ export const useTimelineContext = (): ContextProps => {
     notesFor,
     confirmedModeFor,
     addUserInputToEntry,
-    shouldUpdateTimeline,
-    setShouldUpdateTimeline,
+    shouldRenderTimeline,
+    setShouldRenderTimeline,
   };
 };
 

--- a/src/js/diary/list/LabelListScreen.tsx
+++ b/src/js/diary/list/LabelListScreen.tsx
@@ -25,7 +25,7 @@ const LabelListScreen = () => {
     loadDateRange,
     timelineIsLoading,
     refreshTimeline,
-    shouldUpdateTimeline,
+    shouldRenderTimeline,
   } = useContext(TimelineContext);
   const { colors } = useTheme();
 
@@ -90,7 +90,7 @@ const LabelListScreen = () => {
         />
       </NavBar>
       <View style={{ flex: 1, backgroundColor: colors.background }}>
-        {shouldUpdateTimeline && <TimelineScrollList listEntries={displayedEntries} />}
+        {shouldRenderTimeline && <TimelineScrollList listEntries={displayedEntries} />}
       </View>
     </>
   );


### PR DESCRIPTION
We added a hack a couple years ago (c38c35362c40f0ac42c8bcb8aea6dfe36e0462b7) to work around an issue with Leaflet maps rendering by skipping rendering of the Label tab altogether unless it was active. Using `!index` to check this implicitly assumed that the index of label tab was 0 (i.e. the first tab) which is no longer true of all our configurations, causing a blank page to render with no errors logged. Changing this to explicitly check the key of the active route fixes the issue (reproduced + tested manually in Simulator)

Also renamed 'setShouldUpdateTimeline' to 'setShouldRenderTimeline' since that better describes what it does.